### PR TITLE
Fixed some mistakes, nerfed geode ores

### DIFF
--- a/src/main/resources/config/modules/AppliedEnergistics.xml
+++ b/src/main/resources/config/modules/AppliedEnergistics.xml
@@ -122,21 +122,21 @@
                             <IfCondition condition=':= ?blockExists("appliedenergistics2:tile.OreQuartzCharged")'> <OreBlock block='appliedenergistics2:tile.OreQuartzCharged' weight='0.10' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 2.712 * _default_ * apenCertusQuartzFreq ' range=':=  1 * _default_ * apenCertusQuartzFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.394 * _default_ * apenCertusQuartzSize ' range=':=  1 * _default_ * apenCertusQuartzSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 43 ' range=':=  26 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.394 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * apenCertusQuartzSize ' range=':=  _default_ * apenCertusQuartzSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.394 * _default_ * apenCertusQuartzSize ' range=':=  1 * _default_ * apenCertusQuartzSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 2.712 * _default_ * apenCertusQuartzFreq ' range=':= 1 * _default_ * apenCertusQuartzFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.394 * _default_ * apenCertusQuartzSize ' range=':= 1 * _default_ * apenCertusQuartzSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 43 ' range=':= 26 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.394 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * apenCertusQuartzSize ' range=':= _default_ * apenCertusQuartzSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.394 * _default_ * apenCertusQuartzSize ' range=':= 1 * _default_ * apenCertusQuartzSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -155,10 +155,10 @@
                             <IfCondition condition=':= ?blockExists("appliedenergistics2:tile.OreQuartzCharged")'> <OreBlock block='appliedenergistics2:tile.OreQuartzCharged' weight='0.10' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4 * apenCertusQuartzSize ' range=':=  _default_ * apenCertusQuartzSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 15 * apenCertusQuartzFreq ' range=':=  _default_ * apenCertusQuartzFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 43 ' range=':=  26 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 4 * apenCertusQuartzSize ' range=':= _default_ * apenCertusQuartzSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 15 * apenCertusQuartzFreq ' range=':= _default_ * apenCertusQuartzFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 43 ' range=':= 26 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -187,16 +187,16 @@
                             <IfCondition condition=':= ?blockExists("appliedenergistics2:tile.OreQuartzCharged")'> <OreBlock block='appliedenergistics2:tile.OreQuartzCharged' weight='0.10' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.353 * _default_ * apenCertusQuartzSize ' range=':=  _default_ * apenCertusQuartzSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.353 * _default_ * apenCertusQuartzSize ' range=':=  _default_ * apenCertusQuartzSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.832  * _default_ * apenCertusQuartzFreq ' range=':=  _default_ * apenCertusQuartzFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 43 ' range=':=  26 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 1.353 * _default_ * apenCertusQuartzSize ' range=':= _default_ * apenCertusQuartzSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.353 * _default_ * apenCertusQuartzSize ' range=':= _default_ * apenCertusQuartzSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.832  * _default_ * apenCertusQuartzFreq ' range=':= _default_ * apenCertusQuartzFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 43 ' range=':= 26 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='apenCertusQuartzHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x609BBEC2' drawBoundBox='false' boundBoxColor='0x609BBEC2'>
                                 <Description>
                                     Single blocks, generously

--- a/src/main/resources/config/modules/ArsMagica2.xml
+++ b/src/main/resources/config/modules/ArsMagica2.xml
@@ -186,21 +186,21 @@
                             <IfCondition condition=':= ?blockExists("arsmagica2:vinteumOre")'> <OreBlock block='arsmagica2:vinteumOre' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.213 * _default_ * arsmVinteumFreq ' range=':=  _default_ * arsmVinteumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.066 * _default_ * arsmVinteumSize ' range=':=  _default_ * arsmVinteumSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 22 ' range=':=  17 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.066 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * arsmVinteumSize ' range=':=  _default_ * arsmVinteumSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.066 * _default_ * arsmVinteumSize ' range=':=  _default_ * arsmVinteumSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.213 * _default_ * arsmVinteumFreq ' range=':= _default_ * arsmVinteumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.066 * _default_ * arsmVinteumSize ' range=':= _default_ * arsmVinteumSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 22 ' range=':= 17 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.066 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * arsmVinteumSize ' range=':= _default_ * arsmVinteumSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.066 * _default_ * arsmVinteumSize ' range=':= _default_ * arsmVinteumSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -228,16 +228,16 @@
                             <IfCondition condition=':= ?blockExists("arsmagica2:vinteumOre")'> <OreBlock block='arsmagica2:vinteumOre' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.905 * _default_ * arsmVinteumSize ' range=':=  _default_ * arsmVinteumSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.905 * _default_ * arsmVinteumSize ' range=':=  _default_ * arsmVinteumSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * arsmVinteumFreq ' range=':=  _default_ * arsmVinteumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 22 ' range=':=  17 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 0.905 * _default_ * arsmVinteumSize ' range=':= _default_ * arsmVinteumSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.905 * _default_ * arsmVinteumSize ' range=':= _default_ * arsmVinteumSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * arsmVinteumFreq ' range=':= _default_ * arsmVinteumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 22 ' range=':= 17 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='arsmVinteumHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x605364EE' drawBoundBox='false' boundBoxColor='0x605364EE'>
                                 <Description>
                                     Single blocks, generously
@@ -280,10 +280,10 @@
                             <IfCondition condition=':= ?blockExists("arsmagica2:vinteumOre")'> <OreBlock block='arsmagica2:vinteumOre' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 6 * arsmVinteumSize ' range=':=  _default_ * arsmVinteumSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2 * arsmVinteumFreq ' range=':=  _default_ * arsmVinteumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 22 ' range=':=  17 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 6 * arsmVinteumSize ' range=':= _default_ * arsmVinteumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2 * arsmVinteumFreq ' range=':= _default_ * arsmVinteumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 22 ' range=':= 17 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -312,21 +312,21 @@
                             <IfCondition condition=':= ?blockExists("arsmagica2:vinteumOre:1")'> <OreBlock block='arsmagica2:vinteumOre:1' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.485 * _default_ * arsmChimeriteFreq ' range=':=  _default_ * arsmChimeriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.141 * _default_ * arsmChimeriteSize ' range=':=  _default_ * arsmChimeriteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.141 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * arsmChimeriteSize ' range=':=  _default_ * arsmChimeriteSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.141 * _default_ * arsmChimeriteSize ' range=':=  _default_ * arsmChimeriteSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.485 * _default_ * arsmChimeriteFreq ' range=':= _default_ * arsmChimeriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.141 * _default_ * arsmChimeriteSize ' range=':= _default_ * arsmChimeriteSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 40 ' range=':= 20 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.141 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * arsmChimeriteSize ' range=':= _default_ * arsmChimeriteSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.141 * _default_ * arsmChimeriteSize ' range=':= _default_ * arsmChimeriteSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -354,16 +354,16 @@
                             <IfCondition condition=':= ?blockExists("arsmagica2:vinteumOre:1")'> <OreBlock block='arsmagica2:vinteumOre:1' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.002 * _default_ * arsmChimeriteSize ' range=':=  _default_ * arsmChimeriteSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.002 * _default_ * arsmChimeriteSize ' range=':=  _default_ * arsmChimeriteSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.003  * _default_ * arsmChimeriteFreq ' range=':=  _default_ * arsmChimeriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 1.002 * _default_ * arsmChimeriteSize ' range=':= _default_ * arsmChimeriteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.002 * _default_ * arsmChimeriteSize ' range=':= _default_ * arsmChimeriteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.003  * _default_ * arsmChimeriteFreq ' range=':= _default_ * arsmChimeriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 40 ' range=':= 20 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='arsmChimeriteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60B8E6C6' drawBoundBox='false' boundBoxColor='0x60B8E6C6'>
                                 <Description>
                                     Single blocks, generously
@@ -406,10 +406,10 @@
                             <IfCondition condition=':= ?blockExists("arsmagica2:vinteumOre:1")'> <OreBlock block='arsmagica2:vinteumOre:1' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 6 * arsmChimeriteSize ' range=':=  _default_ * arsmChimeriteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 3 * arsmChimeriteFreq ' range=':=  _default_ * arsmChimeriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 6 * arsmChimeriteSize ' range=':= _default_ * arsmChimeriteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 3 * arsmChimeriteFreq ' range=':= _default_ * arsmChimeriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 40 ' range=':= 20 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -438,21 +438,21 @@
                             <IfCondition condition=':= ?blockExists("arsmagica2:vinteumOre:2")'> <OreBlock block='arsmagica2:vinteumOre:2' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.485 * _default_ * arsmBlueTopazFreq ' range=':=  _default_ * arsmBlueTopazFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.141 * _default_ * arsmBlueTopazSize ' range=':=  _default_ * arsmBlueTopazSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 20 ' range=':=  108 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.141 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * arsmBlueTopazSize ' range=':=  _default_ * arsmBlueTopazSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.141 * _default_ * arsmBlueTopazSize ' range=':=  _default_ * arsmBlueTopazSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.485 * _default_ * arsmBlueTopazFreq ' range=':= _default_ * arsmBlueTopazFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.141 * _default_ * arsmBlueTopazSize ' range=':= _default_ * arsmBlueTopazSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 20 ' range=':= 108 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.141 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * arsmBlueTopazSize ' range=':= _default_ * arsmBlueTopazSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.141 * _default_ * arsmBlueTopazSize ' range=':= _default_ * arsmBlueTopazSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -480,16 +480,16 @@
                             <IfCondition condition=':= ?blockExists("arsmagica2:vinteumOre:2")'> <OreBlock block='arsmagica2:vinteumOre:2' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.002 * _default_ * arsmBlueTopazSize ' range=':=  _default_ * arsmBlueTopazSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.002 * _default_ * arsmBlueTopazSize ' range=':=  _default_ * arsmBlueTopazSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.003  * _default_ * arsmBlueTopazFreq ' range=':=  _default_ * arsmBlueTopazFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 20 ' range=':=  108 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 1.002 * _default_ * arsmBlueTopazSize ' range=':= _default_ * arsmBlueTopazSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.002 * _default_ * arsmBlueTopazSize ' range=':= _default_ * arsmBlueTopazSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.003  * _default_ * arsmBlueTopazFreq ' range=':= _default_ * arsmBlueTopazFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 20 ' range=':= 108 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='arsmBlueTopazHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x607EE5F4' drawBoundBox='false' boundBoxColor='0x607EE5F4'>
                                 <Description>
                                     Single blocks, generously
@@ -532,10 +532,10 @@
                             <IfCondition condition=':= ?blockExists("arsmagica2:vinteumOre:2")'> <OreBlock block='arsmagica2:vinteumOre:2' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 6 * arsmBlueTopazSize ' range=':=  _default_ * arsmBlueTopazSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 3 * arsmBlueTopazFreq ' range=':=  _default_ * arsmBlueTopazFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 20 ' range=':=  108 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 6 * arsmBlueTopazSize ' range=':= _default_ * arsmBlueTopazSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 3 * arsmBlueTopazFreq ' range=':= _default_ * arsmBlueTopazFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 20 ' range=':= 108 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>

--- a/src/main/resources/config/modules/BiomesOPlenty.xml
+++ b/src/main/resources/config/modules/BiomesOPlenty.xml
@@ -346,7 +346,7 @@
                 <!-- Starting PipeVeins Preset for Ruby. -->
                 <ConfigSection>
                     <IfCondition condition=':= boplRubyDist = "PipeVeins"'>
-                        <Veins name='boplRubyVeins'  inherits='PresetPipeVeins' seed='0x2E21' drawWireframe='true' wireframeColor='0x60C60031' drawBoundBox='false' boundBoxColor='0x60C60031'>
+                        <Veins name='boplRubyVeins'  inherits='PresetPipeVeins' seed='0x706D' drawWireframe='true' wireframeColor='0x60C60031' drawBoundBox='false' boundBoxColor='0x60C60031'>
                             <Description>
                                 Short sparsely filled veins  sloping
                                 up from near the bottom  of the map.
@@ -354,30 +354,30 @@
                             <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:2")'> <OreBlock block='BiomesOPlenty:gemOre:2' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <BiomeType name='Desert'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * boplRubyFreq ' range=':=  _default_ * boplRubyFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplRubySize ' range=':=  _default_ * boplRubySize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * boplRubySize ' range=':=  _default_ * boplRubySize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplRubySize ' range=':=  _default_ * boplRubySize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * boplRubyFreq ' range=':= _default_ * boplRubyFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplRubySize ' range=':= _default_ * boplRubySize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * boplRubySize ' range=':= _default_ * boplRubySize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplRubySize ' range=':= _default_ * boplRubySize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
 
                         <!-- Configuring contained material. -->
-                        <Veins name='boplRubyVeinsPipe'  inherits='boplRubyVeins' seed='0x2E21' drawWireframe='true' wireframeColor='0x60C60031' drawBoundBox='false' boundBoxColor='0x60C60031'>
+                        <Veins name='boplRubyVeinsPipe'  inherits='boplRubyVeins' seed='0x706D' drawWireframe='true' wireframeColor='0x60C60031' drawBoundBox='false' boundBoxColor='0x60C60031'>
                             <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:2")'> <Replaces block='BiomesOPlenty:gemOre:2' weight='1.0' /> </IfCondition>
-                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplRubySize  * 0.5 ' range=':=  _default_ * boplRubySize  * 0.5 ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplRubySize  * 0.5 ' range=':=  _default_ * boplRubySize  * 0.5 ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplRubySize  * 0.5 ' range=':= _default_ * boplRubySize  * 0.5 ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplRubySize  * 0.5 ' range=':= _default_ * boplRubySize  * 0.5 ' type='normal' />
                             <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
                         </Veins>
                     </IfCondition>
@@ -406,16 +406,16 @@
                             <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:2")'> <OreBlock block='BiomesOPlenty:gemOre:2' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <BiomeType name='Desert'  />
-                            <Setting name='CloudRadius' avg=':= 0.486 * _default_ * boplRubySize ' range=':=  _default_ * boplRubySize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.486 * _default_ * boplRubySize ' range=':=  _default_ * boplRubySize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.236  * _default_ * boplRubyFreq ' range=':=  _default_ * boplRubyFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 0.486 * _default_ * boplRubySize ' range=':= _default_ * boplRubySize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.486 * _default_ * boplRubySize ' range=':= _default_ * boplRubySize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.236  * _default_ * boplRubyFreq ' range=':= _default_ * boplRubyFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='boplRubyHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60C60031' drawBoundBox='false' boundBoxColor='0x60C60031'>
                                 <Description>
                                     Single blocks, generously
@@ -458,10 +458,10 @@
                             <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:2")'> <OreBlock block='BiomesOPlenty:gemOre:2' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <BiomeType name='Desert'  />
-                            <Setting name='Size' avg=':= 1 * boplRubySize ' range=':=  _default_ * boplRubySize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1 * boplRubyFreq ' range=':=  _default_ * boplRubyFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 1 * boplRubySize ' range=':= _default_ * boplRubySize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1 * boplRubyFreq ' range=':= _default_ * boplRubyFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -475,7 +475,7 @@
                 <!-- Starting PipeVeins Preset for Peridot. -->
                 <ConfigSection>
                     <IfCondition condition=':= boplPeridotDist = "PipeVeins"'>
-                        <Veins name='boplPeridotVeins'  inherits='PresetPipeVeins' seed='0x2E21' drawWireframe='true' wireframeColor='0x60076855' drawBoundBox='false' boundBoxColor='0x60076855'>
+                        <Veins name='boplPeridotVeins'  inherits='PresetPipeVeins' seed='0xA6AC' drawWireframe='true' wireframeColor='0x60076855' drawBoundBox='false' boundBoxColor='0x60076855'>
                             <Description>
                                 Short sparsely filled veins  sloping
                                 up from near the bottom  of the map.
@@ -483,30 +483,30 @@
                             <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:4")'> <OreBlock block='BiomesOPlenty:gemOre:4' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <BiomeType name='Plains'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * boplPeridotFreq ' range=':=  _default_ * boplPeridotFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplPeridotSize ' range=':=  _default_ * boplPeridotSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * boplPeridotSize ' range=':=  _default_ * boplPeridotSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplPeridotSize ' range=':=  _default_ * boplPeridotSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * boplPeridotFreq ' range=':= _default_ * boplPeridotFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplPeridotSize ' range=':= _default_ * boplPeridotSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * boplPeridotSize ' range=':= _default_ * boplPeridotSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplPeridotSize ' range=':= _default_ * boplPeridotSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
 
                         <!-- Configuring contained material. -->
-                        <Veins name='boplPeridotVeinsPipe'  inherits='boplPeridotVeins' seed='0x2E21' drawWireframe='true' wireframeColor='0x60076855' drawBoundBox='false' boundBoxColor='0x60076855'>
+                        <Veins name='boplPeridotVeinsPipe'  inherits='boplPeridotVeins' seed='0xA6AC' drawWireframe='true' wireframeColor='0x60076855' drawBoundBox='false' boundBoxColor='0x60076855'>
                             <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:4")'> <Replaces block='BiomesOPlenty:gemOre:4' weight='1.0' /> </IfCondition>
-                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplPeridotSize  * 0.5 ' range=':=  _default_ * boplPeridotSize  * 0.5 ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplPeridotSize  * 0.5 ' range=':=  _default_ * boplPeridotSize  * 0.5 ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplPeridotSize  * 0.5 ' range=':= _default_ * boplPeridotSize  * 0.5 ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplPeridotSize  * 0.5 ' range=':= _default_ * boplPeridotSize  * 0.5 ' type='normal' />
                             <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
                         </Veins>
                     </IfCondition>
@@ -535,16 +535,16 @@
                             <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:4")'> <OreBlock block='BiomesOPlenty:gemOre:4' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <BiomeType name='Plains'  />
-                            <Setting name='CloudRadius' avg=':= 0.486 * _default_ * boplPeridotSize ' range=':=  _default_ * boplPeridotSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.486 * _default_ * boplPeridotSize ' range=':=  _default_ * boplPeridotSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.236  * _default_ * boplPeridotFreq ' range=':=  _default_ * boplPeridotFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 0.486 * _default_ * boplPeridotSize ' range=':= _default_ * boplPeridotSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.486 * _default_ * boplPeridotSize ' range=':= _default_ * boplPeridotSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.236  * _default_ * boplPeridotFreq ' range=':= _default_ * boplPeridotFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='boplPeridotHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60076855' drawBoundBox='false' boundBoxColor='0x60076855'>
                                 <Description>
                                     Single blocks, generously
@@ -587,10 +587,10 @@
                             <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:4")'> <OreBlock block='BiomesOPlenty:gemOre:4' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <BiomeType name='Plains'  />
-                            <Setting name='Size' avg=':= 1 * boplPeridotSize ' range=':=  _default_ * boplPeridotSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1 * boplPeridotFreq ' range=':=  _default_ * boplPeridotFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 1 * boplPeridotSize ' range=':= _default_ * boplPeridotSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1 * boplPeridotFreq ' range=':= _default_ * boplPeridotFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -604,7 +604,7 @@
                 <!-- Starting PipeVeins Preset for Topaz. -->
                 <ConfigSection>
                     <IfCondition condition=':= boplTopazDist = "PipeVeins"'>
-                        <Veins name='boplTopazVeins'  inherits='PresetPipeVeins' seed='0x2E21' drawWireframe='true' wireframeColor='0x60D95A03' drawBoundBox='false' boundBoxColor='0x60D95A03'>
+                        <Veins name='boplTopazVeins'  inherits='PresetPipeVeins' seed='0xB7E1' drawWireframe='true' wireframeColor='0x60D95A03' drawBoundBox='false' boundBoxColor='0x60D95A03'>
                             <Description>
                                 Short sparsely filled veins  sloping
                                 up from near the bottom  of the map.
@@ -612,30 +612,30 @@
                             <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:6")'> <OreBlock block='BiomesOPlenty:gemOre:6' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <BiomeType name='Jungle'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * boplTopazFreq ' range=':=  _default_ * boplTopazFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplTopazSize ' range=':=  _default_ * boplTopazSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * boplTopazSize ' range=':=  _default_ * boplTopazSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplTopazSize ' range=':=  _default_ * boplTopazSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * boplTopazFreq ' range=':= _default_ * boplTopazFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplTopazSize ' range=':= _default_ * boplTopazSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * boplTopazSize ' range=':= _default_ * boplTopazSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplTopazSize ' range=':= _default_ * boplTopazSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
 
                         <!-- Configuring contained material. -->
-                        <Veins name='boplTopazVeinsPipe'  inherits='boplTopazVeins' seed='0x2E21' drawWireframe='true' wireframeColor='0x60D95A03' drawBoundBox='false' boundBoxColor='0x60D95A03'>
+                        <Veins name='boplTopazVeinsPipe'  inherits='boplTopazVeins' seed='0xB7E1' drawWireframe='true' wireframeColor='0x60D95A03' drawBoundBox='false' boundBoxColor='0x60D95A03'>
                             <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:6")'> <Replaces block='BiomesOPlenty:gemOre:6' weight='1.0' /> </IfCondition>
-                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplTopazSize  * 0.5 ' range=':=  _default_ * boplTopazSize  * 0.5 ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplTopazSize  * 0.5 ' range=':=  _default_ * boplTopazSize  * 0.5 ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplTopazSize  * 0.5 ' range=':= _default_ * boplTopazSize  * 0.5 ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplTopazSize  * 0.5 ' range=':= _default_ * boplTopazSize  * 0.5 ' type='normal' />
                             <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
                         </Veins>
                     </IfCondition>
@@ -664,16 +664,16 @@
                             <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:6")'> <OreBlock block='BiomesOPlenty:gemOre:6' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <BiomeType name='Jungle'  />
-                            <Setting name='CloudRadius' avg=':= 0.486 * _default_ * boplTopazSize ' range=':=  _default_ * boplTopazSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.486 * _default_ * boplTopazSize ' range=':=  _default_ * boplTopazSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.236  * _default_ * boplTopazFreq ' range=':=  _default_ * boplTopazFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 0.486 * _default_ * boplTopazSize ' range=':= _default_ * boplTopazSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.486 * _default_ * boplTopazSize ' range=':= _default_ * boplTopazSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.236  * _default_ * boplTopazFreq ' range=':= _default_ * boplTopazFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='boplTopazHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60D95A03' drawBoundBox='false' boundBoxColor='0x60D95A03'>
                                 <Description>
                                     Single blocks, generously
@@ -716,10 +716,10 @@
                             <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:6")'> <OreBlock block='BiomesOPlenty:gemOre:6' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <BiomeType name='Jungle'  />
-                            <Setting name='Size' avg=':= 1 * boplTopazSize ' range=':=  _default_ * boplTopazSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1 * boplTopazFreq ' range=':=  _default_ * boplTopazFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 1 * boplTopazSize ' range=':= _default_ * boplTopazSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1 * boplTopazFreq ' range=':= _default_ * boplTopazFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -733,7 +733,7 @@
                 <!-- Starting PipeVeins Preset for Tanzanite. -->
                 <ConfigSection>
                     <IfCondition condition=':= boplTanzaniteDist = "PipeVeins"'>
-                        <Veins name='boplTanzaniteVeins'  inherits='PresetPipeVeins' seed='0x2E21' drawWireframe='true' wireframeColor='0x607701B9' drawBoundBox='false' boundBoxColor='0x607701B9'>
+                        <Veins name='boplTanzaniteVeins'  inherits='PresetPipeVeins' seed='0xA51A' drawWireframe='true' wireframeColor='0x607701B9' drawBoundBox='false' boundBoxColor='0x607701B9'>
                             <Description>
                                 Short sparsely filled veins  sloping
                                 up from near the bottom  of the map.
@@ -742,31 +742,31 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <BiomeType name='Frozen'  />
                             <Biome name='Alps'  weight='-1' />
-                            <Biome name='AlpsForest'  weight='-1' />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * boplTanzaniteFreq ' range=':=  _default_ * boplTanzaniteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplTanzaniteSize ' range=':=  _default_ * boplTanzaniteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * boplTanzaniteSize ' range=':=  _default_ * boplTanzaniteSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplTanzaniteSize ' range=':=  _default_ * boplTanzaniteSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Biome name='Alps Forest'  weight='-1' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * boplTanzaniteFreq ' range=':= _default_ * boplTanzaniteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplTanzaniteSize ' range=':= _default_ * boplTanzaniteSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * boplTanzaniteSize ' range=':= _default_ * boplTanzaniteSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplTanzaniteSize ' range=':= _default_ * boplTanzaniteSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
 
                         <!-- Configuring contained material. -->
-                        <Veins name='boplTanzaniteVeinsPipe'  inherits='boplTanzaniteVeins' seed='0x2E21' drawWireframe='true' wireframeColor='0x607701B9' drawBoundBox='false' boundBoxColor='0x607701B9'>
+                        <Veins name='boplTanzaniteVeinsPipe'  inherits='boplTanzaniteVeins' seed='0xA51A' drawWireframe='true' wireframeColor='0x607701B9' drawBoundBox='false' boundBoxColor='0x607701B9'>
                             <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:8")'> <Replaces block='BiomesOPlenty:gemOre:8' weight='1.0' /> </IfCondition>
-                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplTanzaniteSize  * 0.5 ' range=':=  _default_ * boplTanzaniteSize  * 0.5 ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplTanzaniteSize  * 0.5 ' range=':=  _default_ * boplTanzaniteSize  * 0.5 ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplTanzaniteSize  * 0.5 ' range=':= _default_ * boplTanzaniteSize  * 0.5 ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplTanzaniteSize  * 0.5 ' range=':= _default_ * boplTanzaniteSize  * 0.5 ' type='normal' />
                             <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
                         </Veins>
                     </IfCondition>
@@ -796,17 +796,17 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <BiomeType name='Frozen'  />
                             <Biome name='Alps'  weight='-1' />
-                            <Biome name='AlpsForest'  weight='-1' />
-                            <Setting name='CloudRadius' avg=':= 0.486 * _default_ * boplTanzaniteSize ' range=':=  _default_ * boplTanzaniteSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.486 * _default_ * boplTanzaniteSize ' range=':=  _default_ * boplTanzaniteSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.236  * _default_ * boplTanzaniteFreq ' range=':=  _default_ * boplTanzaniteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Biome name='Alps Forest'  weight='-1' />
+                            <Setting name='CloudRadius' avg=':= 0.486 * _default_ * boplTanzaniteSize ' range=':= _default_ * boplTanzaniteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.486 * _default_ * boplTanzaniteSize ' range=':= _default_ * boplTanzaniteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.236  * _default_ * boplTanzaniteFreq ' range=':= _default_ * boplTanzaniteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='boplTanzaniteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x607701B9' drawBoundBox='false' boundBoxColor='0x607701B9'>
                                 <Description>
                                     Single blocks, generously
@@ -850,11 +850,11 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <BiomeType name='Frozen'  />
                             <Biome name='Alps'  weight='-1' />
-                            <Biome name='AlpsForest'  weight='-1' />
-                            <Setting name='Size' avg=':= 1 * boplTanzaniteSize ' range=':=  _default_ * boplTanzaniteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1 * boplTanzaniteFreq ' range=':=  _default_ * boplTanzaniteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Biome name='Alps Forest'  weight='-1' />
+                            <Setting name='Size' avg=':= 1 * boplTanzaniteSize ' range=':= _default_ * boplTanzaniteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1 * boplTanzaniteFreq ' range=':= _default_ * boplTanzaniteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -868,7 +868,7 @@
                 <!-- Starting PipeVeins Preset for Malachite. -->
                 <ConfigSection>
                     <IfCondition condition=':= boplMalachiteDist = "PipeVeins"'>
-                        <Veins name='boplMalachiteVeins'  inherits='PresetPipeVeins' seed='0x2E21' drawWireframe='true' wireframeColor='0x60109D81' drawBoundBox='false' boundBoxColor='0x60109D81'>
+                        <Veins name='boplMalachiteVeins'  inherits='PresetPipeVeins' seed='0x5A38' drawWireframe='true' wireframeColor='0x60109D81' drawBoundBox='false' boundBoxColor='0x60109D81'>
                             <Description>
                                 Short sparsely filled veins  sloping
                                 up from near the bottom  of the map.
@@ -876,30 +876,30 @@
                             <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:10")'> <OreBlock block='BiomesOPlenty:gemOre:10' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <BiomeType name='Swamp'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * boplMalachiteFreq ' range=':=  _default_ * boplMalachiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplMalachiteSize ' range=':=  _default_ * boplMalachiteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * boplMalachiteSize ' range=':=  _default_ * boplMalachiteSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplMalachiteSize ' range=':=  _default_ * boplMalachiteSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * boplMalachiteFreq ' range=':= _default_ * boplMalachiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplMalachiteSize ' range=':= _default_ * boplMalachiteSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * boplMalachiteSize ' range=':= _default_ * boplMalachiteSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplMalachiteSize ' range=':= _default_ * boplMalachiteSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
 
                         <!-- Configuring contained material. -->
-                        <Veins name='boplMalachiteVeinsPipe'  inherits='boplMalachiteVeins' seed='0x2E21' drawWireframe='true' wireframeColor='0x60109D81' drawBoundBox='false' boundBoxColor='0x60109D81'>
+                        <Veins name='boplMalachiteVeinsPipe'  inherits='boplMalachiteVeins' seed='0x5A38' drawWireframe='true' wireframeColor='0x60109D81' drawBoundBox='false' boundBoxColor='0x60109D81'>
                             <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:10")'> <Replaces block='BiomesOPlenty:gemOre:10' weight='1.0' /> </IfCondition>
-                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplMalachiteSize  * 0.5 ' range=':=  _default_ * boplMalachiteSize  * 0.5 ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplMalachiteSize  * 0.5 ' range=':=  _default_ * boplMalachiteSize  * 0.5 ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplMalachiteSize  * 0.5 ' range=':= _default_ * boplMalachiteSize  * 0.5 ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplMalachiteSize  * 0.5 ' range=':= _default_ * boplMalachiteSize  * 0.5 ' type='normal' />
                             <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
                         </Veins>
                     </IfCondition>
@@ -928,16 +928,16 @@
                             <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:10")'> <OreBlock block='BiomesOPlenty:gemOre:10' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <BiomeType name='Swamp'  />
-                            <Setting name='CloudRadius' avg=':= 0.486 * _default_ * boplMalachiteSize ' range=':=  _default_ * boplMalachiteSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.486 * _default_ * boplMalachiteSize ' range=':=  _default_ * boplMalachiteSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.236  * _default_ * boplMalachiteFreq ' range=':=  _default_ * boplMalachiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 0.486 * _default_ * boplMalachiteSize ' range=':= _default_ * boplMalachiteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.486 * _default_ * boplMalachiteSize ' range=':= _default_ * boplMalachiteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.236  * _default_ * boplMalachiteFreq ' range=':= _default_ * boplMalachiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='boplMalachiteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60109D81' drawBoundBox='false' boundBoxColor='0x60109D81'>
                                 <Description>
                                     Single blocks, generously
@@ -980,10 +980,10 @@
                             <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:10")'> <OreBlock block='BiomesOPlenty:gemOre:10' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <BiomeType name='Swamp'  />
-                            <Setting name='Size' avg=':= 1 * boplMalachiteSize ' range=':=  _default_ * boplMalachiteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1 * boplMalachiteFreq ' range=':=  _default_ * boplMalachiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 1 * boplMalachiteSize ' range=':= _default_ * boplMalachiteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1 * boplMalachiteFreq ' range=':= _default_ * boplMalachiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -997,44 +997,44 @@
                 <!-- Starting PipeVeins Preset for Sapphire. -->
                 <ConfigSection>
                     <IfCondition condition=':= boplSapphireDist = "PipeVeins"'>
-                        <Veins name='boplSapphireVeins'  inherits='PresetPipeVeins' seed='0x2E21' drawWireframe='true' wireframeColor='0x603494C3' drawBoundBox='false' boundBoxColor='0x603494C3'>
+                        <Veins name='boplSapphireVeins'  inherits='PresetPipeVeins' seed='0x7474' drawWireframe='true' wireframeColor='0x603494C3' drawBoundBox='false' boundBoxColor='0x603494C3'>
                             <Description>
                                 Short sparsely filled veins  sloping
                                 up from near the bottom  of the map.
                             </Description>
                             <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:12")'> <OreBlock block='BiomesOPlenty:gemOre:12' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
-                            <Biome name='CoralReef'  />
+                            <Biome name='Coral Reef'  />
                             <Biome name='Crag'  />
-                            <Biome name='HotSprings'  />
-                            <Biome name='KelpForest'  />
+                            <Biome name='Hot Springs'  />
+                            <Biome name='Kelp Forest'  />
                             <Biome name='Mangrove'  />
-                            <Biome name='SacredSprings'  />
+                            <Biome name='Sacred Springs'  />
                             <Biome name='Tropics'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * boplSapphireFreq ' range=':=  _default_ * boplSapphireFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplSapphireSize ' range=':=  _default_ * boplSapphireSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * boplSapphireSize ' range=':=  _default_ * boplSapphireSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplSapphireSize ' range=':=  _default_ * boplSapphireSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * boplSapphireFreq ' range=':= _default_ * boplSapphireFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplSapphireSize ' range=':= _default_ * boplSapphireSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * boplSapphireSize ' range=':= _default_ * boplSapphireSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplSapphireSize ' range=':= _default_ * boplSapphireSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
 
                         <!-- Configuring contained material. -->
-                        <Veins name='boplSapphireVeinsPipe'  inherits='boplSapphireVeins' seed='0x2E21' drawWireframe='true' wireframeColor='0x603494C3' drawBoundBox='false' boundBoxColor='0x603494C3'>
+                        <Veins name='boplSapphireVeinsPipe'  inherits='boplSapphireVeins' seed='0x7474' drawWireframe='true' wireframeColor='0x603494C3' drawBoundBox='false' boundBoxColor='0x603494C3'>
                             <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:12")'> <Replaces block='BiomesOPlenty:gemOre:12' weight='1.0' /> </IfCondition>
-                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplSapphireSize  * 0.5 ' range=':=  _default_ * boplSapphireSize  * 0.5 ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplSapphireSize  * 0.5 ' range=':=  _default_ * boplSapphireSize  * 0.5 ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplSapphireSize  * 0.5 ' range=':= _default_ * boplSapphireSize  * 0.5 ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplSapphireSize  * 0.5 ' range=':= _default_ * boplSapphireSize  * 0.5 ' type='normal' />
                             <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
                         </Veins>
                     </IfCondition>
@@ -1062,23 +1062,23 @@
                             </Description>
                             <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:12")'> <OreBlock block='BiomesOPlenty:gemOre:12' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
-                            <Biome name='CoralReef'  />
+                            <Biome name='Coral Reef'  />
                             <Biome name='Crag'  />
-                            <Biome name='HotSprings'  />
-                            <Biome name='KelpForest'  />
+                            <Biome name='Hot Springs'  />
+                            <Biome name='Kelp Forest'  />
                             <Biome name='Mangrove'  />
-                            <Biome name='SacredSprings'  />
+                            <Biome name='Sacred Springs'  />
                             <Biome name='Tropics'  />
-                            <Setting name='CloudRadius' avg=':= 0.486 * _default_ * boplSapphireSize ' range=':=  _default_ * boplSapphireSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.486 * _default_ * boplSapphireSize ' range=':=  _default_ * boplSapphireSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.236  * _default_ * boplSapphireFreq ' range=':=  _default_ * boplSapphireFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 0.486 * _default_ * boplSapphireSize ' range=':= _default_ * boplSapphireSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.486 * _default_ * boplSapphireSize ' range=':= _default_ * boplSapphireSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.236  * _default_ * boplSapphireFreq ' range=':= _default_ * boplSapphireFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='boplSapphireHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x603494C3' drawBoundBox='false' boundBoxColor='0x603494C3'>
                                 <Description>
                                     Single blocks, generously
@@ -1120,17 +1120,17 @@
                             </Description>
                             <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:12")'> <OreBlock block='BiomesOPlenty:gemOre:12' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
-                            <Biome name='CoralReef'  />
+                            <Biome name='Coral Reef'  />
                             <Biome name='Crag'  />
-                            <Biome name='HotSprings'  />
-                            <Biome name='KelpForest'  />
+                            <Biome name='Hot Springs'  />
+                            <Biome name='Kelp Forest'  />
                             <Biome name='Mangrove'  />
-                            <Biome name='SacredSprings'  />
+                            <Biome name='Sacred Springs'  />
                             <Biome name='Tropics'  />
-                            <Setting name='Size' avg=':= 1 * boplSapphireSize ' range=':=  _default_ * boplSapphireSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1 * boplSapphireFreq ' range=':=  _default_ * boplSapphireFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 1 * boplSapphireSize ' range=':= _default_ * boplSapphireSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1 * boplSapphireFreq ' range=':= _default_ * boplSapphireFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -1144,7 +1144,7 @@
                 <!-- Starting PipeVeins Preset for Amber. -->
                 <ConfigSection>
                     <IfCondition condition=':= boplAmberDist = "PipeVeins"'>
-                        <Veins name='boplAmberVeins'  inherits='PresetPipeVeins' seed='0x2E21' drawWireframe='true' wireframeColor='0x60FE9D1B' drawBoundBox='false' boundBoxColor='0x60FE9D1B'>
+                        <Veins name='boplAmberVeins'  inherits='PresetPipeVeins' seed='0x1FEF' drawWireframe='true' wireframeColor='0x60FE9D1B' drawBoundBox='false' boundBoxColor='0x60FE9D1B'>
                             <Description>
                                 Short sparsely filled veins  sloping
                                 up from near the bottom  of the map.
@@ -1155,30 +1155,30 @@
                             <Biome name='Grove'  />
                             <Biome name='Shield'  />
                             <Biome name='Thicket'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * boplAmberFreq ' range=':=  _default_ * boplAmberFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplAmberSize ' range=':=  _default_ * boplAmberSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * boplAmberSize ' range=':=  _default_ * boplAmberSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplAmberSize ' range=':=  _default_ * boplAmberSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * boplAmberFreq ' range=':= _default_ * boplAmberFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplAmberSize ' range=':= _default_ * boplAmberSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * boplAmberSize ' range=':= _default_ * boplAmberSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplAmberSize ' range=':= _default_ * boplAmberSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
 
                         <!-- Configuring contained material. -->
-                        <Veins name='boplAmberVeinsPipe'  inherits='boplAmberVeins' seed='0x2E21' drawWireframe='true' wireframeColor='0x60FE9D1B' drawBoundBox='false' boundBoxColor='0x60FE9D1B'>
+                        <Veins name='boplAmberVeinsPipe'  inherits='boplAmberVeins' seed='0x1FEF' drawWireframe='true' wireframeColor='0x60FE9D1B' drawBoundBox='false' boundBoxColor='0x60FE9D1B'>
                             <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:14")'> <Replaces block='BiomesOPlenty:gemOre:14' weight='1.0' /> </IfCondition>
-                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplAmberSize  * 0.5 ' range=':=  _default_ * boplAmberSize  * 0.5 ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplAmberSize  * 0.5 ' range=':=  _default_ * boplAmberSize  * 0.5 ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplAmberSize  * 0.5 ' range=':= _default_ * boplAmberSize  * 0.5 ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplAmberSize  * 0.5 ' range=':= _default_ * boplAmberSize  * 0.5 ' type='normal' />
                             <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
                         </Veins>
                     </IfCondition>
@@ -1210,16 +1210,16 @@
                             <Biome name='Grove'  />
                             <Biome name='Shield'  />
                             <Biome name='Thicket'  />
-                            <Setting name='CloudRadius' avg=':= 0.486 * _default_ * boplAmberSize ' range=':=  _default_ * boplAmberSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.486 * _default_ * boplAmberSize ' range=':=  _default_ * boplAmberSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.236  * _default_ * boplAmberFreq ' range=':=  _default_ * boplAmberFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 0.486 * _default_ * boplAmberSize ' range=':= _default_ * boplAmberSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.486 * _default_ * boplAmberSize ' range=':= _default_ * boplAmberSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.236  * _default_ * boplAmberFreq ' range=':= _default_ * boplAmberFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='boplAmberHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FE9D1B' drawBoundBox='false' boundBoxColor='0x60FE9D1B'>
                                 <Description>
                                     Single blocks, generously
@@ -1265,10 +1265,10 @@
                             <Biome name='Grove'  />
                             <Biome name='Shield'  />
                             <Biome name='Thicket'  />
-                            <Setting name='Size' avg=':= 1 * boplAmberSize ' range=':=  _default_ * boplAmberSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1 * boplAmberFreq ' range=':=  _default_ * boplAmberFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 1 * boplAmberSize ' range=':= _default_ * boplAmberSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1 * boplAmberFreq ' range=':= _default_ * boplAmberFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -1315,7 +1315,7 @@
                 <!-- Starting PipeVeins Preset for EnderAmathyst. -->
                 <ConfigSection>
                     <IfCondition condition=':= boplEnderAmathystDist = "PipeVeins"'>
-                        <Veins name='boplEnderAmathystVeins'  inherits='PresetPipeVeins' seed='0x2E21' drawWireframe='true' wireframeColor='0x60DD4EEA' drawBoundBox='false' boundBoxColor='0x60DD4EEA'>
+                        <Veins name='boplEnderAmathystVeins'  inherits='PresetPipeVeins' seed='0x58D8' drawWireframe='true' wireframeColor='0x60DD4EEA' drawBoundBox='false' boundBoxColor='0x60DD4EEA'>
                             <Description>
                                 Short sparsely filled veins  sloping
                                 up from near the bottom  of the map.
@@ -1323,30 +1323,30 @@
                             <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre")'> <OreBlock block='BiomesOPlenty:gemOre' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * boplEnderAmathystFreq ' range=':=  _default_ * boplEnderAmathystFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplEnderAmathystSize ' range=':=  _default_ * boplEnderAmathystSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * boplEnderAmathystSize ' range=':=  _default_ * boplEnderAmathystSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplEnderAmathystSize ' range=':=  _default_ * boplEnderAmathystSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * boplEnderAmathystFreq ' range=':= _default_ * boplEnderAmathystFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplEnderAmathystSize ' range=':= _default_ * boplEnderAmathystSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * boplEnderAmathystSize ' range=':= _default_ * boplEnderAmathystSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplEnderAmathystSize ' range=':= _default_ * boplEnderAmathystSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
 
                         <!-- Configuring contained material. -->
-                        <Veins name='boplEnderAmathystVeinsPipe'  inherits='boplEnderAmathystVeins' seed='0x2E21' drawWireframe='true' wireframeColor='0x60DD4EEA' drawBoundBox='false' boundBoxColor='0x60DD4EEA'>
+                        <Veins name='boplEnderAmathystVeinsPipe'  inherits='boplEnderAmathystVeins' seed='0x58D8' drawWireframe='true' wireframeColor='0x60DD4EEA' drawBoundBox='false' boundBoxColor='0x60DD4EEA'>
                             <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre")'> <Replaces block='BiomesOPlenty:gemOre' weight='1.0' /> </IfCondition>
-                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplEnderAmathystSize  * 0.5 ' range=':=  _default_ * boplEnderAmathystSize  * 0.5 ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplEnderAmathystSize  * 0.5 ' range=':=  _default_ * boplEnderAmathystSize  * 0.5 ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplEnderAmathystSize  * 0.5 ' range=':= _default_ * boplEnderAmathystSize  * 0.5 ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplEnderAmathystSize  * 0.5 ' range=':= _default_ * boplEnderAmathystSize  * 0.5 ' type='normal' />
                             <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
                         </Veins>
                     </IfCondition>
@@ -1375,16 +1375,16 @@
                             <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre")'> <OreBlock block='BiomesOPlenty:gemOre' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.486 * _default_ * boplEnderAmathystSize ' range=':=  _default_ * boplEnderAmathystSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.486 * _default_ * boplEnderAmathystSize ' range=':=  _default_ * boplEnderAmathystSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.236  * _default_ * boplEnderAmathystFreq ' range=':=  _default_ * boplEnderAmathystFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 0.486 * _default_ * boplEnderAmathystSize ' range=':= _default_ * boplEnderAmathystSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.486 * _default_ * boplEnderAmathystSize ' range=':= _default_ * boplEnderAmathystSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.236  * _default_ * boplEnderAmathystFreq ' range=':= _default_ * boplEnderAmathystFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='boplEnderAmathystHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60DD4EEA' drawBoundBox='false' boundBoxColor='0x60DD4EEA'>
                                 <Description>
                                     Single blocks, generously
@@ -1427,10 +1427,10 @@
                             <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre")'> <OreBlock block='BiomesOPlenty:gemOre' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 1 * boplEnderAmathystSize ' range=':=  _default_ * boplEnderAmathystSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1 * boplEnderAmathystFreq ' range=':=  _default_ * boplEnderAmathystFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 1 * boplEnderAmathystSize ' range=':= _default_ * boplEnderAmathystSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1 * boplEnderAmathystFreq ' range=':= _default_ * boplEnderAmathystFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>

--- a/src/main/resources/config/modules/Chisel2.xml
+++ b/src/main/resources/config/modules/Chisel2.xml
@@ -226,21 +226,21 @@
                             <IfCondition condition=':= ?blockExists("chisel:andesite")'> <OreBlock block='chisel:andesite' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.340 * _default_ * chslAndesiteFreq ' range=':=  1 * _default_ * chslAndesiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.102 * _default_ * chslAndesiteSize ' range=':=  1 * _default_ * chslAndesiteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 43 ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.102 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * chslAndesiteSize ' range=':=  _default_ * chslAndesiteSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.102 * _default_ * chslAndesiteSize ' range=':=  1 * _default_ * chslAndesiteSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.340 * _default_ * chslAndesiteFreq ' range=':= 1 * _default_ * chslAndesiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.102 * _default_ * chslAndesiteSize ' range=':= 1 * _default_ * chslAndesiteSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 43 ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.102 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * chslAndesiteSize ' range=':= _default_ * chslAndesiteSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.102 * _default_ * chslAndesiteSize ' range=':= 1 * _default_ * chslAndesiteSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -268,16 +268,16 @@
                             <IfCondition condition=':= ?blockExists("chisel:andesite")'> <OreBlock block='chisel:andesite' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.636 * _default_ * chslAndesiteSize ' range=':=  _default_ * chslAndesiteSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.636 * _default_ * chslAndesiteSize ' range=':=  _default_ * chslAndesiteSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 2.676  * _default_ * chslAndesiteFreq ' range=':=  _default_ * chslAndesiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 43 ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 1.636 * _default_ * chslAndesiteSize ' range=':= _default_ * chslAndesiteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.636 * _default_ * chslAndesiteSize ' range=':= _default_ * chslAndesiteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 2.676  * _default_ * chslAndesiteFreq ' range=':= _default_ * chslAndesiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 43 ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='chslAndesiteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60CECABE' drawBoundBox='false' boundBoxColor='0x60CECABE'>
                                 <Description>
                                     Single blocks, generously
@@ -324,21 +324,21 @@
                             <IfCondition condition=':= ?blockExists("chisel:diorite")'> <OreBlock block='chisel:diorite' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.340 * _default_ * chslDioriteFreq ' range=':=  1 * _default_ * chslDioriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.102 * _default_ * chslDioriteSize ' range=':=  1 * _default_ * chslDioriteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 61 ' range=':=  67 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.102 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * chslDioriteSize ' range=':=  _default_ * chslDioriteSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.102 * _default_ * chslDioriteSize ' range=':=  1 * _default_ * chslDioriteSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.340 * _default_ * chslDioriteFreq ' range=':= 1 * _default_ * chslDioriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.102 * _default_ * chslDioriteSize ' range=':= 1 * _default_ * chslDioriteSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 61 ' range=':= 67 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.102 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * chslDioriteSize ' range=':= _default_ * chslDioriteSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.102 * _default_ * chslDioriteSize ' range=':= 1 * _default_ * chslDioriteSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -366,16 +366,16 @@
                             <IfCondition condition=':= ?blockExists("chisel:diorite")'> <OreBlock block='chisel:diorite' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.636 * _default_ * chslDioriteSize ' range=':=  _default_ * chslDioriteSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.636 * _default_ * chslDioriteSize ' range=':=  _default_ * chslDioriteSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 2.676  * _default_ * chslDioriteFreq ' range=':=  _default_ * chslDioriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 61 ' range=':=  67 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 1.636 * _default_ * chslDioriteSize ' range=':= _default_ * chslDioriteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.636 * _default_ * chslDioriteSize ' range=':= _default_ * chslDioriteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 2.676  * _default_ * chslDioriteFreq ' range=':= _default_ * chslDioriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 61 ' range=':= 67 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='chslDioriteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60E6E5D3' drawBoundBox='false' boundBoxColor='0x60E6E5D3'>
                                 <Description>
                                     Single blocks, generously
@@ -422,21 +422,21 @@
                             <IfCondition condition=':= ?blockExists("chisel:granite")'> <OreBlock block='chisel:granite' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.340 * _default_ * chslGraniteFreq ' range=':=  1 * _default_ * chslGraniteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.102 * _default_ * chslGraniteSize ' range=':=  1 * _default_ * chslGraniteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 61 ' range=':=  67 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.102 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * chslGraniteSize ' range=':=  _default_ * chslGraniteSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.102 * _default_ * chslGraniteSize ' range=':=  1 * _default_ * chslGraniteSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.340 * _default_ * chslGraniteFreq ' range=':= 1 * _default_ * chslGraniteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.102 * _default_ * chslGraniteSize ' range=':= 1 * _default_ * chslGraniteSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 61 ' range=':= 67 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.102 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * chslGraniteSize ' range=':= _default_ * chslGraniteSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.102 * _default_ * chslGraniteSize ' range=':= 1 * _default_ * chslGraniteSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -464,16 +464,16 @@
                             <IfCondition condition=':= ?blockExists("chisel:granite")'> <OreBlock block='chisel:granite' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.636 * _default_ * chslGraniteSize ' range=':=  _default_ * chslGraniteSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.636 * _default_ * chslGraniteSize ' range=':=  _default_ * chslGraniteSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 2.676  * _default_ * chslGraniteFreq ' range=':=  _default_ * chslGraniteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 61 ' range=':=  67 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 1.636 * _default_ * chslGraniteSize ' range=':= _default_ * chslGraniteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.636 * _default_ * chslGraniteSize ' range=':= _default_ * chslGraniteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 2.676  * _default_ * chslGraniteFreq ' range=':= _default_ * chslGraniteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 61 ' range=':= 67 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='chslGraniteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60F2D9C3' drawBoundBox='false' boundBoxColor='0x60F2D9C3'>
                                 <Description>
                                     Single blocks, generously
@@ -520,21 +520,21 @@
                             <IfCondition condition=':= ?blockExists("chisel:limestone")'> <OreBlock block='chisel:limestone' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.571 * _default_ * chslLimestoneFreq ' range=':=  1 * _default_ * chslLimestoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.163 * _default_ * chslLimestoneSize ' range=':=  1 * _default_ * chslLimestoneSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 61 ' range=':=  67 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.163 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * chslLimestoneSize ' range=':=  _default_ * chslLimestoneSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.163 * _default_ * chslLimestoneSize ' range=':=  1 * _default_ * chslLimestoneSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.571 * _default_ * chslLimestoneFreq ' range=':= 1 * _default_ * chslLimestoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.163 * _default_ * chslLimestoneSize ' range=':= 1 * _default_ * chslLimestoneSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 61 ' range=':= 67 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.163 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * chslLimestoneSize ' range=':= _default_ * chslLimestoneSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.163 * _default_ * chslLimestoneSize ' range=':= 1 * _default_ * chslLimestoneSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -562,16 +562,16 @@
                             <IfCondition condition=':= ?blockExists("chisel:limestone")'> <OreBlock block='chisel:limestone' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.771 * _default_ * chslLimestoneSize ' range=':=  _default_ * chslLimestoneSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.771 * _default_ * chslLimestoneSize ' range=':=  _default_ * chslLimestoneSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 3.137  * _default_ * chslLimestoneFreq ' range=':=  _default_ * chslLimestoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 61 ' range=':=  67 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 1.771 * _default_ * chslLimestoneSize ' range=':= _default_ * chslLimestoneSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.771 * _default_ * chslLimestoneSize ' range=':= _default_ * chslLimestoneSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 3.137  * _default_ * chslLimestoneFreq ' range=':= _default_ * chslLimestoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 61 ' range=':= 67 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='chslLimestoneHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60A5A28F' drawBoundBox='false' boundBoxColor='0x60A5A28F'>
                                 <Description>
                                     Single blocks, generously
@@ -618,21 +618,21 @@
                             <IfCondition condition=':= ?blockExists("chisel:marble")'> <OreBlock block='chisel:marble' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.470 * _default_ * chslMarbleFreq ' range=':=  1 * _default_ * chslMarbleFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.137 * _default_ * chslMarbleSize ' range=':=  1 * _default_ * chslMarbleSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 61 ' range=':=  67 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.137 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * chslMarbleSize ' range=':=  _default_ * chslMarbleSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.137 * _default_ * chslMarbleSize ' range=':=  1 * _default_ * chslMarbleSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.470 * _default_ * chslMarbleFreq ' range=':= 1 * _default_ * chslMarbleFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.137 * _default_ * chslMarbleSize ' range=':= 1 * _default_ * chslMarbleSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 61 ' range=':= 67 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.137 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * chslMarbleSize ' range=':= _default_ * chslMarbleSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.137 * _default_ * chslMarbleSize ' range=':= 1 * _default_ * chslMarbleSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -660,16 +660,16 @@
                             <IfCondition condition=':= ?blockExists("chisel:marble")'> <OreBlock block='chisel:marble' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.713 * _default_ * chslMarbleSize ' range=':=  _default_ * chslMarbleSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.713 * _default_ * chslMarbleSize ' range=':=  _default_ * chslMarbleSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 2.935  * _default_ * chslMarbleFreq ' range=':=  _default_ * chslMarbleFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 61 ' range=':=  67 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 1.713 * _default_ * chslMarbleSize ' range=':= _default_ * chslMarbleSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.713 * _default_ * chslMarbleSize ' range=':= _default_ * chslMarbleSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 2.935  * _default_ * chslMarbleFreq ' range=':= _default_ * chslMarbleFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 61 ' range=':= 67 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='chslMarbleHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60CECECE' drawBoundBox='false' boundBoxColor='0x60CECECE'>
                                 <Description>
                                     Single blocks, generously

--- a/src/main/resources/config/modules/DenseOres.xml
+++ b/src/main/resources/config/modules/DenseOres.xml
@@ -367,21 +367,21 @@
                             <IfCondition condition=':= ?blockExists("denseores:block0")'> <OreBlock block='denseores:block0' weight='0.1' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.498 * _default_ * dnsoIronFreq ' range=':=  1 * _default_ * dnsoIronFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.144 * _default_ * dnsoIronSize ' range=':=  1 * _default_ * dnsoIronSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 36 ' range=':=  31 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.144 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * dnsoIronSize ' range=':=  _default_ * dnsoIronSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.144 * _default_ * dnsoIronSize ' range=':=  1 * _default_ * dnsoIronSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.498 * _default_ * dnsoIronFreq ' range=':= 1 * _default_ * dnsoIronFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.144 * _default_ * dnsoIronSize ' range=':= 1 * _default_ * dnsoIronSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 36 ' range=':= 31 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.144 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * dnsoIronSize ' range=':= _default_ * dnsoIronSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.144 * _default_ * dnsoIronSize ' range=':= 1 * _default_ * dnsoIronSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -400,10 +400,10 @@
                             <IfCondition condition=':= ?blockExists("denseores:block0")'> <OreBlock block='denseores:block0' weight='0.1' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 8 * dnsoIronSize ' range=':=  _default_ * dnsoIronSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 20 * dnsoIronFreq ' range=':=  _default_ * dnsoIronFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 36 ' range=':=  31 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 8 * dnsoIronSize ' range=':= _default_ * dnsoIronSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 20 * dnsoIronFreq ' range=':= _default_ * dnsoIronFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 36 ' range=':= 31 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -432,16 +432,16 @@
                             <IfCondition condition=':= ?blockExists("denseores:block0")'> <OreBlock block='denseores:block0' weight='0.1' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.730 * _default_ * dnsoIronSize ' range=':=  _default_ * dnsoIronSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.730 * _default_ * dnsoIronSize ' range=':=  _default_ * dnsoIronSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 2.991  * _default_ * dnsoIronFreq ' range=':=  _default_ * dnsoIronFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 36 ' range=':=  31 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 1.730 * _default_ * dnsoIronSize ' range=':= _default_ * dnsoIronSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.730 * _default_ * dnsoIronSize ' range=':= _default_ * dnsoIronSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 2.991  * _default_ * dnsoIronFreq ' range=':= _default_ * dnsoIronFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 36 ' range=':= 31 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='dnsoIronHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60DDC2AF' drawBoundBox='false' boundBoxColor='0x60DDC2AF'>
                                 <Description>
                                     Single blocks, generously
@@ -490,21 +490,21 @@
                             <IfCondition condition=':= ?blockExists("denseores:block0:1")'> <OreBlock block='denseores:block0:1' weight='0.1' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.474 * _default_ * dnsoGoldFreq ' range=':=  1 * _default_ * dnsoGoldFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.780 * _default_ * dnsoGoldSize ' range=':=  1 * _default_ * dnsoGoldSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 17 ' range=':=  12 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.780 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * dnsoGoldSize ' range=':=  _default_ * dnsoGoldSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.780 * _default_ * dnsoGoldSize ' range=':=  1 * _default_ * dnsoGoldSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.474 * _default_ * dnsoGoldFreq ' range=':= 1 * _default_ * dnsoGoldFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.780 * _default_ * dnsoGoldSize ' range=':= 1 * _default_ * dnsoGoldSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 17 ' range=':= 12 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.780 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * dnsoGoldSize ' range=':= _default_ * dnsoGoldSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.780 * _default_ * dnsoGoldSize ' range=':= 1 * _default_ * dnsoGoldSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -523,10 +523,10 @@
                             <IfCondition condition=':= ?blockExists("denseores:block0:1")'> <OreBlock block='denseores:block0:1' weight='0.1' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 8 * dnsoGoldSize ' range=':=  _default_ * dnsoGoldSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2 * dnsoGoldFreq ' range=':=  _default_ * dnsoGoldFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 17 ' range=':=  12 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 8 * dnsoGoldSize ' range=':= _default_ * dnsoGoldSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2 * dnsoGoldFreq ' range=':= _default_ * dnsoGoldFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 17 ' range=':= 12 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -555,16 +555,16 @@
                             <IfCondition condition=':= ?blockExists("denseores:block0:1")'> <OreBlock block='denseores:block0:1' weight='0.1' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.973 * _default_ * dnsoGoldSize ' range=':=  _default_ * dnsoGoldSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.973 * _default_ * dnsoGoldSize ' range=':=  _default_ * dnsoGoldSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * dnsoGoldFreq ' range=':=  _default_ * dnsoGoldFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 17 ' range=':=  12 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 0.973 * _default_ * dnsoGoldSize ' range=':= _default_ * dnsoGoldSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.973 * _default_ * dnsoGoldSize ' range=':= _default_ * dnsoGoldSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * dnsoGoldFreq ' range=':= _default_ * dnsoGoldFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 17 ' range=':= 12 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='dnsoGoldHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60EAEF57' drawBoundBox='false' boundBoxColor='0x60EAEF57'>
                                 <Description>
                                     Single blocks, generously
@@ -613,21 +613,21 @@
                             <IfCondition condition=':= ?blockExists("denseores:block0:2")'> <OreBlock block='denseores:block0:2' weight='0.1' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.538 * _default_ * dnsoLapisFreq ' range=':=  1 * _default_ * dnsoLapisFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.813 * _default_ * dnsoLapisSize ' range=':=  1 * _default_ * dnsoLapisSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 19 ' range=':=  14 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= -_default_ ' range=':=  -_default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.813 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * dnsoLapisSize ' range=':=  _default_ * dnsoLapisSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.813 * _default_ * dnsoLapisSize ' range=':=  1 * _default_ * dnsoLapisSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.538 * _default_ * dnsoLapisFreq ' range=':= 1 * _default_ * dnsoLapisFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.813 * _default_ * dnsoLapisSize ' range=':= 1 * _default_ * dnsoLapisSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 19 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= -_default_ ' range=':= -_default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.813 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * dnsoLapisSize ' range=':= _default_ * dnsoLapisSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.813 * _default_ * dnsoLapisSize ' range=':= 1 * _default_ * dnsoLapisSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
 
                         <!-- Beginning "Preferred" configuration. -->
@@ -640,21 +640,21 @@
                             <IfCondition condition=':= ?blockExists("denseores:block0:2")'> <OreBlock block='denseores:block0:2' weight='0.1' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <BiomeType name='Ocean'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.538 * _default_ * dnsoLapisFreq ' range=':=  1 * _default_ * dnsoLapisFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.813 * _default_ * dnsoLapisSize ' range=':=  1 * _default_ * dnsoLapisSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 19 ' range=':=  14 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= -_default_ ' range=':=  -_default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.813 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * dnsoLapisSize ' range=':=  _default_ * dnsoLapisSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.813 * _default_ * dnsoLapisSize ' range=':=  1 * _default_ * dnsoLapisSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.538 * _default_ * dnsoLapisFreq ' range=':= 1 * _default_ * dnsoLapisFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.813 * _default_ * dnsoLapisSize ' range=':= 1 * _default_ * dnsoLapisSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 19 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= -_default_ ' range=':= -_default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.813 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * dnsoLapisSize ' range=':= _default_ * dnsoLapisSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.813 * _default_ * dnsoLapisSize ' range=':= 1 * _default_ * dnsoLapisSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                         <!-- "Preferred" configuration complete. -->
 
@@ -675,10 +675,10 @@
                             <IfCondition condition=':= ?blockExists("denseores:block0:2")'> <OreBlock block='denseores:block0:2' weight='0.1' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 6 * dnsoLapisSize ' range=':=  _default_ * dnsoLapisSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1 * dnsoLapisFreq ' range=':=  _default_ * dnsoLapisFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 19 ' range=':=  14 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 6 * dnsoLapisSize ' range=':= _default_ * dnsoLapisSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1 * dnsoLapisFreq ' range=':= _default_ * dnsoLapisFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 19 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -707,16 +707,16 @@
                             <IfCondition condition=':= ?blockExists("denseores:block0:2")'> <OreBlock block='denseores:block0:2' weight='0.1' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.761 * _default_ * dnsoLapisSize ' range=':=  _default_ * dnsoLapisSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.761 * _default_ * dnsoLapisSize ' range=':=  _default_ * dnsoLapisSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.579  * _default_ * dnsoLapisFreq ' range=':=  _default_ * dnsoLapisFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 19 ' range=':=  14 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 0.761 * _default_ * dnsoLapisSize ' range=':= _default_ * dnsoLapisSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.761 * _default_ * dnsoLapisSize ' range=':= _default_ * dnsoLapisSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.579  * _default_ * dnsoLapisFreq ' range=':= _default_ * dnsoLapisFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 19 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='dnsoLapisHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x601442BA' drawBoundBox='false' boundBoxColor='0x601442BA'>
                                 <Description>
                                     Single blocks, generously
@@ -755,16 +755,16 @@
                             <IfCondition condition=':= ?blockExists("denseores:block0:2")'> <OreBlock block='denseores:block0:2' weight='0.1' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <BiomeType name='Ocean'  />
-                            <Setting name='CloudRadius' avg=':= 0.761 * _default_ * dnsoLapisSize ' range=':=  _default_ * dnsoLapisSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.761 * _default_ * dnsoLapisSize ' range=':=  _default_ * dnsoLapisSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.579  * _default_ * dnsoLapisFreq ' range=':=  _default_ * dnsoLapisFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 19 ' range=':=  14 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 0.761 * _default_ * dnsoLapisSize ' range=':= _default_ * dnsoLapisSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.761 * _default_ * dnsoLapisSize ' range=':= _default_ * dnsoLapisSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.579  * _default_ * dnsoLapisFreq ' range=':= _default_ * dnsoLapisFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 19 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='dnsoLapisPreferredHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x601442BA' drawBoundBox='false' boundBoxColor='0x601442BA'>
                                 <Description>
                                     Ore generation is doubled in
@@ -799,21 +799,21 @@
                             <IfCondition condition=':= ?blockExists("denseores:block0:3")'> <OreBlock block='denseores:block0:3' weight='0.1' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.365 * _default_ * dnsoDiamondFreq ' range=':=  1 * _default_ * dnsoDiamondFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.715 * _default_ * dnsoDiamondSize ' range=':=  1 * _default_ * dnsoDiamondSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 10 ' range=':=  5 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.715 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * dnsoDiamondSize ' range=':=  _default_ * dnsoDiamondSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.715 * _default_ * dnsoDiamondSize ' range=':=  1 * _default_ * dnsoDiamondSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.365 * _default_ * dnsoDiamondFreq ' range=':= 1 * _default_ * dnsoDiamondFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.715 * _default_ * dnsoDiamondSize ' range=':= 1 * _default_ * dnsoDiamondSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 10 ' range=':= 5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.715 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * dnsoDiamondSize ' range=':= _default_ * dnsoDiamondSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.715 * _default_ * dnsoDiamondSize ' range=':= 1 * _default_ * dnsoDiamondSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
 
                         <!-- Configuring contained material. -->
@@ -822,8 +822,8 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:diamond_ore")'> <Replaces block='minecraft:diamond_ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("denseores:block0:3")'> <Replaces block='denseores:block0:3' weight='1.0' /> </IfCondition>
-                            <Setting name='MotherlodeSize' avg=':= 0.715 * _default_ * dnsoDiamondSize  * 0.5 ' range=':=  1 * _default_ * dnsoDiamondSize  * 0.5 ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.715 * _default_ * dnsoDiamondSize  * 0.5 ' range=':=  1 * _default_ * dnsoDiamondSize  * 0.5 ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.715 * _default_ * dnsoDiamondSize  * 0.5 ' range=':= 1 * _default_ * dnsoDiamondSize  * 0.5 ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.715 * _default_ * dnsoDiamondSize  * 0.5 ' range=':= 1 * _default_ * dnsoDiamondSize  * 0.5 ' type='normal' />
                             <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
                         </Veins>
                     </IfCondition>
@@ -843,10 +843,10 @@
                             <IfCondition condition=':= ?blockExists("denseores:block0:3")'> <OreBlock block='denseores:block0:3' weight='0.1' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 7 * dnsoDiamondSize ' range=':=  _default_ * dnsoDiamondSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1 * dnsoDiamondFreq ' range=':=  _default_ * dnsoDiamondFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 10 ' range=':=  5 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 7 * dnsoDiamondSize ' range=':= _default_ * dnsoDiamondSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1 * dnsoDiamondFreq ' range=':= _default_ * dnsoDiamondFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 10 ' range=':= 5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -875,16 +875,16 @@
                             <IfCondition condition=':= ?blockExists("denseores:block0:3")'> <OreBlock block='denseores:block0:3' weight='0.1' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.791 * _default_ * dnsoDiamondSize ' range=':=  _default_ * dnsoDiamondSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.791 * _default_ * dnsoDiamondSize ' range=':=  _default_ * dnsoDiamondSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.626  * _default_ * dnsoDiamondFreq ' range=':=  _default_ * dnsoDiamondFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 10 ' range=':=  5 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 0.791 * _default_ * dnsoDiamondSize ' range=':= _default_ * dnsoDiamondSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.791 * _default_ * dnsoDiamondSize ' range=':= _default_ * dnsoDiamondSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.626  * _default_ * dnsoDiamondFreq ' range=':= _default_ * dnsoDiamondFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 10 ' range=':= 5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='dnsoDiamondHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x608BF4E3' drawBoundBox='false' boundBoxColor='0x608BF4E3'>
                                 <Description>
                                     Single blocks, generously
@@ -924,7 +924,7 @@
                 <!-- Starting PipeVeins Preset for Emerald. -->
                 <ConfigSection>
                     <IfCondition condition=':= dnsoEmeraldDist = "PipeVeins"'>
-                        <Veins name='dnsoEmeraldVeins'  inherits='PresetPipeVeins' seed='0xA4DC' drawWireframe='true' wireframeColor='0x606CE391' drawBoundBox='false' boundBoxColor='0x606CE391'>
+                        <Veins name='dnsoEmeraldVeins'  inherits='PresetPipeVeins' seed='0x81E5' drawWireframe='true' wireframeColor='0x606CE391' drawBoundBox='false' boundBoxColor='0x606CE391'>
                             <Description>
                                 Short sparsely filled veins  sloping
                                 up from near the bottom  of the map.
@@ -933,31 +933,31 @@
                             <IfCondition condition=':= ?blockExists("denseores:block0:4")'> <OreBlock block='denseores:block0:4' weight='0.1' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <BiomeType name='Mountain'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * dnsoEmeraldFreq ' range=':=  1 * _default_ * dnsoEmeraldFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * dnsoEmeraldSize ' range=':=  1 * _default_ * dnsoEmeraldSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 37 ' range=':=  14 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * dnsoEmeraldSize ' range=':=  _default_ * dnsoEmeraldSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * dnsoEmeraldSize ' range=':=  1 * _default_ * dnsoEmeraldSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * dnsoEmeraldFreq ' range=':= 1 * _default_ * dnsoEmeraldFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * dnsoEmeraldSize ' range=':= 1 * _default_ * dnsoEmeraldSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 37 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * dnsoEmeraldSize ' range=':= _default_ * dnsoEmeraldSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * dnsoEmeraldSize ' range=':= 1 * _default_ * dnsoEmeraldSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
 
                         <!-- Configuring contained material. -->
-                        <Veins name='dnsoEmeraldVeinsPipe'  inherits='dnsoEmeraldVeins' seed='0xA4DC' drawWireframe='true' wireframeColor='0x606CE391' drawBoundBox='false' boundBoxColor='0x606CE391'>
+                        <Veins name='dnsoEmeraldVeinsPipe'  inherits='dnsoEmeraldVeins' seed='0x81E5' drawWireframe='true' wireframeColor='0x606CE391' drawBoundBox='false' boundBoxColor='0x606CE391'>
                             <IfCondition condition=':= ?blockExists("minecraft:monster_egg")'> <OreBlock block='minecraft:monster_egg' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:emerald_ore")'> <Replaces block='minecraft:emerald_ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("denseores:block0:4")'> <Replaces block='denseores:block0:4' weight='1.0' /> </IfCondition>
-                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * dnsoEmeraldSize  * 0.5 ' range=':=  1 * _default_ * dnsoEmeraldSize  * 0.5 ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * dnsoEmeraldSize  * 0.5 ' range=':=  1 * _default_ * dnsoEmeraldSize  * 0.5 ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * dnsoEmeraldSize  * 0.5 ' range=':= 1 * _default_ * dnsoEmeraldSize  * 0.5 ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * dnsoEmeraldSize  * 0.5 ' range=':= 1 * _default_ * dnsoEmeraldSize  * 0.5 ' type='normal' />
                             <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
                         </Veins>
                     </IfCondition>
@@ -977,10 +977,10 @@
                             <IfCondition condition=':= ?blockExists("denseores:block0:4")'> <OreBlock block='denseores:block0:4' weight='0.1' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <BiomeType name='Mountain'  />
-                            <Setting name='Size' avg=':= 1 * dnsoEmeraldSize ' range=':=  _default_ * dnsoEmeraldSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1 * dnsoEmeraldFreq ' range=':=  _default_ * dnsoEmeraldFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 37 ' range=':=  14 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 1 * dnsoEmeraldSize ' range=':= _default_ * dnsoEmeraldSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1 * dnsoEmeraldFreq ' range=':= _default_ * dnsoEmeraldFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 37 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -1009,16 +1009,16 @@
                             <IfCondition condition=':= ?blockExists("denseores:block0:4")'> <OreBlock block='denseores:block0:4' weight='0.1' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <BiomeType name='Mountain'  />
-                            <Setting name='CloudRadius' avg=':= 0.486 * _default_ * dnsoEmeraldSize ' range=':=  _default_ * dnsoEmeraldSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.486 * _default_ * dnsoEmeraldSize ' range=':=  _default_ * dnsoEmeraldSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.236  * _default_ * dnsoEmeraldFreq ' range=':=  _default_ * dnsoEmeraldFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 37 ' range=':=  14 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 0.486 * _default_ * dnsoEmeraldSize ' range=':= _default_ * dnsoEmeraldSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.486 * _default_ * dnsoEmeraldSize ' range=':= _default_ * dnsoEmeraldSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.236  * _default_ * dnsoEmeraldFreq ' range=':= _default_ * dnsoEmeraldFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 37 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='dnsoEmeraldHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x606CE391' drawBoundBox='false' boundBoxColor='0x606CE391'>
                                 <Description>
                                     Single blocks, generously
@@ -1067,21 +1067,21 @@
                             <IfCondition condition=':= ?blockExists("denseores:block0:5")'> <OreBlock block='denseores:block0:5' weight='0.1' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.642 * _default_ * dnsoRedstoneFreq ' range=':=  1 * _default_ * dnsoRedstoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.180 * _default_ * dnsoRedstoneSize ' range=':=  1 * _default_ * dnsoRedstoneSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 10 ' range=':=  5 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= -_default_ ' range=':=  -_default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.180 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * dnsoRedstoneSize ' range=':=  _default_ * dnsoRedstoneSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.180 * _default_ * dnsoRedstoneSize ' range=':=  1 * _default_ * dnsoRedstoneSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.642 * _default_ * dnsoRedstoneFreq ' range=':= 1 * _default_ * dnsoRedstoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.180 * _default_ * dnsoRedstoneSize ' range=':= 1 * _default_ * dnsoRedstoneSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 10 ' range=':= 5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= -_default_ ' range=':= -_default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.180 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * dnsoRedstoneSize ' range=':= _default_ * dnsoRedstoneSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.180 * _default_ * dnsoRedstoneSize ' range=':= 1 * _default_ * dnsoRedstoneSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
 
                         <!-- Beginning "Preferred" configuration. -->
@@ -1094,21 +1094,21 @@
                             <IfCondition condition=':= ?blockExists("denseores:block0:5")'> <OreBlock block='denseores:block0:5' weight='0.1' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <BiomeType name='Desert'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.642 * _default_ * dnsoRedstoneFreq ' range=':=  1 * _default_ * dnsoRedstoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.180 * _default_ * dnsoRedstoneSize ' range=':=  1 * _default_ * dnsoRedstoneSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 10 ' range=':=  5 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= -_default_ ' range=':=  -_default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.180 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * dnsoRedstoneSize ' range=':=  _default_ * dnsoRedstoneSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.180 * _default_ * dnsoRedstoneSize ' range=':=  1 * _default_ * dnsoRedstoneSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.642 * _default_ * dnsoRedstoneFreq ' range=':= 1 * _default_ * dnsoRedstoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.180 * _default_ * dnsoRedstoneSize ' range=':= 1 * _default_ * dnsoRedstoneSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 10 ' range=':= 5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= -_default_ ' range=':= -_default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.180 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * dnsoRedstoneSize ' range=':= _default_ * dnsoRedstoneSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.180 * _default_ * dnsoRedstoneSize ' range=':= 1 * _default_ * dnsoRedstoneSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                         <!-- "Preferred" configuration complete. -->
 
@@ -1129,10 +1129,10 @@
                             <IfCondition condition=':= ?blockExists("denseores:block0:5")'> <OreBlock block='denseores:block0:5' weight='0.1' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 7 * dnsoRedstoneSize ' range=':=  _default_ * dnsoRedstoneSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 8 * dnsoRedstoneFreq ' range=':=  _default_ * dnsoRedstoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 10 ' range=':=  5 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 7 * dnsoRedstoneSize ' range=':= _default_ * dnsoRedstoneSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 8 * dnsoRedstoneFreq ' range=':= _default_ * dnsoRedstoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 10 ' range=':= 5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -1161,16 +1161,16 @@
                             <IfCondition condition=':= ?blockExists("denseores:block0:5")'> <OreBlock block='denseores:block0:5' weight='0.1' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.330 * _default_ * dnsoRedstoneSize ' range=':=  _default_ * dnsoRedstoneSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.330 * _default_ * dnsoRedstoneSize ' range=':=  _default_ * dnsoRedstoneSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.770  * _default_ * dnsoRedstoneFreq ' range=':=  _default_ * dnsoRedstoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 10 ' range=':=  5 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 1.330 * _default_ * dnsoRedstoneSize ' range=':= _default_ * dnsoRedstoneSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.330 * _default_ * dnsoRedstoneSize ' range=':= _default_ * dnsoRedstoneSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.770  * _default_ * dnsoRedstoneFreq ' range=':= _default_ * dnsoRedstoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 10 ' range=':= 5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='dnsoRedstoneHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60A80002' drawBoundBox='false' boundBoxColor='0x60A80002'>
                                 <Description>
                                     Single blocks, generously
@@ -1209,16 +1209,16 @@
                             <IfCondition condition=':= ?blockExists("denseores:block0:5")'> <OreBlock block='denseores:block0:5' weight='0.1' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <BiomeType name='Desert'  />
-                            <Setting name='CloudRadius' avg=':= 1.330 * _default_ * dnsoRedstoneSize ' range=':=  _default_ * dnsoRedstoneSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.330 * _default_ * dnsoRedstoneSize ' range=':=  _default_ * dnsoRedstoneSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.770  * _default_ * dnsoRedstoneFreq ' range=':=  _default_ * dnsoRedstoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 10 ' range=':=  5 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 1.330 * _default_ * dnsoRedstoneSize ' range=':= _default_ * dnsoRedstoneSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.330 * _default_ * dnsoRedstoneSize ' range=':= _default_ * dnsoRedstoneSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.770  * _default_ * dnsoRedstoneFreq ' range=':= _default_ * dnsoRedstoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 10 ' range=':= 5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='dnsoRedstonePreferredHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60A80002' drawBoundBox='false' boundBoxColor='0x60A80002'>
                                 <Description>
                                     Ore generation is doubled in
@@ -1260,21 +1260,21 @@
                             <IfCondition condition=':= ?blockExists("denseores:block0:6")'> <OreBlock block='denseores:block0:6' weight='0.1' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 6.262 * _default_ * dnsoCoalFreq ' range=':=  1 * _default_ * dnsoCoalFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.843 * _default_ * dnsoCoalSize ' range=':=  1 * _default_ * dnsoCoalSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 68 ' range=':=  63 ' type='uniform' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.843 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * dnsoCoalSize ' range=':=  _default_ * dnsoCoalSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.843 * _default_ * dnsoCoalSize ' range=':=  1 * _default_ * dnsoCoalSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 6.262 * _default_ * dnsoCoalFreq ' range=':= 1 * _default_ * dnsoCoalFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.843 * _default_ * dnsoCoalSize ' range=':= 1 * _default_ * dnsoCoalSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 68 ' range=':= 63 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.843 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * dnsoCoalSize ' range=':= _default_ * dnsoCoalSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.843 * _default_ * dnsoCoalSize ' range=':= 1 * _default_ * dnsoCoalSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -1303,16 +1303,16 @@
                             <IfCondition condition=':= ?blockExists("denseores:block0:6")'> <OreBlock block='denseores:block0:6' weight='0.1' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 2.057 * _default_ * dnsoCoalSize ' range=':=  _default_ * dnsoCoalSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 2.057 * _default_ * dnsoCoalSize ' range=':=  _default_ * dnsoCoalSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 4.230  * _default_ * dnsoCoalFreq ' range=':=  _default_ * dnsoCoalFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 68 ' range=':=  63 ' type='uniform' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 2.057 * _default_ * dnsoCoalSize ' range=':= _default_ * dnsoCoalSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 2.057 * _default_ * dnsoCoalSize ' range=':= _default_ * dnsoCoalSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 4.230  * _default_ * dnsoCoalFreq ' range=':= _default_ * dnsoCoalFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 68 ' range=':= 63 ' type='uniform' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='dnsoCoalHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x602A2A2A' drawBoundBox='false' boundBoxColor='0x602A2A2A'>
                                 <Description>
                                     Single blocks, generously
@@ -1357,10 +1357,10 @@
                             <IfCondition condition=':= ?blockExists("denseores:block0:6")'> <OreBlock block='denseores:block0:6' weight='0.1' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 16 * dnsoCoalSize ' range=':=  _default_ * dnsoCoalSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 20 * dnsoCoalFreq ' range=':=  _default_ * dnsoCoalFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 68 ' range=':=  63 ' type='uniform' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 16 * dnsoCoalSize ' range=':= _default_ * dnsoCoalSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 20 * dnsoCoalFreq ' range=':= _default_ * dnsoCoalFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 68 ' range=':= 63 ' type='uniform' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -1389,16 +1389,16 @@
                             <IfCondition condition=':= ?blockExists("denseores:block0:6")'> <OreBlock block='denseores:block0:6' weight='0.1' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 2.057 * _default_ * dnsoCoalSize ' range=':=  _default_ * dnsoCoalSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 2.057 * _default_ * dnsoCoalSize ' range=':=  _default_ * dnsoCoalSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 4.230  * _default_ * dnsoCoalFreq ' range=':=  _default_ * dnsoCoalFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 68 ' range=':=  63 ' type='uniform' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 2.057 * _default_ * dnsoCoalSize ' range=':= _default_ * dnsoCoalSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 2.057 * _default_ * dnsoCoalSize ' range=':= _default_ * dnsoCoalSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 4.230  * _default_ * dnsoCoalFreq ' range=':= _default_ * dnsoCoalFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 68 ' range=':= 63 ' type='uniform' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='dnsoCoalHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x602A2A2A' drawBoundBox='false' boundBoxColor='0x602A2A2A'>
                                 <Description>
                                     Single blocks, generously
@@ -1480,21 +1480,21 @@
                             <IfCondition condition=':= ?blockExists("denseores:block0:7")'> <OreBlock block='denseores:block0:7' weight='0.1' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 5.049 * _default_ * dnsoNetherQuartzFreq ' range=':=  1 * _default_ * dnsoNetherQuartzFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.716 * _default_ * dnsoNetherQuartzSize ' range=':=  1 * _default_ * dnsoNetherQuartzSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 68 ' range=':=  52 ' type='uniform' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.716 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * dnsoNetherQuartzSize ' range=':=  _default_ * dnsoNetherQuartzSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.716 * _default_ * dnsoNetherQuartzSize ' range=':=  1 * _default_ * dnsoNetherQuartzSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 5.049 * _default_ * dnsoNetherQuartzFreq ' range=':= 1 * _default_ * dnsoNetherQuartzFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.716 * _default_ * dnsoNetherQuartzSize ' range=':= 1 * _default_ * dnsoNetherQuartzSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 68 ' range=':= 52 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.716 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * dnsoNetherQuartzSize ' range=':= _default_ * dnsoNetherQuartzSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.716 * _default_ * dnsoNetherQuartzSize ' range=':= 1 * _default_ * dnsoNetherQuartzSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -1514,10 +1514,10 @@
                             <IfCondition condition=':= ?blockExists("denseores:block0:7")'> <OreBlock block='denseores:block0:7' weight='0.1' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 13 * dnsoNetherQuartzSize ' range=':=  _default_ * dnsoNetherQuartzSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 16 * dnsoNetherQuartzFreq ' range=':=  _default_ * dnsoNetherQuartzFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 68 ' range=':=  52 ' type='uniform' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 13 * dnsoNetherQuartzSize ' range=':= _default_ * dnsoNetherQuartzSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 16 * dnsoNetherQuartzFreq ' range=':= _default_ * dnsoNetherQuartzFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 68 ' range=':= 52 ' type='uniform' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -1546,16 +1546,16 @@
                             <IfCondition condition=':= ?blockExists("denseores:block0:7")'> <OreBlock block='denseores:block0:7' weight='0.1' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.847 * _default_ * dnsoNetherQuartzSize ' range=':=  _default_ * dnsoNetherQuartzSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.847 * _default_ * dnsoNetherQuartzSize ' range=':=  _default_ * dnsoNetherQuartzSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 3.411  * _default_ * dnsoNetherQuartzFreq ' range=':=  _default_ * dnsoNetherQuartzFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 68 ' range=':=  52 ' type='uniform' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 1.847 * _default_ * dnsoNetherQuartzSize ' range=':= _default_ * dnsoNetherQuartzSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.847 * _default_ * dnsoNetherQuartzSize ' range=':= _default_ * dnsoNetherQuartzSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 3.411  * _default_ * dnsoNetherQuartzFreq ' range=':= _default_ * dnsoNetherQuartzFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 68 ' range=':= 52 ' type='uniform' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='dnsoNetherQuartzHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60DBCCBF' drawBoundBox='false' boundBoxColor='0x60DBCCBF'>
                                 <Description>
                                     Single blocks, generously

--- a/src/main/resources/config/modules/ElectriCraft.xml
+++ b/src/main/resources/config/modules/ElectriCraft.xml
@@ -287,21 +287,21 @@
                             <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore")'> <OreBlock block='ElectriCraft:electricraft_block_ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.821 * _default_ * elcrCopperFreq ' range=':=  1 * _default_ * elcrCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.936 * _default_ * elcrCopperSize ' range=':=  1 * _default_ * elcrCopperSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 48 ' range=':=  16 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.936 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * elcrCopperSize ' range=':=  _default_ * elcrCopperSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.936 * _default_ * elcrCopperSize ' range=':=  1 * _default_ * elcrCopperSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.821 * _default_ * elcrCopperFreq ' range=':= 1 * _default_ * elcrCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.936 * _default_ * elcrCopperSize ' range=':= 1 * _default_ * elcrCopperSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 48 ' range=':= 16 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.936 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * elcrCopperSize ' range=':= _default_ * elcrCopperSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.936 * _default_ * elcrCopperSize ' range=':= 1 * _default_ * elcrCopperSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -319,10 +319,10 @@
                             <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore")'> <OreBlock block='ElectriCraft:electricraft_block_ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 6 * elcrCopperSize ' range=':=  _default_ * elcrCopperSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 8 * elcrCopperFreq ' range=':=  _default_ * elcrCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 48 ' range=':=  16 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 6 * elcrCopperSize ' range=':= _default_ * elcrCopperSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 8 * elcrCopperFreq ' range=':= _default_ * elcrCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 48 ' range=':= 16 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -350,16 +350,16 @@
                             <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore")'> <OreBlock block='ElectriCraft:electricraft_block_ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.280 * _default_ * elcrCopperSize ' range=':=  _default_ * elcrCopperSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.280 * _default_ * elcrCopperSize ' range=':=  _default_ * elcrCopperSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.638  * _default_ * elcrCopperFreq ' range=':=  _default_ * elcrCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 48 ' range=':=  16 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 1.280 * _default_ * elcrCopperSize ' range=':= _default_ * elcrCopperSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.280 * _default_ * elcrCopperSize ' range=':= _default_ * elcrCopperSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.638  * _default_ * elcrCopperFreq ' range=':= _default_ * elcrCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 48 ' range=':= 16 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='elcrCopperHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60BB6E30' drawBoundBox='false' boundBoxColor='0x60BB6E30'>
                                 <Description>
                                     Single blocks, generously
@@ -406,21 +406,21 @@
                             <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:1")'> <OreBlock block='ElectriCraft:electricraft_block_ore:1' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.948 * _default_ * elcrTinFreq ' range=':=  1 * _default_ * elcrTinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.982 * _default_ * elcrTinSize ' range=':=  1 * _default_ * elcrTinSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 60 ' range=':=  12 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.982 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * elcrTinSize ' range=':=  _default_ * elcrTinSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.982 * _default_ * elcrTinSize ' range=':=  1 * _default_ * elcrTinSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.948 * _default_ * elcrTinFreq ' range=':= 1 * _default_ * elcrTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.982 * _default_ * elcrTinSize ' range=':= 1 * _default_ * elcrTinSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 60 ' range=':= 12 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.982 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * elcrTinSize ' range=':= _default_ * elcrTinSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.982 * _default_ * elcrTinSize ' range=':= 1 * _default_ * elcrTinSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -438,10 +438,10 @@
                             <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:1")'> <OreBlock block='ElectriCraft:electricraft_block_ore:1' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 8 * elcrTinSize ' range=':=  _default_ * elcrTinSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 8 * elcrTinFreq ' range=':=  _default_ * elcrTinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 60 ' range=':=  12 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 8 * elcrTinSize ' range=':= _default_ * elcrTinSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 8 * elcrTinFreq ' range=':= _default_ * elcrTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 60 ' range=':= 12 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -469,16 +469,16 @@
                             <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:1")'> <OreBlock block='ElectriCraft:electricraft_block_ore:1' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.280 * _default_ * elcrTinSize ' range=':=  _default_ * elcrTinSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.280 * _default_ * elcrTinSize ' range=':=  _default_ * elcrTinSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.892  * _default_ * elcrTinFreq ' range=':=  _default_ * elcrTinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 60 ' range=':=  12 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 1.280 * _default_ * elcrTinSize ' range=':= _default_ * elcrTinSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.280 * _default_ * elcrTinSize ' range=':= _default_ * elcrTinSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.892  * _default_ * elcrTinFreq ' range=':= _default_ * elcrTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 60 ' range=':= 12 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='elcrTinHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60A9C7CF' drawBoundBox='false' boundBoxColor='0x60A9C7CF'>
                                 <Description>
                                     Single blocks, generously
@@ -525,21 +525,21 @@
                             <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:2")'> <OreBlock block='ElectriCraft:electricraft_block_ore:2' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.580 * _default_ * elcrSilverFreq ' range=':=  1 * _default_ * elcrSilverFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.834 * _default_ * elcrSilverSize ' range=':=  1 * _default_ * elcrSilverSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.834 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * elcrSilverSize ' range=':=  _default_ * elcrSilverSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.834 * _default_ * elcrSilverSize ' range=':=  1 * _default_ * elcrSilverSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.580 * _default_ * elcrSilverFreq ' range=':= 1 * _default_ * elcrSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.834 * _default_ * elcrSilverSize ' range=':= 1 * _default_ * elcrSilverSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.834 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * elcrSilverSize ' range=':= _default_ * elcrSilverSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.834 * _default_ * elcrSilverSize ' range=':= 1 * _default_ * elcrSilverSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -557,10 +557,10 @@
                             <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:2")'> <OreBlock block='ElectriCraft:electricraft_block_ore:2' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 6 * elcrSilverSize ' range=':=  _default_ * elcrSilverSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 4 * elcrSilverFreq ' range=':=  _default_ * elcrSilverFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 6 * elcrSilverSize ' range=':= _default_ * elcrSilverSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4 * elcrSilverFreq ' range=':= _default_ * elcrSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -588,16 +588,16 @@
                             <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:2")'> <OreBlock block='ElectriCraft:electricraft_block_ore:2' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.076 * _default_ * elcrSilverSize ' range=':=  _default_ * elcrSilverSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.076 * _default_ * elcrSilverSize ' range=':=  _default_ * elcrSilverSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.159 * _default_ * elcrSilverFreq ' range=':=  _default_ * elcrSilverFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 1.076 * _default_ * elcrSilverSize ' range=':= _default_ * elcrSilverSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.076 * _default_ * elcrSilverSize ' range=':= _default_ * elcrSilverSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.159 * _default_ * elcrSilverFreq ' range=':= _default_ * elcrSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='elcrSilverHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60B6D2EA' drawBoundBox='false' boundBoxColor='0x60B6D2EA'>
                                 <Description>
                                     Single blocks, generously
@@ -644,21 +644,21 @@
                             <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:3")'> <OreBlock block='ElectriCraft:electricraft_block_ore:3' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.821 * _default_ * elcrNickelFreq ' range=':=  1 * _default_ * elcrNickelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.936 * _default_ * elcrNickelSize ' range=':=  1 * _default_ * elcrNickelSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 32 ' range=':=  16 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.936 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * elcrNickelSize ' range=':=  _default_ * elcrNickelSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.936 * _default_ * elcrNickelSize ' range=':=  1 * _default_ * elcrNickelSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.821 * _default_ * elcrNickelFreq ' range=':= 1 * _default_ * elcrNickelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.936 * _default_ * elcrNickelSize ' range=':= 1 * _default_ * elcrNickelSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 32 ' range=':= 16 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.936 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * elcrNickelSize ' range=':= _default_ * elcrNickelSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.936 * _default_ * elcrNickelSize ' range=':= 1 * _default_ * elcrNickelSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -676,10 +676,10 @@
                             <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:3")'> <OreBlock block='ElectriCraft:electricraft_block_ore:3' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 8 * elcrNickelSize ' range=':=  _default_ * elcrNickelSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 6 * elcrNickelFreq ' range=':=  _default_ * elcrNickelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 32 ' range=':=  16 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 8 * elcrNickelSize ' range=':= _default_ * elcrNickelSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 6 * elcrNickelFreq ' range=':= _default_ * elcrNickelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 32 ' range=':= 16 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -707,16 +707,16 @@
                             <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:3")'> <OreBlock block='ElectriCraft:electricraft_block_ore:3' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.280 * _default_ * elcrNickelSize ' range=':=  _default_ * elcrNickelSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.280 * _default_ * elcrNickelSize ' range=':=  _default_ * elcrNickelSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.638  * _default_ * elcrNickelFreq ' range=':=  _default_ * elcrNickelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 32 ' range=':=  16 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 1.280 * _default_ * elcrNickelSize ' range=':= _default_ * elcrNickelSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.280 * _default_ * elcrNickelSize ' range=':= _default_ * elcrNickelSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.638  * _default_ * elcrNickelFreq ' range=':= _default_ * elcrNickelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 32 ' range=':= 16 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='elcrNickelHintVeins'  inherits='PresetHintVeins' drawWireframe='false' wireframeColor='0x60D2D1B6' drawBoundBox='false' boundBoxColor='0x60D2D1B6'>
                                 <Description>
                                     Single blocks, generously
@@ -763,21 +763,21 @@
                             <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:4")'> <OreBlock block='ElectriCraft:electricraft_block_ore:4' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.059 * _default_ * elcrAluminumFreq ' range=':=  1 * _default_ * elcrAluminumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.019 * _default_ * elcrAluminumSize ' range=':=  1 * _default_ * elcrAluminumSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 94 ' range=':=  34 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.019 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * elcrAluminumSize ' range=':=  _default_ * elcrAluminumSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.019 * _default_ * elcrAluminumSize ' range=':=  1 * _default_ * elcrAluminumSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.059 * _default_ * elcrAluminumFreq ' range=':= 1 * _default_ * elcrAluminumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.019 * _default_ * elcrAluminumSize ' range=':= 1 * _default_ * elcrAluminumSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 94 ' range=':= 34 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.019 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * elcrAluminumSize ' range=':= _default_ * elcrAluminumSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.019 * _default_ * elcrAluminumSize ' range=':= 1 * _default_ * elcrAluminumSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -795,10 +795,10 @@
                             <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:4")'> <OreBlock block='ElectriCraft:electricraft_block_ore:4' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 8 * elcrAluminumSize ' range=':=  _default_ * elcrAluminumSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 10 * elcrAluminumFreq ' range=':=  _default_ * elcrAluminumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 94 ' range=':=  34 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 8 * elcrAluminumSize ' range=':= _default_ * elcrAluminumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 10 * elcrAluminumFreq ' range=':= _default_ * elcrAluminumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 94 ' range=':= 34 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -826,16 +826,16 @@
                             <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:4")'> <OreBlock block='ElectriCraft:electricraft_block_ore:4' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.454 * _default_ * elcrAluminumSize ' range=':=  _default_ * elcrAluminumSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.454 * _default_ * elcrAluminumSize ' range=':=  _default_ * elcrAluminumSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 2.115 * _default_ * elcrAluminumFreq ' range=':=  _default_ * elcrAluminumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 94 ' range=':=  34 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 1.454 * _default_ * elcrAluminumSize ' range=':= _default_ * elcrAluminumSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.454 * _default_ * elcrAluminumSize ' range=':= _default_ * elcrAluminumSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 2.115 * _default_ * elcrAluminumFreq ' range=':= _default_ * elcrAluminumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 94 ' range=':= 34 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='elcrAluminumHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60DAD9DB' drawBoundBox='false' boundBoxColor='0x60DAD9DB'>
                                 <Description>
                                     Single blocks, generously
@@ -882,21 +882,21 @@
                             <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:5")'> <OreBlock block='ElectriCraft:electricraft_block_ore:5' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.335 * _default_ * elcrPlatinumFreq ' range=':=  1 * _default_ * elcrPlatinumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.695 * _default_ * elcrPlatinumSize ' range=':=  1 * _default_ * elcrPlatinumSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 11 ' range=':=  5 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.695 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * elcrPlatinumSize ' range=':=  _default_ * elcrPlatinumSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.695 * _default_ * elcrPlatinumSize ' range=':=  1 * _default_ * elcrPlatinumSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.335 * _default_ * elcrPlatinumFreq ' range=':= 1 * _default_ * elcrPlatinumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.695 * _default_ * elcrPlatinumSize ' range=':= 1 * _default_ * elcrPlatinumSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 11 ' range=':= 5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.695 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * elcrPlatinumSize ' range=':= _default_ * elcrPlatinumSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.695 * _default_ * elcrPlatinumSize ' range=':= 1 * _default_ * elcrPlatinumSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -914,10 +914,10 @@
                             <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:5")'> <OreBlock block='ElectriCraft:electricraft_block_ore:5' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4 * elcrPlatinumSize ' range=':=  _default_ * elcrPlatinumSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2 * elcrPlatinumFreq ' range=':=  _default_ * elcrPlatinumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 11 ' range=':=  5 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 4 * elcrPlatinumSize ' range=':= _default_ * elcrPlatinumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2 * elcrPlatinumFreq ' range=':= _default_ * elcrPlatinumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 11 ' range=':= 5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -945,16 +945,16 @@
                             <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:5")'> <OreBlock block='ElectriCraft:electricraft_block_ore:5' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.669 * _default_ * elcrPlatinumSize ' range=':=  _default_ * elcrPlatinumSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.669 * _default_ * elcrPlatinumSize ' range=':=  _default_ * elcrPlatinumSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.447  * _default_ * elcrPlatinumFreq ' range=':=  _default_ * elcrPlatinumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 11 ' range=':=  5 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 0.669 * _default_ * elcrPlatinumSize ' range=':= _default_ * elcrPlatinumSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.669 * _default_ * elcrPlatinumSize ' range=':= _default_ * elcrPlatinumSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.447  * _default_ * elcrPlatinumFreq ' range=':= _default_ * elcrPlatinumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 11 ' range=':= 5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='elcrPlatinumHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x602D84E7' drawBoundBox='false' boundBoxColor='0x602D84E7'>
                                 <Description>
                                     Single blocks, generously

--- a/src/main/resources/config/modules/Factorization.xml
+++ b/src/main/resources/config/modules/Factorization.xml
@@ -144,21 +144,21 @@
                             <IfCondition condition=':= ?blockExists("factorization:ResourceBlock")'> <OreBlock block='factorization:ResourceBlock' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.543 * _default_ * fctrSilverFreq ' range=':=  _default_ * fctrSilverFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.816 * _default_ * fctrSilverSize ' range=':=  _default_ * fctrSilverSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 25 ' range=':=  10 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.816 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * fctrSilverSize ' range=':=  _default_ * fctrSilverSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.816 * _default_ * fctrSilverSize ' range=':=  _default_ * fctrSilverSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.543 * _default_ * fctrSilverFreq ' range=':= _default_ * fctrSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.816 * _default_ * fctrSilverSize ' range=':= _default_ * fctrSilverSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 25 ' range=':= 10 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.816 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * fctrSilverSize ' range=':= _default_ * fctrSilverSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.816 * _default_ * fctrSilverSize ' range=':= _default_ * fctrSilverSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -186,16 +186,16 @@
                             <IfCondition condition=':= ?blockExists("factorization:ResourceBlock")'> <OreBlock block='factorization:ResourceBlock' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.041 * _default_ * fctrSilverSize ' range=':=  _default_ * fctrSilverSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.041 * _default_ * fctrSilverSize ' range=':=  _default_ * fctrSilverSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.084  * _default_ * fctrSilverFreq ' range=':=  _default_ * fctrSilverFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 25 ' range=':=  10 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 1.041 * _default_ * fctrSilverSize ' range=':= _default_ * fctrSilverSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.041 * _default_ * fctrSilverSize ' range=':= _default_ * fctrSilverSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.084  * _default_ * fctrSilverFreq ' range=':= _default_ * fctrSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 25 ' range=':= 10 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='fctrSilverHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x608C9EBE' drawBoundBox='false' boundBoxColor='0x608C9EBE'>
                                 <Description>
                                     Single blocks, generously
@@ -238,10 +238,10 @@
                             <IfCondition condition=':= ?blockExists("factorization:ResourceBlock")'> <OreBlock block='factorization:ResourceBlock' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 7 * fctrSilverSize ' range=':=  _default_ * fctrSilverSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 3 * fctrSilverFreq ' range=':=  _default_ * fctrSilverFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 25 ' range=':=  10 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 7 * fctrSilverSize ' range=':= _default_ * fctrSilverSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 3 * fctrSilverFreq ' range=':= _default_ * fctrSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 25 ' range=':= 10 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -272,21 +272,21 @@
                             <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.350 * _default_ * fctrDarkIronFreq ' range=':=  _default_ * fctrDarkIronFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.705 * _default_ * fctrDarkIronSize ' range=':=  _default_ * fctrDarkIronSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 3 ' range=':=  2 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.705 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * fctrDarkIronSize ' range=':=  _default_ * fctrDarkIronSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.705 * _default_ * fctrDarkIronSize ' range=':=  _default_ * fctrDarkIronSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.350 * _default_ * fctrDarkIronFreq ' range=':= _default_ * fctrDarkIronFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.705 * _default_ * fctrDarkIronSize ' range=':= _default_ * fctrDarkIronSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 3 ' range=':= 2 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.705 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * fctrDarkIronSize ' range=':= _default_ * fctrDarkIronSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.705 * _default_ * fctrDarkIronSize ' range=':= _default_ * fctrDarkIronSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -316,16 +316,16 @@
                             <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.486 * _default_ * fctrDarkIronSize ' range=':=  _default_ * fctrDarkIronSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.486 * _default_ * fctrDarkIronSize ' range=':=  _default_ * fctrDarkIronSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.236  * _default_ * fctrDarkIronFreq ' range=':=  _default_ * fctrDarkIronFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 3 ' range=':=  2 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 0.486 * _default_ * fctrDarkIronSize ' range=':= _default_ * fctrDarkIronSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.486 * _default_ * fctrDarkIronSize ' range=':= _default_ * fctrDarkIronSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.236  * _default_ * fctrDarkIronFreq ' range=':= _default_ * fctrDarkIronFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 3 ' range=':= 2 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='fctrDarkIronHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60781CCB' drawBoundBox='false' boundBoxColor='0x60781CCB'>
                                 <Description>
                                     Single blocks, generously
@@ -370,10 +370,10 @@
                             <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 1 * fctrDarkIronSize ' range=':=  _default_ * fctrDarkIronSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1 * fctrDarkIronFreq ' range=':=  _default_ * fctrDarkIronFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 3 ' range=':=  2 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 1 * fctrDarkIronSize ' range=':= _default_ * fctrDarkIronSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1 * fctrDarkIronFreq ' range=':= _default_ * fctrDarkIronFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 3 ' range=':= 2 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>

--- a/src/main/resources/config/modules/Forestry.xml
+++ b/src/main/resources/config/modules/Forestry.xml
@@ -186,21 +186,21 @@
                             <IfCondition condition=':= ?blockExists("Forestry:resources")'> <OreBlock block='Forestry:resources' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 2.100 * _default_ * frstApatiteFreq ' range=':=  _default_ * frstApatiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.281 * _default_ * frstApatiteSize ' range=':=  _default_ * frstApatiteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 120 ' range=':=  64 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.281 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * frstApatiteSize ' range=':=  _default_ * frstApatiteSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.281 * _default_ * frstApatiteSize ' range=':=  _default_ * frstApatiteSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 2.100 * _default_ * frstApatiteFreq ' range=':= _default_ * frstApatiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.281 * _default_ * frstApatiteSize ' range=':= _default_ * frstApatiteSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 120 ' range=':= 64 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.281 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * frstApatiteSize ' range=':= _default_ * frstApatiteSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.281 * _default_ * frstApatiteSize ' range=':= _default_ * frstApatiteSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -228,16 +228,16 @@
                             <IfCondition condition=':= ?blockExists("Forestry:resources")'> <OreBlock block='Forestry:resources' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.191 * _default_ * frstApatiteSize ' range=':=  _default_ * frstApatiteSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.191 * _default_ * frstApatiteSize ' range=':=  _default_ * frstApatiteSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.419  * _default_ * frstApatiteFreq ' range=':=  _default_ * frstApatiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 120 ' range=':=  64 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 1.191 * _default_ * frstApatiteSize ' range=':= _default_ * frstApatiteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.191 * _default_ * frstApatiteSize ' range=':= _default_ * frstApatiteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.419  * _default_ * frstApatiteFreq ' range=':= _default_ * frstApatiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 120 ' range=':= 64 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='frstApatiteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60D1EDF1' drawBoundBox='false' boundBoxColor='0x6052BBEF'>
                                 <Description>
                                     Single blocks, generously
@@ -280,10 +280,10 @@
                             <IfCondition condition=':= ?blockExists("Forestry:resources")'> <OreBlock block='Forestry:resources' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 36 * frstApatiteSize ' range=':=  _default_ * frstApatiteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1 * frstApatiteFreq ' range=':=  _default_ * frstApatiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 120 ' range=':=  64 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 36 * frstApatiteSize ' range=':= _default_ * frstApatiteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1 * frstApatiteFreq ' range=':= _default_ * frstApatiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 120 ' range=':= 64 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -305,21 +305,21 @@
                             <IfCondition condition=':= ?blockExists("Forestry:resources:1")'> <OreBlock block='Forestry:resources:1' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.297 * _default_ * frstCopperFreq ' range=':=  _default_ * frstCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.091 * _default_ * frstCopperSize ' range=':=  _default_ * frstCopperSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 106 ' range=':=  74 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.091 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * frstCopperSize ' range=':=  _default_ * frstCopperSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.091 * _default_ * frstCopperSize ' range=':=  _default_ * frstCopperSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.297 * _default_ * frstCopperFreq ' range=':= _default_ * frstCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.091 * _default_ * frstCopperSize ' range=':= _default_ * frstCopperSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 106 ' range=':= 74 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.091 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * frstCopperSize ' range=':= _default_ * frstCopperSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.091 * _default_ * frstCopperSize ' range=':= _default_ * frstCopperSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -347,16 +347,16 @@
                             <IfCondition condition=':= ?blockExists("Forestry:resources:1")'> <OreBlock block='Forestry:resources:1' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.610 * _default_ * frstCopperSize ' range=':=  _default_ * frstCopperSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.610 * _default_ * frstCopperSize ' range=':=  _default_ * frstCopperSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 2.591  * _default_ * frstCopperFreq ' range=':=  _default_ * frstCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 106 ' range=':=  74 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 1.610 * _default_ * frstCopperSize ' range=':= _default_ * frstCopperSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.610 * _default_ * frstCopperSize ' range=':= _default_ * frstCopperSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 2.591  * _default_ * frstCopperFreq ' range=':= _default_ * frstCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 106 ' range=':= 74 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='frstCopperHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60D1EDF1' drawBoundBox='false' boundBoxColor='0x60E3B78E'>
                                 <Description>
                                     Single blocks, generously
@@ -399,10 +399,10 @@
                             <IfCondition condition=':= ?blockExists("Forestry:resources:1")'> <OreBlock block='Forestry:resources:1' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 6 * frstCopperSize ' range=':=  _default_ * frstCopperSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 20 * frstCopperFreq ' range=':=  _default_ * frstCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 106 ' range=':=  74 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 6 * frstCopperSize ' range=':= _default_ * frstCopperSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 20 * frstCopperFreq ' range=':= _default_ * frstCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 106 ' range=':= 74 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -424,21 +424,21 @@
                             <IfCondition condition=':= ?blockExists("Forestry:resources:2")'> <OreBlock block='Forestry:resources:2' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.231 * _default_ * frstTinFreq ' range=':=  _default_ * frstTinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.072 * _default_ * frstTinSize ' range=':=  _default_ * frstTinSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 98 ' range=':=  82 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.072 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * frstTinSize ' range=':=  _default_ * frstTinSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.072 * _default_ * frstTinSize ' range=':=  _default_ * frstTinSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.231 * _default_ * frstTinFreq ' range=':= _default_ * frstTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.072 * _default_ * frstTinSize ' range=':= _default_ * frstTinSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 98 ' range=':= 82 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.072 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * frstTinSize ' range=':= _default_ * frstTinSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.072 * _default_ * frstTinSize ' range=':= _default_ * frstTinSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -466,16 +466,16 @@
                             <IfCondition condition=':= ?blockExists("Forestry:resources:2")'> <OreBlock block='Forestry:resources:2' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.568 * _default_ * frstTinSize ' range=':=  _default_ * frstTinSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.568 * _default_ * frstTinSize ' range=':=  _default_ * frstTinSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 2.458  * _default_ * frstTinFreq ' range=':=  _default_ * frstTinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 98 ' range=':=  82 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 1.568 * _default_ * frstTinSize ' range=':= _default_ * frstTinSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.568 * _default_ * frstTinSize ' range=':= _default_ * frstTinSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 2.458  * _default_ * frstTinFreq ' range=':= _default_ * frstTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 98 ' range=':= 82 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='frstTinHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60D1EDF1' drawBoundBox='false' boundBoxColor='0x60D1EDF1'>
                                 <Description>
                                     Single blocks, generously
@@ -518,10 +518,10 @@
                             <IfCondition condition=':= ?blockExists("Forestry:resources:2")'> <OreBlock block='Forestry:resources:2' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 6 * frstTinSize ' range=':=  _default_ * frstTinSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 18 * frstTinFreq ' range=':=  _default_ * frstTinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 98 ' range=':=  82 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 6 * frstTinSize ' range=':= _default_ * frstTinSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 18 * frstTinFreq ' range=':= _default_ * frstTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 98 ' range=':= 82 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>

--- a/src/main/resources/config/modules/FossilsandArchaeology.xml
+++ b/src/main/resources/config/modules/FossilsandArchaeology.xml
@@ -152,21 +152,21 @@
                             <IfCondition condition=':= ?blockExists("fossil:fossil")'> <OreBlock block='fossil:fossil' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 6.104 * _default_ * fsarFossilsFreq ' range=':=  _default_ * fsarFossilsFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.828 * _default_ * fsarFossilsSize ' range=':=  _default_ * fsarFossilsSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 53 ' range=':=  47 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.828 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * fsarFossilsSize ' range=':=  _default_ * fsarFossilsSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.828 * _default_ * fsarFossilsSize ' range=':=  _default_ * fsarFossilsSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 6.104 * _default_ * fsarFossilsFreq ' range=':= _default_ * fsarFossilsFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.828 * _default_ * fsarFossilsSize ' range=':= _default_ * fsarFossilsSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 53 ' range=':= 47 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.828 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * fsarFossilsSize ' range=':= _default_ * fsarFossilsSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.828 * _default_ * fsarFossilsSize ' range=':= _default_ * fsarFossilsSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
 
                         <!-- Beginning "Preferred" configuration. -->
@@ -179,21 +179,21 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <BiomeType name='Swamp'  />
                             <BiomeType name='desert'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 6.104 * _default_ * fsarFossilsFreq ' range=':=  _default_ * fsarFossilsFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.828 * _default_ * fsarFossilsSize ' range=':=  _default_ * fsarFossilsSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 53 ' range=':=  47 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.828 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * fsarFossilsSize ' range=':=  _default_ * fsarFossilsSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.828 * _default_ * fsarFossilsSize ' range=':=  _default_ * fsarFossilsSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 6.104 * _default_ * fsarFossilsFreq ' range=':= _default_ * fsarFossilsFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.828 * _default_ * fsarFossilsSize ' range=':= _default_ * fsarFossilsSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 53 ' range=':= 47 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.828 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * fsarFossilsSize ' range=':= _default_ * fsarFossilsSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.828 * _default_ * fsarFossilsSize ' range=':= _default_ * fsarFossilsSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                         <!-- "Preferred" configuration complete. -->
 
@@ -223,16 +223,16 @@
                             <IfCondition condition=':= ?blockExists("fossil:fossil")'> <OreBlock block='fossil:fossil' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 2.031 * _default_ * fsarFossilsSize ' range=':=  _default_ * fsarFossilsSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 2.031 * _default_ * fsarFossilsSize ' range=':=  _default_ * fsarFossilsSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 4.123  * _default_ * fsarFossilsFreq ' range=':=  _default_ * fsarFossilsFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 53 ' range=':=  47 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 2.031 * _default_ * fsarFossilsSize ' range=':= _default_ * fsarFossilsSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 2.031 * _default_ * fsarFossilsSize ' range=':= _default_ * fsarFossilsSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 4.123  * _default_ * fsarFossilsFreq ' range=':= _default_ * fsarFossilsFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 53 ' range=':= 47 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='fsarFossilsHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FEFDDF' drawBoundBox='false' boundBoxColor='0x60FEFDDF'>
                                 <Description>
                                     Single blocks, generously
@@ -270,16 +270,16 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <BiomeType name='Swamp'  />
                             <BiomeType name='desert'  />
-                            <Setting name='CloudRadius' avg=':= 2.031 * _default_ * fsarFossilsSize ' range=':=  _default_ * fsarFossilsSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 2.031 * _default_ * fsarFossilsSize ' range=':=  _default_ * fsarFossilsSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 4.123  * _default_ * fsarFossilsFreq ' range=':=  _default_ * fsarFossilsFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 53 ' range=':=  47 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 2.031 * _default_ * fsarFossilsSize ' range=':= _default_ * fsarFossilsSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 2.031 * _default_ * fsarFossilsSize ' range=':= _default_ * fsarFossilsSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 4.123  * _default_ * fsarFossilsFreq ' range=':= _default_ * fsarFossilsFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 53 ' range=':= 47 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='fsarFossilsPreferredHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FEFDDF' drawBoundBox='false' boundBoxColor='0x60FEFDDF'>
                                 <Description>
                                     Ore generation is doubled in
@@ -308,10 +308,10 @@
                             <IfCondition condition=':= ?blockExists("fossil:fossil")'> <OreBlock block='fossil:fossil' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 8 * fsarFossilsSize ' range=':=  _default_ * fsarFossilsSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 38 * fsarFossilsFreq ' range=':=  _default_ * fsarFossilsFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 53 ' range=':=  47 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 8 * fsarFossilsSize ' range=':= _default_ * fsarFossilsSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 38 * fsarFossilsFreq ' range=':= _default_ * fsarFossilsFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 53 ' range=':= 47 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -341,21 +341,21 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <BiomeType name='Frozen'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.980 * _default_ * fsarPermafrostFreq ' range=':=  _default_ * fsarPermafrostFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.256 * _default_ * fsarPermafrostSize ' range=':=  _default_ * fsarPermafrostSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 18 ' range=':=  12.5 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.256 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * fsarPermafrostSize ' range=':=  _default_ * fsarPermafrostSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.256 * _default_ * fsarPermafrostSize ' range=':=  _default_ * fsarPermafrostSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.980 * _default_ * fsarPermafrostFreq ' range=':= _default_ * fsarPermafrostFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.256 * _default_ * fsarPermafrostSize ' range=':= _default_ * fsarPermafrostSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 18 ' range=':= 12.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.256 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * fsarPermafrostSize ' range=':= _default_ * fsarPermafrostSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.256 * _default_ * fsarPermafrostSize ' range=':= _default_ * fsarPermafrostSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -384,16 +384,16 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <BiomeType name='Frozen'  />
-                            <Setting name='CloudRadius' avg=':= 1.157 * _default_ * fsarPermafrostSize ' range=':=  _default_ * fsarPermafrostSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.157 * _default_ * fsarPermafrostSize ' range=':=  _default_ * fsarPermafrostSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.338  * _default_ * fsarPermafrostFreq ' range=':=  _default_ * fsarPermafrostFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 18 ' range=':=  12.5 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 1.157 * _default_ * fsarPermafrostSize ' range=':= _default_ * fsarPermafrostSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.157 * _default_ * fsarPermafrostSize ' range=':= _default_ * fsarPermafrostSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.338  * _default_ * fsarPermafrostFreq ' range=':= _default_ * fsarPermafrostFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 18 ' range=':= 12.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='fsarPermafrostHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FEFDDF' drawBoundBox='false' boundBoxColor='0x60A5C3F5'>
                                 <Description>
                                     Single blocks, generously
@@ -437,10 +437,10 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <BiomeType name='Frozen'  />
-                            <Setting name='Size' avg=':= 4 * fsarPermafrostSize ' range=':=  _default_ * fsarPermafrostSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 8 * fsarPermafrostFreq ' range=':=  _default_ * fsarPermafrostFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 18 ' range=':=  12.5 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 4 * fsarPermafrostSize ' range=':= _default_ * fsarPermafrostSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 8 * fsarPermafrostFreq ' range=':= _default_ * fsarPermafrostFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 18 ' range=':= 12.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>

--- a/src/main/resources/config/modules/GeoStrata.xml
+++ b/src/main/resources/config/modules/GeoStrata.xml
@@ -671,21 +671,21 @@
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_shale_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_shale_smooth' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 3.282 * _default_ * gstaShaleFreq ' range=':=  _default_ * gstaShaleFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.486 * _default_ * gstaShaleSize ' range=':=  _default_ * gstaShaleSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 56 ' range=':=  8 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.486 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * gstaShaleSize ' range=':=  _default_ * gstaShaleSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.486 * _default_ * gstaShaleSize ' range=':=  _default_ * gstaShaleSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 3.282 * _default_ * gstaShaleFreq ' range=':= _default_ * gstaShaleFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.486 * _default_ * gstaShaleSize ' range=':= _default_ * gstaShaleSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 56 ' range=':= 8 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.486 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * gstaShaleSize ' range=':= _default_ * gstaShaleSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.486 * _default_ * gstaShaleSize ' range=':= _default_ * gstaShaleSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -713,16 +713,16 @@
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_shale_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_shale_smooth' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 2.560 * _default_ * gstaShaleSize ' range=':=  _default_ * gstaShaleSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 2.560 * _default_ * gstaShaleSize ' range=':=  _default_ * gstaShaleSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 6.554  * _default_ * gstaShaleFreq ' range=':=  _default_ * gstaShaleFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 56 ' range=':=  8 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 2.560 * _default_ * gstaShaleSize ' range=':= _default_ * gstaShaleSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 2.560 * _default_ * gstaShaleSize ' range=':= _default_ * gstaShaleSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 6.554  * _default_ * gstaShaleFreq ' range=':= _default_ * gstaShaleFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 56 ' range=':= 8 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='gstaShaleHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60676970' drawBoundBox='false' boundBoxColor='0x60676970'>
                                 <Description>
                                     Single blocks, generously
@@ -765,10 +765,10 @@
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_shale_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_shale_smooth' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 32 * gstaShaleSize ' range=':=  _default_ * gstaShaleSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 24 * gstaShaleFreq ' range=':=  _default_ * gstaShaleFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 56 ' range=':=  8 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 32 * gstaShaleSize ' range=':= _default_ * gstaShaleSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 24 * gstaShaleFreq ' range=':= _default_ * gstaShaleFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 56 ' range=':= 8 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -790,21 +790,21 @@
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_sandstone_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_sandstone_smooth' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 3.282 * _default_ * gstaSandstoneFreq ' range=':=  _default_ * gstaSandstoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.486 * _default_ * gstaSandstoneSize ' range=':=  _default_ * gstaSandstoneSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 88 ' range=':=  40 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.486 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * gstaSandstoneSize ' range=':=  _default_ * gstaSandstoneSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.486 * _default_ * gstaSandstoneSize ' range=':=  _default_ * gstaSandstoneSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 3.282 * _default_ * gstaSandstoneFreq ' range=':= _default_ * gstaSandstoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.486 * _default_ * gstaSandstoneSize ' range=':= _default_ * gstaSandstoneSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 88 ' range=':= 40 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.486 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * gstaSandstoneSize ' range=':= _default_ * gstaSandstoneSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.486 * _default_ * gstaSandstoneSize ' range=':= _default_ * gstaSandstoneSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -832,16 +832,16 @@
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_sandstone_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_sandstone_smooth' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 2.560 * _default_ * gstaSandstoneSize ' range=':=  _default_ * gstaSandstoneSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 2.560 * _default_ * gstaSandstoneSize ' range=':=  _default_ * gstaSandstoneSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 6.554  * _default_ * gstaSandstoneFreq ' range=':=  _default_ * gstaSandstoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 88 ' range=':=  40 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 2.560 * _default_ * gstaSandstoneSize ' range=':= _default_ * gstaSandstoneSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 2.560 * _default_ * gstaSandstoneSize ' range=':= _default_ * gstaSandstoneSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 6.554  * _default_ * gstaSandstoneFreq ' range=':= _default_ * gstaSandstoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 88 ' range=':= 40 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='gstaSandstoneHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60BA9D80' drawBoundBox='false' boundBoxColor='0x60BA9D80'>
                                 <Description>
                                     Single blocks, generously
@@ -884,10 +884,10 @@
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_sandstone_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_sandstone_smooth' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 32 * gstaSandstoneSize ' range=':=  _default_ * gstaSandstoneSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= _default_ * gstaSandstoneFreq ' range=':=  _default_ * gstaSandstoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 88 ' range=':=  40 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 32 * gstaSandstoneSize ' range=':= _default_ * gstaSandstoneSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= _default_ * gstaSandstoneFreq ' range=':= _default_ * gstaSandstoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 88 ' range=':= 40 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -909,21 +909,21 @@
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_limestone_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_limestone_smooth' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 3.282 * _default_ * gstaLimestoneFreq ' range=':=  _default_ * gstaLimestoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.486 * _default_ * gstaLimestoneSize ' range=':=  _default_ * gstaLimestoneSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 88 ' range=':=  40 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.486 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * gstaLimestoneSize ' range=':=  _default_ * gstaLimestoneSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.486 * _default_ * gstaLimestoneSize ' range=':=  _default_ * gstaLimestoneSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 3.282 * _default_ * gstaLimestoneFreq ' range=':= _default_ * gstaLimestoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.486 * _default_ * gstaLimestoneSize ' range=':= _default_ * gstaLimestoneSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 88 ' range=':= 40 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.486 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * gstaLimestoneSize ' range=':= _default_ * gstaLimestoneSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.486 * _default_ * gstaLimestoneSize ' range=':= _default_ * gstaLimestoneSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -951,16 +951,16 @@
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_limestone_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_limestone_smooth' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 2.560 * _default_ * gstaLimestoneSize ' range=':=  _default_ * gstaLimestoneSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 2.560 * _default_ * gstaLimestoneSize ' range=':=  _default_ * gstaLimestoneSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 6.554  * _default_ * gstaLimestoneFreq ' range=':=  _default_ * gstaLimestoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 88 ' range=':=  40 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 2.560 * _default_ * gstaLimestoneSize ' range=':= _default_ * gstaLimestoneSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 2.560 * _default_ * gstaLimestoneSize ' range=':= _default_ * gstaLimestoneSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 6.554  * _default_ * gstaLimestoneFreq ' range=':= _default_ * gstaLimestoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 88 ' range=':= 40 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='gstaLimestoneHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60CBBFAD' drawBoundBox='false' boundBoxColor='0x60CBBFAD'>
                                 <Description>
                                     Single blocks, generously
@@ -1003,10 +1003,10 @@
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_limestone_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_limestone_smooth' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 32 * gstaLimestoneSize ' range=':=  _default_ * gstaLimestoneSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= _default_ * gstaLimestoneFreq ' range=':=  _default_ * gstaLimestoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 88 ' range=':=  40 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 32 * gstaLimestoneSize ' range=':= _default_ * gstaLimestoneSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= _default_ * gstaLimestoneFreq ' range=':= _default_ * gstaLimestoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 88 ' range=':= 40 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -1028,21 +1028,21 @@
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_pumice_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_pumice_smooth' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 2.543 * _default_ * gstaPumiceFreq ' range=':=  _default_ * gstaPumiceFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.365 * _default_ * gstaPumiceSize ' range=':=  _default_ * gstaPumiceSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 11 ' range=':=  5 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.365 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * gstaPumiceSize ' range=':=  _default_ * gstaPumiceSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.365 * _default_ * gstaPumiceSize ' range=':=  _default_ * gstaPumiceSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 2.543 * _default_ * gstaPumiceFreq ' range=':= _default_ * gstaPumiceFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.365 * _default_ * gstaPumiceSize ' range=':= _default_ * gstaPumiceSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 11 ' range=':= 5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.365 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * gstaPumiceSize ' range=':= _default_ * gstaPumiceSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.365 * _default_ * gstaPumiceSize ' range=':= _default_ * gstaPumiceSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -1070,16 +1070,16 @@
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_pumice_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_pumice_smooth' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 2.253 * _default_ * gstaPumiceSize ' range=':=  _default_ * gstaPumiceSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 2.253 * _default_ * gstaPumiceSize ' range=':=  _default_ * gstaPumiceSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 5.077  * _default_ * gstaPumiceFreq ' range=':=  _default_ * gstaPumiceFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 11 ' range=':=  5 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 2.253 * _default_ * gstaPumiceSize ' range=':= _default_ * gstaPumiceSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 2.253 * _default_ * gstaPumiceSize ' range=':= _default_ * gstaPumiceSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 5.077  * _default_ * gstaPumiceFreq ' range=':= _default_ * gstaPumiceFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 11 ' range=':= 5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='gstaPumiceHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60C4C1BA' drawBoundBox='false' boundBoxColor='0x60C4C1BA'>
                                 <Description>
                                     Single blocks, generously
@@ -1122,10 +1122,10 @@
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_pumice_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_pumice_smooth' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 32 * gstaPumiceSize ' range=':=  _default_ * gstaPumiceSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 14.4 * gstaPumiceFreq ' range=':=  _default_ * gstaPumiceFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 11 ' range=':=  5 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 32 * gstaPumiceSize ' range=':= _default_ * gstaPumiceSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 14.4 * gstaPumiceFreq ' range=':= _default_ * gstaPumiceFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 11 ' range=':= 5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -1147,21 +1147,21 @@
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_opal_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_opal_smooth' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.161 * _default_ * gstaOpalFreq ' range=':=  _default_ * gstaOpalFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.051 * _default_ * gstaOpalSize ' range=':=  _default_ * gstaOpalSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.051 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * gstaOpalSize ' range=':=  _default_ * gstaOpalSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.051 * _default_ * gstaOpalSize ' range=':=  _default_ * gstaOpalSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.161 * _default_ * gstaOpalFreq ' range=':= _default_ * gstaOpalFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.051 * _default_ * gstaOpalSize ' range=':= _default_ * gstaOpalSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.051 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * gstaOpalSize ' range=':= _default_ * gstaOpalSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.051 * _default_ * gstaOpalSize ' range=':= _default_ * gstaOpalSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -1189,16 +1189,16 @@
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_opal_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_opal_smooth' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.522 * _default_ * gstaOpalSize ' range=':=  _default_ * gstaOpalSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.522 * _default_ * gstaOpalSize ' range=':=  _default_ * gstaOpalSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 2.317  * _default_ * gstaOpalFreq ' range=':=  _default_ * gstaOpalFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 1.522 * _default_ * gstaOpalSize ' range=':= _default_ * gstaOpalSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.522 * _default_ * gstaOpalSize ' range=':= _default_ * gstaOpalSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 2.317  * _default_ * gstaOpalFreq ' range=':= _default_ * gstaOpalFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='gstaOpalHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60CAFFFF' drawBoundBox='false' boundBoxColor='0x60CAFFFF'>
                                 <Description>
                                     Single blocks, generously
@@ -1241,10 +1241,10 @@
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_opal_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_opal_smooth' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 32 * gstaOpalSize ' range=':=  _default_ * gstaOpalSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 3 * gstaOpalFreq ' range=':=  _default_ * gstaOpalFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 32 * gstaOpalSize ' range=':= _default_ * gstaOpalSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 3 * gstaOpalFreq ' range=':= _default_ * gstaOpalFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -1266,21 +1266,21 @@
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_slate_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_slate_smooth' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 3.282 * _default_ * gstaSlateFreq ' range=':=  _default_ * gstaSlateFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.486 * _default_ * gstaSlateSize ' range=':=  _default_ * gstaSlateSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 40 ' range=':=  8 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.486 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * gstaSlateSize ' range=':=  _default_ * gstaSlateSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.486 * _default_ * gstaSlateSize ' range=':=  _default_ * gstaSlateSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 3.282 * _default_ * gstaSlateFreq ' range=':= _default_ * gstaSlateFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.486 * _default_ * gstaSlateSize ' range=':= _default_ * gstaSlateSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 40 ' range=':= 8 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.486 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * gstaSlateSize ' range=':= _default_ * gstaSlateSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.486 * _default_ * gstaSlateSize ' range=':= _default_ * gstaSlateSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -1308,16 +1308,16 @@
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_slate_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_slate_smooth' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 2.560 * _default_ * gstaSlateSize ' range=':=  _default_ * gstaSlateSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 2.560 * _default_ * gstaSlateSize ' range=':=  _default_ * gstaSlateSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 6.554  * _default_ * gstaSlateFreq ' range=':=  _default_ * gstaSlateFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 40 ' range=':=  8 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 2.560 * _default_ * gstaSlateSize ' range=':= _default_ * gstaSlateSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 2.560 * _default_ * gstaSlateSize ' range=':= _default_ * gstaSlateSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 6.554  * _default_ * gstaSlateFreq ' range=':= _default_ * gstaSlateFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 40 ' range=':= 8 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='gstaSlateHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60494B53' drawBoundBox='false' boundBoxColor='0x60494B53'>
                                 <Description>
                                     Single blocks, generously
@@ -1360,10 +1360,10 @@
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_slate_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_slate_smooth' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 32 * gstaSlateSize ' range=':=  _default_ * gstaSlateSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 24 * gstaSlateFreq ' range=':=  _default_ * gstaSlateFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 40 ' range=':=  8 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 32 * gstaSlateSize ' range=':= _default_ * gstaSlateSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 24 * gstaSlateFreq ' range=':= _default_ * gstaSlateFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 40 ' range=':= 8 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -1385,21 +1385,21 @@
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_gneiss_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_gneiss_smooth' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 2.936 * _default_ * gstaGneissFreq ' range=':=  _default_ * gstaGneissFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.432 * _default_ * gstaGneissSize ' range=':=  _default_ * gstaGneissSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 24 ' range=':=  8 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.432 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * gstaGneissSize ' range=':=  _default_ * gstaGneissSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.432 * _default_ * gstaGneissSize ' range=':=  _default_ * gstaGneissSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 2.936 * _default_ * gstaGneissFreq ' range=':= _default_ * gstaGneissFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.432 * _default_ * gstaGneissSize ' range=':= _default_ * gstaGneissSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 24 ' range=':= 8 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.432 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * gstaGneissSize ' range=':= _default_ * gstaGneissSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.432 * _default_ * gstaGneissSize ' range=':= _default_ * gstaGneissSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -1427,16 +1427,16 @@
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_gneiss_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_gneiss_smooth' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 2.421 * _default_ * gstaGneissSize ' range=':=  _default_ * gstaGneissSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 2.421 * _default_ * gstaGneissSize ' range=':=  _default_ * gstaGneissSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 5.862  * _default_ * gstaGneissFreq ' range=':=  _default_ * gstaGneissFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 24 ' range=':=  8 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 2.421 * _default_ * gstaGneissSize ' range=':= _default_ * gstaGneissSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 2.421 * _default_ * gstaGneissSize ' range=':= _default_ * gstaGneissSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 5.862  * _default_ * gstaGneissFreq ' range=':= _default_ * gstaGneissFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 24 ' range=':= 8 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='gstaGneissHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60BFBDBC' drawBoundBox='false' boundBoxColor='0x60BFBDBC'>
                                 <Description>
                                     Single blocks, generously
@@ -1479,10 +1479,10 @@
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_gneiss_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_gneiss_smooth' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 32 * gstaGneissSize ' range=':=  _default_ * gstaGneissSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 19.2 * gstaGneissFreq ' range=':=  _default_ * gstaGneissFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 24 ' range=':=  8 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 32 * gstaGneissSize ' range=':= _default_ * gstaGneissSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 19.2 * gstaGneissFreq ' range=':= _default_ * gstaGneissFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 24 ' range=':= 8 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -1504,21 +1504,21 @@
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_peridotite_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_peridotite_smooth' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 2.543 * _default_ * gstaPeridotiteFreq ' range=':=  _default_ * gstaPeridotiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.365 * _default_ * gstaPeridotiteSize ' range=':=  _default_ * gstaPeridotiteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 15 ' range=':=  9 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.365 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * gstaPeridotiteSize ' range=':=  _default_ * gstaPeridotiteSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.365 * _default_ * gstaPeridotiteSize ' range=':=  _default_ * gstaPeridotiteSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 2.543 * _default_ * gstaPeridotiteFreq ' range=':= _default_ * gstaPeridotiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.365 * _default_ * gstaPeridotiteSize ' range=':= _default_ * gstaPeridotiteSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 15 ' range=':= 9 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.365 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * gstaPeridotiteSize ' range=':= _default_ * gstaPeridotiteSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.365 * _default_ * gstaPeridotiteSize ' range=':= _default_ * gstaPeridotiteSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -1546,16 +1546,16 @@
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_peridotite_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_peridotite_smooth' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 2.253 * _default_ * gstaPeridotiteSize ' range=':=  _default_ * gstaPeridotiteSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 2.253 * _default_ * gstaPeridotiteSize ' range=':=  _default_ * gstaPeridotiteSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 5.077  * _default_ * gstaPeridotiteFreq ' range=':=  _default_ * gstaPeridotiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 15 ' range=':=  9 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 2.253 * _default_ * gstaPeridotiteSize ' range=':= _default_ * gstaPeridotiteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 2.253 * _default_ * gstaPeridotiteSize ' range=':= _default_ * gstaPeridotiteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 5.077  * _default_ * gstaPeridotiteFreq ' range=':= _default_ * gstaPeridotiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 15 ' range=':= 9 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='gstaPeridotiteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60617361' drawBoundBox='false' boundBoxColor='0x60617361'>
                                 <Description>
                                     Single blocks, generously
@@ -1598,10 +1598,10 @@
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_peridotite_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_peridotite_smooth' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 32 * gstaPeridotiteSize ' range=':=  _default_ * gstaPeridotiteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 14.4 * gstaPeridotiteFreq ' range=':=  _default_ * gstaPeridotiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 15 ' range=':=  9 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 32 * gstaPeridotiteSize ' range=':= _default_ * gstaPeridotiteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 14.4 * gstaPeridotiteFreq ' range=':= _default_ * gstaPeridotiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 15 ' range=':= 9 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -1623,21 +1623,21 @@
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_granulite_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_granulite_smooth' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 2.746 * _default_ * gstaGranuliteFreq ' range=':=  _default_ * gstaGranuliteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.4 * _default_ * gstaGranuliteSize ' range=':=  _default_ * gstaGranuliteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 24 ' range=':=  8 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.4 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * gstaGranuliteSize ' range=':=  _default_ * gstaGranuliteSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.4 * _default_ * gstaGranuliteSize ' range=':=  _default_ * gstaGranuliteSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 2.746 * _default_ * gstaGranuliteFreq ' range=':= _default_ * gstaGranuliteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.4 * _default_ * gstaGranuliteSize ' range=':= _default_ * gstaGranuliteSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 24 ' range=':= 8 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.4 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * gstaGranuliteSize ' range=':= _default_ * gstaGranuliteSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.4 * _default_ * gstaGranuliteSize ' range=':= _default_ * gstaGranuliteSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -1665,16 +1665,16 @@
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_granulite_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_granulite_smooth' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 2.342 * _default_ * gstaGranuliteSize ' range=':=  _default_ * gstaGranuliteSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 2.342 * _default_ * gstaGranuliteSize ' range=':=  _default_ * gstaGranuliteSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 5.483  * _default_ * gstaGranuliteFreq ' range=':=  _default_ * gstaGranuliteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 24 ' range=':=  8 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 2.342 * _default_ * gstaGranuliteSize ' range=':= _default_ * gstaGranuliteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 2.342 * _default_ * gstaGranuliteSize ' range=':= _default_ * gstaGranuliteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 5.483  * _default_ * gstaGranuliteFreq ' range=':= _default_ * gstaGranuliteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 24 ' range=':= 8 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='gstaGranuliteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60AEB3AB' drawBoundBox='false' boundBoxColor='0x60AEB3AB'>
                                 <Description>
                                     Single blocks, generously
@@ -1717,10 +1717,10 @@
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_granulite_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_granulite_smooth' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 32 * gstaGranuliteSize ' range=':=  _default_ * gstaGranuliteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 16.8 * gstaGranuliteFreq ' range=':=  _default_ * gstaGranuliteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 24 ' range=':=  8 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 32 * gstaGranuliteSize ' range=':= _default_ * gstaGranuliteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 16.8 * gstaGranuliteFreq ' range=':= _default_ * gstaGranuliteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 24 ' range=':= 8 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -1742,21 +1742,21 @@
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_migmatite_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_migmatite_smooth' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 2.543 * _default_ * gstaMigmatiteFreq ' range=':=  _default_ * gstaMigmatiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.365 * _default_ * gstaMigmatiteSize ' range=':=  _default_ * gstaMigmatiteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 11 ' range=':=  5 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.365 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * gstaMigmatiteSize ' range=':=  _default_ * gstaMigmatiteSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.365 * _default_ * gstaMigmatiteSize ' range=':=  _default_ * gstaMigmatiteSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 2.543 * _default_ * gstaMigmatiteFreq ' range=':= _default_ * gstaMigmatiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.365 * _default_ * gstaMigmatiteSize ' range=':= _default_ * gstaMigmatiteSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 11 ' range=':= 5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.365 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * gstaMigmatiteSize ' range=':= _default_ * gstaMigmatiteSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.365 * _default_ * gstaMigmatiteSize ' range=':= _default_ * gstaMigmatiteSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -1784,16 +1784,16 @@
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_migmatite_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_migmatite_smooth' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 2.253 * _default_ * gstaMigmatiteSize ' range=':=  _default_ * gstaMigmatiteSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 2.253 * _default_ * gstaMigmatiteSize ' range=':=  _default_ * gstaMigmatiteSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 5.077  * _default_ * gstaMigmatiteFreq ' range=':=  _default_ * gstaMigmatiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 11 ' range=':=  5 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 2.253 * _default_ * gstaMigmatiteSize ' range=':= _default_ * gstaMigmatiteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 2.253 * _default_ * gstaMigmatiteSize ' range=':= _default_ * gstaMigmatiteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 5.077  * _default_ * gstaMigmatiteFreq ' range=':= _default_ * gstaMigmatiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 11 ' range=':= 5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='gstaMigmatiteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x6092958C' drawBoundBox='false' boundBoxColor='0x6092958C'>
                                 <Description>
                                     Single blocks, generously
@@ -1836,10 +1836,10 @@
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_migmatite_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_migmatite_smooth' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 32 * gstaMigmatiteSize ' range=':=  _default_ * gstaMigmatiteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 14.4 * gstaMigmatiteFreq ' range=':=  _default_ * gstaMigmatiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 11 ' range=':=  5 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 32 * gstaMigmatiteSize ' range=':= _default_ * gstaMigmatiteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 14.4 * gstaMigmatiteFreq ' range=':= _default_ * gstaMigmatiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 11 ' range=':= 5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -1861,21 +1861,21 @@
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_schist_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_schist_smooth' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 2.936 * _default_ * gstaSchistFreq ' range=':=  _default_ * gstaSchistFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.432 * _default_ * gstaSchistSize ' range=':=  _default_ * gstaSchistSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 32 ' range=':=  16 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.432 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * gstaSchistSize ' range=':=  _default_ * gstaSchistSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.432 * _default_ * gstaSchistSize ' range=':=  _default_ * gstaSchistSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 2.936 * _default_ * gstaSchistFreq ' range=':= _default_ * gstaSchistFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.432 * _default_ * gstaSchistSize ' range=':= _default_ * gstaSchistSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 32 ' range=':= 16 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.432 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * gstaSchistSize ' range=':= _default_ * gstaSchistSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.432 * _default_ * gstaSchistSize ' range=':= _default_ * gstaSchistSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -1903,16 +1903,16 @@
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_schist_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_schist_smooth' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 2.421 * _default_ * gstaSchistSize ' range=':=  _default_ * gstaSchistSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 2.421 * _default_ * gstaSchistSize ' range=':=  _default_ * gstaSchistSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 5.862  * _default_ * gstaSchistFreq ' range=':=  _default_ * gstaSchistFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 32 ' range=':=  16 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 2.421 * _default_ * gstaSchistSize ' range=':= _default_ * gstaSchistSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 2.421 * _default_ * gstaSchistSize ' range=':= _default_ * gstaSchistSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 5.862  * _default_ * gstaSchistFreq ' range=':= _default_ * gstaSchistFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 32 ' range=':= 16 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='gstaSchistHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x604B4C52' drawBoundBox='false' boundBoxColor='0x604B4C52'>
                                 <Description>
                                     Single blocks, generously
@@ -1955,10 +1955,10 @@
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_schist_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_schist_smooth' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 32 * gstaSchistSize ' range=':=  _default_ * gstaSchistSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 19.2 * gstaSchistFreq ' range=':=  _default_ * gstaSchistFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 32 ' range=':=  16 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 32 * gstaSchistSize ' range=':= _default_ * gstaSchistSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 19.2 * gstaSchistFreq ' range=':= _default_ * gstaSchistFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 32 ' range=':= 16 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -1980,21 +1980,21 @@
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_basalt_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_basalt_smooth' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 3.282 * _default_ * gstaBasaltFreq ' range=':=  _default_ * gstaBasaltFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.486 * _default_ * gstaBasaltSize ' range=':=  _default_ * gstaBasaltSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 88 ' range=':=  40 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.486 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * gstaBasaltSize ' range=':=  _default_ * gstaBasaltSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.486 * _default_ * gstaBasaltSize ' range=':=  _default_ * gstaBasaltSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 3.282 * _default_ * gstaBasaltFreq ' range=':= _default_ * gstaBasaltFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.486 * _default_ * gstaBasaltSize ' range=':= _default_ * gstaBasaltSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 88 ' range=':= 40 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.486 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * gstaBasaltSize ' range=':= _default_ * gstaBasaltSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.486 * _default_ * gstaBasaltSize ' range=':= _default_ * gstaBasaltSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -2022,16 +2022,16 @@
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_basalt_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_basalt_smooth' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 2.560 * _default_ * gstaBasaltSize ' range=':=  _default_ * gstaBasaltSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 2.560 * _default_ * gstaBasaltSize ' range=':=  _default_ * gstaBasaltSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 6.554  * _default_ * gstaBasaltFreq ' range=':=  _default_ * gstaBasaltFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 88 ' range=':=  40 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 2.560 * _default_ * gstaBasaltSize ' range=':= _default_ * gstaBasaltSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 2.560 * _default_ * gstaBasaltSize ' range=':= _default_ * gstaBasaltSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 6.554  * _default_ * gstaBasaltFreq ' range=':= _default_ * gstaBasaltFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 88 ' range=':= 40 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='gstaBasaltHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60383844' drawBoundBox='false' boundBoxColor='0x60383844'>
                                 <Description>
                                     Single blocks, generously
@@ -2074,10 +2074,10 @@
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_basalt_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_basalt_smooth' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 32 * gstaBasaltSize ' range=':=  _default_ * gstaBasaltSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 24 * gstaBasaltFreq ' range=':=  _default_ * gstaBasaltFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 88 ' range=':=  40 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 32 * gstaBasaltSize ' range=':= _default_ * gstaBasaltSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 24 * gstaBasaltFreq ' range=':= _default_ * gstaBasaltFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 88 ' range=':= 40 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -2099,21 +2099,21 @@
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_onyx_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_onyx_smooth' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 3.282 * _default_ * gstaOnyxFreq ' range=':=  _default_ * gstaOnyxFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.486 * _default_ * gstaOnyxSize ' range=':=  _default_ * gstaOnyxSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 15 ' range=':=  9 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.486 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * gstaOnyxSize ' range=':=  _default_ * gstaOnyxSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.486 * _default_ * gstaOnyxSize ' range=':=  _default_ * gstaOnyxSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 3.282 * _default_ * gstaOnyxFreq ' range=':= _default_ * gstaOnyxFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.486 * _default_ * gstaOnyxSize ' range=':= _default_ * gstaOnyxSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 15 ' range=':= 9 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.486 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * gstaOnyxSize ' range=':= _default_ * gstaOnyxSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.486 * _default_ * gstaOnyxSize ' range=':= _default_ * gstaOnyxSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -2141,16 +2141,16 @@
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_onyx_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_onyx_smooth' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 2.560 * _default_ * gstaOnyxSize ' range=':=  _default_ * gstaOnyxSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 2.560 * _default_ * gstaOnyxSize ' range=':=  _default_ * gstaOnyxSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 6.554  * _default_ * gstaOnyxFreq ' range=':=  _default_ * gstaOnyxFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 15 ' range=':=  9 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 2.560 * _default_ * gstaOnyxSize ' range=':= _default_ * gstaOnyxSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 2.560 * _default_ * gstaOnyxSize ' range=':= _default_ * gstaOnyxSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 6.554  * _default_ * gstaOnyxFreq ' range=':= _default_ * gstaOnyxFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 15 ' range=':= 9 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='gstaOnyxHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60303030' drawBoundBox='false' boundBoxColor='0x60303030'>
                                 <Description>
                                     Single blocks, generously
@@ -2193,10 +2193,10 @@
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_onyx_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_onyx_smooth' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 32 * gstaOnyxSize ' range=':=  _default_ * gstaOnyxSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 24 * gstaOnyxFreq ' range=':=  _default_ * gstaOnyxFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 15 ' range=':=  9 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 32 * gstaOnyxSize ' range=':= _default_ * gstaOnyxSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 24 * gstaOnyxFreq ' range=':= _default_ * gstaOnyxFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 15 ' range=':= 9 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -2218,21 +2218,21 @@
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_quartz_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_quartz_smooth' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 2.321 * _default_ * gstaQuartzFreq ' range=':=  _default_ * gstaQuartzFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.324 * _default_ * gstaQuartzSize ' range=':=  _default_ * gstaQuartzSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 35 ' range=':=  29 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.324 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * gstaQuartzSize ' range=':=  _default_ * gstaQuartzSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.324 * _default_ * gstaQuartzSize ' range=':=  _default_ * gstaQuartzSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 2.321 * _default_ * gstaQuartzFreq ' range=':= _default_ * gstaQuartzFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.324 * _default_ * gstaQuartzSize ' range=':= _default_ * gstaQuartzSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 35 ' range=':= 29 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.324 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * gstaQuartzSize ' range=':= _default_ * gstaQuartzSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.324 * _default_ * gstaQuartzSize ' range=':= _default_ * gstaQuartzSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -2260,16 +2260,16 @@
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_quartz_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_quartz_smooth' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 2.153 * _default_ * gstaQuartzSize ' range=':=  _default_ * gstaQuartzSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 2.153 * _default_ * gstaQuartzSize ' range=':=  _default_ * gstaQuartzSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 4.634  * _default_ * gstaQuartzFreq ' range=':=  _default_ * gstaQuartzFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 35 ' range=':=  29 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 2.153 * _default_ * gstaQuartzSize ' range=':= _default_ * gstaQuartzSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 2.153 * _default_ * gstaQuartzSize ' range=':= _default_ * gstaQuartzSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 4.634  * _default_ * gstaQuartzFreq ' range=':= _default_ * gstaQuartzFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 35 ' range=':= 29 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='gstaQuartzHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60C9D2D9' drawBoundBox='false' boundBoxColor='0x60C9D2D9'>
                                 <Description>
                                     Single blocks, generously
@@ -2312,10 +2312,10 @@
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_quartz_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_quartz_smooth' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 32 * gstaQuartzSize ' range=':=  _default_ * gstaQuartzSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 12 * gstaQuartzFreq ' range=':=  _default_ * gstaQuartzFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 35 ' range=':=  29 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 32 * gstaQuartzSize ' range=':= _default_ * gstaQuartzSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 12 * gstaQuartzFreq ' range=':= _default_ * gstaQuartzFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 35 ' range=':= 29 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -2337,21 +2337,21 @@
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_marble_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_marble_smooth' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 3.282 * _default_ * gstaMarbleFreq ' range=':=  _default_ * gstaMarbleFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.486 * _default_ * gstaMarbleSize ' range=':=  _default_ * gstaMarbleSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 40 ' range=':=  24 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.486 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * gstaMarbleSize ' range=':=  _default_ * gstaMarbleSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.486 * _default_ * gstaMarbleSize ' range=':=  _default_ * gstaMarbleSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 3.282 * _default_ * gstaMarbleFreq ' range=':= _default_ * gstaMarbleFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.486 * _default_ * gstaMarbleSize ' range=':= _default_ * gstaMarbleSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 40 ' range=':= 24 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.486 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * gstaMarbleSize ' range=':= _default_ * gstaMarbleSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.486 * _default_ * gstaMarbleSize ' range=':= _default_ * gstaMarbleSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -2379,16 +2379,16 @@
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_marble_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_marble_smooth' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 2.560 * _default_ * gstaMarbleSize ' range=':=  _default_ * gstaMarbleSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 2.560 * _default_ * gstaMarbleSize ' range=':=  _default_ * gstaMarbleSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 6.554  * _default_ * gstaMarbleFreq ' range=':=  _default_ * gstaMarbleFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 40 ' range=':=  24 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 2.560 * _default_ * gstaMarbleSize ' range=':= _default_ * gstaMarbleSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 2.560 * _default_ * gstaMarbleSize ' range=':= _default_ * gstaMarbleSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 6.554  * _default_ * gstaMarbleFreq ' range=':= _default_ * gstaMarbleFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 40 ' range=':= 24 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='gstaMarbleHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60B4B4BC' drawBoundBox='false' boundBoxColor='0x60B4B4BC'>
                                 <Description>
                                     Single blocks, generously
@@ -2431,10 +2431,10 @@
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_marble_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_marble_smooth' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 32 * gstaMarbleSize ' range=':=  _default_ * gstaMarbleSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 24 * gstaMarbleFreq ' range=':=  _default_ * gstaMarbleFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 40 ' range=':=  24 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 32 * gstaMarbleSize ' range=':= _default_ * gstaMarbleSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 24 * gstaMarbleFreq ' range=':= _default_ * gstaMarbleFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 40 ' range=':= 24 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -2456,21 +2456,21 @@
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_granite_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_granite_smooth' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 3.282 * _default_ * gstaGraniteFreq ' range=':=  _default_ * gstaGraniteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.486 * _default_ * gstaGraniteSize ' range=':=  _default_ * gstaGraniteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 32 ' range=':=  16 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.486 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * gstaGraniteSize ' range=':=  _default_ * gstaGraniteSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.486 * _default_ * gstaGraniteSize ' range=':=  _default_ * gstaGraniteSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 3.282 * _default_ * gstaGraniteFreq ' range=':= _default_ * gstaGraniteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.486 * _default_ * gstaGraniteSize ' range=':= _default_ * gstaGraniteSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 32 ' range=':= 16 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.486 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * gstaGraniteSize ' range=':= _default_ * gstaGraniteSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.486 * _default_ * gstaGraniteSize ' range=':= _default_ * gstaGraniteSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -2498,16 +2498,16 @@
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_granite_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_granite_smooth' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 2.560 * _default_ * gstaGraniteSize ' range=':=  _default_ * gstaGraniteSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 2.560 * _default_ * gstaGraniteSize ' range=':=  _default_ * gstaGraniteSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 6.554  * _default_ * gstaGraniteFreq ' range=':=  _default_ * gstaGraniteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 32 ' range=':=  16 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 2.560 * _default_ * gstaGraniteSize ' range=':= _default_ * gstaGraniteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 2.560 * _default_ * gstaGraniteSize ' range=':= _default_ * gstaGraniteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 6.554  * _default_ * gstaGraniteFreq ' range=':= _default_ * gstaGraniteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 32 ' range=':= 16 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='gstaGraniteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60CA9C7F' drawBoundBox='false' boundBoxColor='0x60CA9C7F'>
                                 <Description>
                                     Single blocks, generously
@@ -2550,10 +2550,10 @@
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_granite_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_granite_smooth' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 32 * gstaGraniteSize ' range=':=  _default_ * gstaGraniteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 24 * gstaGraniteFreq ' range=':=  _default_ * gstaGraniteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 32 ' range=':=  16 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 32 * gstaGraniteSize ' range=':= _default_ * gstaGraniteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 24 * gstaGraniteFreq ' range=':= _default_ * gstaGraniteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 32 ' range=':= 16 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -2575,21 +2575,21 @@
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_hornfel_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_hornfel_smooth' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 2.936 * _default_ * gstaHornfelFreq ' range=':=  _default_ * gstaHornfelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.432 * _default_ * gstaHornfelSize ' range=':=  _default_ * gstaHornfelSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 35 ' range=':=  29 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.432 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * gstaHornfelSize ' range=':=  _default_ * gstaHornfelSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.432 * _default_ * gstaHornfelSize ' range=':=  _default_ * gstaHornfelSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 2.936 * _default_ * gstaHornfelFreq ' range=':= _default_ * gstaHornfelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.432 * _default_ * gstaHornfelSize ' range=':= _default_ * gstaHornfelSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 35 ' range=':= 29 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.432 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * gstaHornfelSize ' range=':= _default_ * gstaHornfelSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.432 * _default_ * gstaHornfelSize ' range=':= _default_ * gstaHornfelSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -2617,16 +2617,16 @@
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_hornfel_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_hornfel_smooth' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 2.421 * _default_ * gstaHornfelSize ' range=':=  _default_ * gstaHornfelSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 2.421 * _default_ * gstaHornfelSize ' range=':=  _default_ * gstaHornfelSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 5.862  * _default_ * gstaHornfelFreq ' range=':=  _default_ * gstaHornfelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 35 ' range=':=  29 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 2.421 * _default_ * gstaHornfelSize ' range=':= _default_ * gstaHornfelSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 2.421 * _default_ * gstaHornfelSize ' range=':= _default_ * gstaHornfelSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 5.862  * _default_ * gstaHornfelFreq ' range=':= _default_ * gstaHornfelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 35 ' range=':= 29 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='gstaHornfelHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60A4A7B0' drawBoundBox='false' boundBoxColor='0x60A4A7B0'>
                                 <Description>
                                     Single blocks, generously
@@ -2669,10 +2669,10 @@
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_hornfel_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_hornfel_smooth' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 32 * gstaHornfelSize ' range=':=  _default_ * gstaHornfelSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 19.2 * gstaHornfelFreq ' range=':=  _default_ * gstaHornfelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 35 ' range=':=  29 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 32 * gstaHornfelSize ' range=':= _default_ * gstaHornfelSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 19.2 * gstaHornfelFreq ' range=':= _default_ * gstaHornfelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 35 ' range=':= 29 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>

--- a/src/main/resources/config/modules/Mekanism.xml
+++ b/src/main/resources/config/modules/Mekanism.xml
@@ -179,21 +179,21 @@
                             <IfCondition condition=':= ?blockExists("Mekanism:OreBlock")'> <OreBlock block='Mekanism:OreBlock' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.161 * _default_ * mknsOsmiumFreq ' range=':=  _default_ * mknsOsmiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.051 * _default_ * mknsOsmiumSize ' range=':=  _default_ * mknsOsmiumSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 33 ' range=':=  27 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.051 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * mknsOsmiumSize ' range=':=  _default_ * mknsOsmiumSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.051 * _default_ * mknsOsmiumSize ' range=':=  _default_ * mknsOsmiumSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.161 * _default_ * mknsOsmiumFreq ' range=':= _default_ * mknsOsmiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.051 * _default_ * mknsOsmiumSize ' range=':= _default_ * mknsOsmiumSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 33 ' range=':= 27 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.051 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mknsOsmiumSize ' range=':= _default_ * mknsOsmiumSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.051 * _default_ * mknsOsmiumSize ' range=':= _default_ * mknsOsmiumSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -221,16 +221,16 @@
                             <IfCondition condition=':= ?blockExists("Mekanism:OreBlock")'> <OreBlock block='Mekanism:OreBlock' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.522 * _default_ * mknsOsmiumSize ' range=':=  _default_ * mknsOsmiumSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.522 * _default_ * mknsOsmiumSize ' range=':=  _default_ * mknsOsmiumSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 2.317  * _default_ * mknsOsmiumFreq ' range=':=  _default_ * mknsOsmiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 33 ' range=':=  27 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 1.522 * _default_ * mknsOsmiumSize ' range=':= _default_ * mknsOsmiumSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.522 * _default_ * mknsOsmiumSize ' range=':= _default_ * mknsOsmiumSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 2.317  * _default_ * mknsOsmiumFreq ' range=':= _default_ * mknsOsmiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 33 ' range=':= 27 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='mknsOsmiumHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x607CB3EE' drawBoundBox='false' boundBoxColor='0x607CB3EE'>
                                 <Description>
                                     Single blocks, generously
@@ -273,10 +273,10 @@
                             <IfCondition condition=':= ?blockExists("Mekanism:OreBlock")'> <OreBlock block='Mekanism:OreBlock' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 8 * mknsOsmiumSize ' range=':=  _default_ * mknsOsmiumSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 12 * mknsOsmiumFreq ' range=':=  _default_ * mknsOsmiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 33 ' range=':=  27 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 8 * mknsOsmiumSize ' range=':= _default_ * mknsOsmiumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 12 * mknsOsmiumFreq ' range=':= _default_ * mknsOsmiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 33 ' range=':= 27 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -298,21 +298,21 @@
                             <IfCondition condition=':= ?blockExists("Mekanism:OreBlock:1")'> <OreBlock block='Mekanism:OreBlock:1' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.340 * _default_ * mknsCopperFreq ' range=':=  _default_ * mknsCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.102 * _default_ * mknsCopperSize ' range=':=  _default_ * mknsCopperSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 33 ' range=':=  27 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.102 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * mknsCopperSize ' range=':=  _default_ * mknsCopperSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.102 * _default_ * mknsCopperSize ' range=':=  _default_ * mknsCopperSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.340 * _default_ * mknsCopperFreq ' range=':= _default_ * mknsCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.102 * _default_ * mknsCopperSize ' range=':= _default_ * mknsCopperSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 33 ' range=':= 27 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.102 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mknsCopperSize ' range=':= _default_ * mknsCopperSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.102 * _default_ * mknsCopperSize ' range=':= _default_ * mknsCopperSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -340,16 +340,16 @@
                             <IfCondition condition=':= ?blockExists("Mekanism:OreBlock:1")'> <OreBlock block='Mekanism:OreBlock:1' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.636 * _default_ * mknsCopperSize ' range=':=  _default_ * mknsCopperSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.636 * _default_ * mknsCopperSize ' range=':=  _default_ * mknsCopperSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 2.676  * _default_ * mknsCopperFreq ' range=':=  _default_ * mknsCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 33 ' range=':=  27 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 1.636 * _default_ * mknsCopperSize ' range=':= _default_ * mknsCopperSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.636 * _default_ * mknsCopperSize ' range=':= _default_ * mknsCopperSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 2.676  * _default_ * mknsCopperFreq ' range=':= _default_ * mknsCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 33 ' range=':= 27 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='mknsCopperHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60AE4408' drawBoundBox='false' boundBoxColor='0x60AE4408'>
                                 <Description>
                                     Single blocks, generously
@@ -392,10 +392,10 @@
                             <IfCondition condition=':= ?blockExists("Mekanism:OreBlock:1")'> <OreBlock block='Mekanism:OreBlock:1' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 8 * mknsCopperSize ' range=':=  _default_ * mknsCopperSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 16 * mknsCopperFreq ' range=':=  _default_ * mknsCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 33 ' range=':=  27 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 8 * mknsCopperSize ' range=':= _default_ * mknsCopperSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 16 * mknsCopperFreq ' range=':= _default_ * mknsCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 33 ' range=':= 27 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -417,21 +417,21 @@
                             <IfCondition condition=':= ?blockExists("Mekanism:OreBlock:2")'> <OreBlock block='Mekanism:OreBlock:2' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.254 * _default_ * mknsTinFreq ' range=':=  _default_ * mknsTinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.078 * _default_ * mknsTinSize ' range=':=  _default_ * mknsTinSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 33 ' range=':=  27 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.078 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * mknsTinSize ' range=':=  _default_ * mknsTinSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.078 * _default_ * mknsTinSize ' range=':=  _default_ * mknsTinSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.254 * _default_ * mknsTinFreq ' range=':= _default_ * mknsTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.078 * _default_ * mknsTinSize ' range=':= _default_ * mknsTinSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 33 ' range=':= 27 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.078 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mknsTinSize ' range=':= _default_ * mknsTinSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.078 * _default_ * mknsTinSize ' range=':= _default_ * mknsTinSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -459,16 +459,16 @@
                             <IfCondition condition=':= ?blockExists("Mekanism:OreBlock:2")'> <OreBlock block='Mekanism:OreBlock:2' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.582 * _default_ * mknsTinSize ' range=':=  _default_ * mknsTinSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.582 * _default_ * mknsTinSize ' range=':=  _default_ * mknsTinSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 2.503  * _default_ * mknsTinFreq ' range=':=  _default_ * mknsTinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 33 ' range=':=  27 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 1.582 * _default_ * mknsTinSize ' range=':= _default_ * mknsTinSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.582 * _default_ * mknsTinSize ' range=':= _default_ * mknsTinSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 2.503  * _default_ * mknsTinFreq ' range=':= _default_ * mknsTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 33 ' range=':= 27 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='mknsTinHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60C1C8C8' drawBoundBox='false' boundBoxColor='0x60C1C8C8'>
                                 <Description>
                                     Single blocks, generously
@@ -511,10 +511,10 @@
                             <IfCondition condition=':= ?blockExists("Mekanism:OreBlock:2")'> <OreBlock block='Mekanism:OreBlock:2' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 8 * mknsTinSize ' range=':=  _default_ * mknsTinSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 14 * mknsTinFreq ' range=':=  _default_ * mknsTinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 33 ' range=':=  27 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 8 * mknsTinSize ' range=':= _default_ * mknsTinSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 14 * mknsTinFreq ' range=':= _default_ * mknsTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 33 ' range=':= 27 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>

--- a/src/main/resources/config/modules/Metallurgy4.xml
+++ b/src/main/resources/config/modules/Metallurgy4.xml
@@ -1302,21 +1302,21 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore")'> <OreBlock block='Metallurgy:utility.ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.400 * _default_ * mtlgSulfurFreq ' range=':=  _default_ * mtlgSulfurFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.119 * _default_ * mtlgSulfurSize ' range=':=  _default_ * mtlgSulfurSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.119 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * mtlgSulfurSize ' range=':=  _default_ * mtlgSulfurSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.119 * _default_ * mtlgSulfurSize ' range=':=  _default_ * mtlgSulfurSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.400 * _default_ * mtlgSulfurFreq ' range=':= _default_ * mtlgSulfurFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.119 * _default_ * mtlgSulfurSize ' range=':= _default_ * mtlgSulfurSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.119 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mtlgSulfurSize ' range=':= _default_ * mtlgSulfurSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.119 * _default_ * mtlgSulfurSize ' range=':= _default_ * mtlgSulfurSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -1344,16 +1344,16 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore")'> <OreBlock block='Metallurgy:utility.ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.973 * _default_ * mtlgSulfurSize ' range=':=  _default_ * mtlgSulfurSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.973 * _default_ * mtlgSulfurSize ' range=':=  _default_ * mtlgSulfurSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * mtlgSulfurFreq ' range=':=  _default_ * mtlgSulfurFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 0.973 * _default_ * mtlgSulfurSize ' range=':= _default_ * mtlgSulfurSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.973 * _default_ * mtlgSulfurSize ' range=':= _default_ * mtlgSulfurSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * mtlgSulfurFreq ' range=':= _default_ * mtlgSulfurFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='mtlgSulfurHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FCF570' drawBoundBox='false' boundBoxColor='0x60FCF570'>
                                 <Description>
                                     Single blocks, generously
@@ -1396,10 +1396,10 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore")'> <OreBlock block='Metallurgy:utility.ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4 * mtlgSulfurSize ' range=':=  _default_ * mtlgSulfurSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 4 * mtlgSulfurFreq ' range=':=  _default_ * mtlgSulfurFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 4 * mtlgSulfurSize ' range=':= _default_ * mtlgSulfurSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4 * mtlgSulfurFreq ' range=':= _default_ * mtlgSulfurFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -1428,21 +1428,21 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:1")'> <OreBlock block='Metallurgy:utility.ore:1' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.400 * _default_ * mtlgPhosphoriteFreq ' range=':=  _default_ * mtlgPhosphoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.119 * _default_ * mtlgPhosphoriteSize ' range=':=  _default_ * mtlgPhosphoriteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.119 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * mtlgPhosphoriteSize ' range=':=  _default_ * mtlgPhosphoriteSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.119 * _default_ * mtlgPhosphoriteSize ' range=':=  _default_ * mtlgPhosphoriteSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.400 * _default_ * mtlgPhosphoriteFreq ' range=':= _default_ * mtlgPhosphoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.119 * _default_ * mtlgPhosphoriteSize ' range=':= _default_ * mtlgPhosphoriteSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.119 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mtlgPhosphoriteSize ' range=':= _default_ * mtlgPhosphoriteSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.119 * _default_ * mtlgPhosphoriteSize ' range=':= _default_ * mtlgPhosphoriteSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -1470,16 +1470,16 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:1")'> <OreBlock block='Metallurgy:utility.ore:1' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.973 * _default_ * mtlgPhosphoriteSize ' range=':=  _default_ * mtlgPhosphoriteSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.973 * _default_ * mtlgPhosphoriteSize ' range=':=  _default_ * mtlgPhosphoriteSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * mtlgPhosphoriteFreq ' range=':=  _default_ * mtlgPhosphoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 0.973 * _default_ * mtlgPhosphoriteSize ' range=':= _default_ * mtlgPhosphoriteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.973 * _default_ * mtlgPhosphoriteSize ' range=':= _default_ * mtlgPhosphoriteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * mtlgPhosphoriteFreq ' range=':= _default_ * mtlgPhosphoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='mtlgPhosphoriteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x608D6161' drawBoundBox='false' boundBoxColor='0x608D6161'>
                                 <Description>
                                     Single blocks, generously
@@ -1522,10 +1522,10 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:1")'> <OreBlock block='Metallurgy:utility.ore:1' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4 * mtlgPhosphoriteSize ' range=':=  _default_ * mtlgPhosphoriteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 4 * mtlgPhosphoriteFreq ' range=':=  _default_ * mtlgPhosphoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 4 * mtlgPhosphoriteSize ' range=':= _default_ * mtlgPhosphoriteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4 * mtlgPhosphoriteFreq ' range=':= _default_ * mtlgPhosphoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -1554,21 +1554,21 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:2")'> <OreBlock block='Metallurgy:utility.ore:2' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.400 * _default_ * mtlgSaltpeterFreq ' range=':=  _default_ * mtlgSaltpeterFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.119 * _default_ * mtlgSaltpeterSize ' range=':=  _default_ * mtlgSaltpeterSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.119 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * mtlgSaltpeterSize ' range=':=  _default_ * mtlgSaltpeterSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.119 * _default_ * mtlgSaltpeterSize ' range=':=  _default_ * mtlgSaltpeterSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.400 * _default_ * mtlgSaltpeterFreq ' range=':= _default_ * mtlgSaltpeterFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.119 * _default_ * mtlgSaltpeterSize ' range=':= _default_ * mtlgSaltpeterSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.119 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mtlgSaltpeterSize ' range=':= _default_ * mtlgSaltpeterSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.119 * _default_ * mtlgSaltpeterSize ' range=':= _default_ * mtlgSaltpeterSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -1596,16 +1596,16 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:2")'> <OreBlock block='Metallurgy:utility.ore:2' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.973 * _default_ * mtlgSaltpeterSize ' range=':=  _default_ * mtlgSaltpeterSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.973 * _default_ * mtlgSaltpeterSize ' range=':=  _default_ * mtlgSaltpeterSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * mtlgSaltpeterFreq ' range=':=  _default_ * mtlgSaltpeterFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 0.973 * _default_ * mtlgSaltpeterSize ' range=':= _default_ * mtlgSaltpeterSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.973 * _default_ * mtlgSaltpeterSize ' range=':= _default_ * mtlgSaltpeterSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * mtlgSaltpeterFreq ' range=':= _default_ * mtlgSaltpeterFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='mtlgSaltpeterHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60EAEAEA' drawBoundBox='false' boundBoxColor='0x60EAEAEA'>
                                 <Description>
                                     Single blocks, generously
@@ -1648,10 +1648,10 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:2")'> <OreBlock block='Metallurgy:utility.ore:2' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4 * mtlgSaltpeterSize ' range=':=  _default_ * mtlgSaltpeterSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 4 * mtlgSaltpeterFreq ' range=':=  _default_ * mtlgSaltpeterFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 4 * mtlgSaltpeterSize ' range=':= _default_ * mtlgSaltpeterSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4 * mtlgSaltpeterFreq ' range=':= _default_ * mtlgSaltpeterFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -1680,21 +1680,21 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:3")'> <OreBlock block='Metallurgy:utility.ore:3' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.400 * _default_ * mtlgMagnesiumFreq ' range=':=  _default_ * mtlgMagnesiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.119 * _default_ * mtlgMagnesiumSize ' range=':=  _default_ * mtlgMagnesiumSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.119 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * mtlgMagnesiumSize ' range=':=  _default_ * mtlgMagnesiumSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.119 * _default_ * mtlgMagnesiumSize ' range=':=  _default_ * mtlgMagnesiumSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.400 * _default_ * mtlgMagnesiumFreq ' range=':= _default_ * mtlgMagnesiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.119 * _default_ * mtlgMagnesiumSize ' range=':= _default_ * mtlgMagnesiumSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.119 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mtlgMagnesiumSize ' range=':= _default_ * mtlgMagnesiumSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.119 * _default_ * mtlgMagnesiumSize ' range=':= _default_ * mtlgMagnesiumSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -1722,16 +1722,16 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:3")'> <OreBlock block='Metallurgy:utility.ore:3' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.973 * _default_ * mtlgMagnesiumSize ' range=':=  _default_ * mtlgMagnesiumSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.973 * _default_ * mtlgMagnesiumSize ' range=':=  _default_ * mtlgMagnesiumSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * mtlgMagnesiumFreq ' range=':=  _default_ * mtlgMagnesiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 0.973 * _default_ * mtlgMagnesiumSize ' range=':= _default_ * mtlgMagnesiumSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.973 * _default_ * mtlgMagnesiumSize ' range=':= _default_ * mtlgMagnesiumSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * mtlgMagnesiumFreq ' range=':= _default_ * mtlgMagnesiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='mtlgMagnesiumHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60927C6C' drawBoundBox='false' boundBoxColor='0x60927C6C'>
                                 <Description>
                                     Single blocks, generously
@@ -1774,10 +1774,10 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:3")'> <OreBlock block='Metallurgy:utility.ore:3' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4 * mtlgMagnesiumSize ' range=':=  _default_ * mtlgMagnesiumSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 4 * mtlgMagnesiumFreq ' range=':=  _default_ * mtlgMagnesiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 4 * mtlgMagnesiumSize ' range=':= _default_ * mtlgMagnesiumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4 * mtlgMagnesiumFreq ' range=':= _default_ * mtlgMagnesiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -1806,21 +1806,21 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:4")'> <OreBlock block='Metallurgy:utility.ore:4' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.400 * _default_ * mtlgBitumenFreq ' range=':=  _default_ * mtlgBitumenFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.119 * _default_ * mtlgBitumenSize ' range=':=  _default_ * mtlgBitumenSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.119 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * mtlgBitumenSize ' range=':=  _default_ * mtlgBitumenSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.119 * _default_ * mtlgBitumenSize ' range=':=  _default_ * mtlgBitumenSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.400 * _default_ * mtlgBitumenFreq ' range=':= _default_ * mtlgBitumenFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.119 * _default_ * mtlgBitumenSize ' range=':= _default_ * mtlgBitumenSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.119 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mtlgBitumenSize ' range=':= _default_ * mtlgBitumenSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.119 * _default_ * mtlgBitumenSize ' range=':= _default_ * mtlgBitumenSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -1848,16 +1848,16 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:4")'> <OreBlock block='Metallurgy:utility.ore:4' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.973 * _default_ * mtlgBitumenSize ' range=':=  _default_ * mtlgBitumenSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.973 * _default_ * mtlgBitumenSize ' range=':=  _default_ * mtlgBitumenSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * mtlgBitumenFreq ' range=':=  _default_ * mtlgBitumenFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 0.973 * _default_ * mtlgBitumenSize ' range=':= _default_ * mtlgBitumenSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.973 * _default_ * mtlgBitumenSize ' range=':= _default_ * mtlgBitumenSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * mtlgBitumenFreq ' range=':= _default_ * mtlgBitumenFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='mtlgBitumenHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x602A2A2A' drawBoundBox='false' boundBoxColor='0x602A2A2A'>
                                 <Description>
                                     Single blocks, generously
@@ -1900,10 +1900,10 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:4")'> <OreBlock block='Metallurgy:utility.ore:4' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4 * mtlgBitumenSize ' range=':=  _default_ * mtlgBitumenSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 4 * mtlgBitumenFreq ' range=':=  _default_ * mtlgBitumenFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 4 * mtlgBitumenSize ' range=':= _default_ * mtlgBitumenSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4 * mtlgBitumenFreq ' range=':= _default_ * mtlgBitumenFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -1932,21 +1932,21 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:5")'> <OreBlock block='Metallurgy:utility.ore:5' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.400 * _default_ * mtlgPotashFreq ' range=':=  _default_ * mtlgPotashFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.119 * _default_ * mtlgPotashSize ' range=':=  _default_ * mtlgPotashSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.119 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * mtlgPotashSize ' range=':=  _default_ * mtlgPotashSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.119 * _default_ * mtlgPotashSize ' range=':=  _default_ * mtlgPotashSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.400 * _default_ * mtlgPotashFreq ' range=':= _default_ * mtlgPotashFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.119 * _default_ * mtlgPotashSize ' range=':= _default_ * mtlgPotashSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.119 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mtlgPotashSize ' range=':= _default_ * mtlgPotashSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.119 * _default_ * mtlgPotashSize ' range=':= _default_ * mtlgPotashSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -1974,16 +1974,16 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:5")'> <OreBlock block='Metallurgy:utility.ore:5' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.973 * _default_ * mtlgPotashSize ' range=':=  _default_ * mtlgPotashSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.973 * _default_ * mtlgPotashSize ' range=':=  _default_ * mtlgPotashSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * mtlgPotashFreq ' range=':=  _default_ * mtlgPotashFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 0.973 * _default_ * mtlgPotashSize ' range=':= _default_ * mtlgPotashSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.973 * _default_ * mtlgPotashSize ' range=':= _default_ * mtlgPotashSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * mtlgPotashFreq ' range=':= _default_ * mtlgPotashFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='mtlgPotashHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FFAA00' drawBoundBox='false' boundBoxColor='0x60FFAA00'>
                                 <Description>
                                     Single blocks, generously
@@ -2026,10 +2026,10 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:5")'> <OreBlock block='Metallurgy:utility.ore:5' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4 * mtlgPotashSize ' range=':=  _default_ * mtlgPotashSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 4 * mtlgPotashFreq ' range=':=  _default_ * mtlgPotashFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 4 * mtlgPotashSize ' range=':= _default_ * mtlgPotashSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4 * mtlgPotashFreq ' range=':= _default_ * mtlgPotashFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -2051,21 +2051,21 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:base.ore")'> <OreBlock block='Metallurgy:base.ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.005 * _default_ * mtlgCopperFreq ' range=':=  _default_ * mtlgCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.002 * _default_ * mtlgCopperSize ' range=':=  _default_ * mtlgCopperSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.002 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * mtlgCopperSize ' range=':=  _default_ * mtlgCopperSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.002 * _default_ * mtlgCopperSize ' range=':=  _default_ * mtlgCopperSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.005 * _default_ * mtlgCopperFreq ' range=':= _default_ * mtlgCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.002 * _default_ * mtlgCopperSize ' range=':= _default_ * mtlgCopperSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.002 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mtlgCopperSize ' range=':= _default_ * mtlgCopperSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.002 * _default_ * mtlgCopperSize ' range=':= _default_ * mtlgCopperSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -2093,16 +2093,16 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:base.ore")'> <OreBlock block='Metallurgy:base.ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.417 * _default_ * mtlgCopperSize ' range=':=  _default_ * mtlgCopperSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.417 * _default_ * mtlgCopperSize ' range=':=  _default_ * mtlgCopperSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 2.007  * _default_ * mtlgCopperFreq ' range=':=  _default_ * mtlgCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 1.417 * _default_ * mtlgCopperSize ' range=':= _default_ * mtlgCopperSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.417 * _default_ * mtlgCopperSize ' range=':= _default_ * mtlgCopperSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 2.007  * _default_ * mtlgCopperFreq ' range=':= _default_ * mtlgCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='mtlgCopperHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60EA6515' drawBoundBox='false' boundBoxColor='0x60EA6515'>
                                 <Description>
                                     Single blocks, generously
@@ -2145,10 +2145,10 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:base.ore")'> <OreBlock block='Metallurgy:base.ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 6 * mtlgCopperSize ' range=':=  _default_ * mtlgCopperSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 12 * mtlgCopperFreq ' range=':=  _default_ * mtlgCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 6 * mtlgCopperSize ' range=':= _default_ * mtlgCopperSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 12 * mtlgCopperFreq ' range=':= _default_ * mtlgCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -2170,21 +2170,21 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:base.ore:1")'> <OreBlock block='Metallurgy:base.ore:1' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.991 * _default_ * mtlgTinFreq ' range=':=  _default_ * mtlgTinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.997 * _default_ * mtlgTinSize ' range=':=  _default_ * mtlgTinSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.997 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * mtlgTinSize ' range=':=  _default_ * mtlgTinSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.997 * _default_ * mtlgTinSize ' range=':=  _default_ * mtlgTinSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.991 * _default_ * mtlgTinFreq ' range=':= _default_ * mtlgTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.997 * _default_ * mtlgTinSize ' range=':= _default_ * mtlgTinSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.997 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mtlgTinSize ' range=':= _default_ * mtlgTinSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.997 * _default_ * mtlgTinSize ' range=':= _default_ * mtlgTinSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -2212,16 +2212,16 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:base.ore:1")'> <OreBlock block='Metallurgy:base.ore:1' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.407 * _default_ * mtlgTinSize ' range=':=  _default_ * mtlgTinSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.407 * _default_ * mtlgTinSize ' range=':=  _default_ * mtlgTinSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.979  * _default_ * mtlgTinFreq ' range=':=  _default_ * mtlgTinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 1.407 * _default_ * mtlgTinSize ' range=':= _default_ * mtlgTinSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.407 * _default_ * mtlgTinSize ' range=':= _default_ * mtlgTinSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.979  * _default_ * mtlgTinFreq ' range=':= _default_ * mtlgTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='mtlgTinHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60BDBDBD' drawBoundBox='false' boundBoxColor='0x60BDBDBD'>
                                 <Description>
                                     Single blocks, generously
@@ -2264,10 +2264,10 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:base.ore:1")'> <OreBlock block='Metallurgy:base.ore:1' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 10 * mtlgTinSize ' range=':=  _default_ * mtlgTinSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 7 * mtlgTinFreq ' range=':=  _default_ * mtlgTinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 10 * mtlgTinSize ' range=':= _default_ * mtlgTinSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 7 * mtlgTinFreq ' range=':= _default_ * mtlgTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -2289,21 +2289,21 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:base.ore:2")'> <OreBlock block='Metallurgy:base.ore:2' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.530 * _default_ * mtlgManganeseFreq ' range=':=  _default_ * mtlgManganeseFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.809 * _default_ * mtlgManganeseSize ' range=':=  _default_ * mtlgManganeseSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.809 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * mtlgManganeseSize ' range=':=  _default_ * mtlgManganeseSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.809 * _default_ * mtlgManganeseSize ' range=':=  _default_ * mtlgManganeseSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.530 * _default_ * mtlgManganeseFreq ' range=':= _default_ * mtlgManganeseFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.809 * _default_ * mtlgManganeseSize ' range=':= _default_ * mtlgManganeseSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.809 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mtlgManganeseSize ' range=':= _default_ * mtlgManganeseSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.809 * _default_ * mtlgManganeseSize ' range=':= _default_ * mtlgManganeseSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -2331,16 +2331,16 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:base.ore:2")'> <OreBlock block='Metallurgy:base.ore:2' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.028 * _default_ * mtlgManganeseSize ' range=':=  _default_ * mtlgManganeseSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.028 * _default_ * mtlgManganeseSize ' range=':=  _default_ * mtlgManganeseSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.058  * _default_ * mtlgManganeseFreq ' range=':=  _default_ * mtlgManganeseFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 1.028 * _default_ * mtlgManganeseSize ' range=':= _default_ * mtlgManganeseSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.028 * _default_ * mtlgManganeseSize ' range=':= _default_ * mtlgManganeseSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.058  * _default_ * mtlgManganeseFreq ' range=':= _default_ * mtlgManganeseFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='mtlgManganeseHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FCC7C7' drawBoundBox='false' boundBoxColor='0x60FCC7C7'>
                                 <Description>
                                     Single blocks, generously
@@ -2383,10 +2383,10 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:base.ore:2")'> <OreBlock block='Metallurgy:base.ore:2' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4 * mtlgManganeseSize ' range=':=  _default_ * mtlgManganeseSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 5 * mtlgManganeseFreq ' range=':=  _default_ * mtlgManganeseFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 4 * mtlgManganeseSize ' range=':= _default_ * mtlgManganeseSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 5 * mtlgManganeseFreq ' range=':= _default_ * mtlgManganeseFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -2408,21 +2408,21 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:precious.ore")'> <OreBlock block='Metallurgy:precious.ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.649 * _default_ * mtlgZincFreq ' range=':=  _default_ * mtlgZincFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.866 * _default_ * mtlgZincSize ' range=':=  _default_ * mtlgZincSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.866 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * mtlgZincSize ' range=':=  _default_ * mtlgZincSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.866 * _default_ * mtlgZincSize ' range=':=  _default_ * mtlgZincSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.649 * _default_ * mtlgZincFreq ' range=':= _default_ * mtlgZincFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.866 * _default_ * mtlgZincSize ' range=':= _default_ * mtlgZincSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.866 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mtlgZincSize ' range=':= _default_ * mtlgZincSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.866 * _default_ * mtlgZincSize ' range=':= _default_ * mtlgZincSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -2450,16 +2450,16 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:precious.ore")'> <OreBlock block='Metallurgy:precious.ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.138 * _default_ * mtlgZincSize ' range=':=  _default_ * mtlgZincSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.138 * _default_ * mtlgZincSize ' range=':=  _default_ * mtlgZincSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.295  * _default_ * mtlgZincFreq ' range=':=  _default_ * mtlgZincFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 1.138 * _default_ * mtlgZincSize ' range=':= _default_ * mtlgZincSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.138 * _default_ * mtlgZincSize ' range=':= _default_ * mtlgZincSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.295  * _default_ * mtlgZincFreq ' range=':= _default_ * mtlgZincFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='mtlgZincHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60BFC55C' drawBoundBox='false' boundBoxColor='0x60BFC55C'>
                                 <Description>
                                     Single blocks, generously
@@ -2502,10 +2502,10 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:precious.ore")'> <OreBlock block='Metallurgy:precious.ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 5 * mtlgZincSize ' range=':=  _default_ * mtlgZincSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 6 * mtlgZincFreq ' range=':=  _default_ * mtlgZincFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 5 * mtlgZincSize ' range=':= _default_ * mtlgZincSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 6 * mtlgZincFreq ' range=':= _default_ * mtlgZincFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -2527,21 +2527,21 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:precious.ore:1")'> <OreBlock block='Metallurgy:precious.ore:1' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.649 * _default_ * mtlgSilverFreq ' range=':=  _default_ * mtlgSilverFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.866 * _default_ * mtlgSilverSize ' range=':=  _default_ * mtlgSilverSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.866 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * mtlgSilverSize ' range=':=  _default_ * mtlgSilverSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.866 * _default_ * mtlgSilverSize ' range=':=  _default_ * mtlgSilverSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.649 * _default_ * mtlgSilverFreq ' range=':= _default_ * mtlgSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.866 * _default_ * mtlgSilverSize ' range=':= _default_ * mtlgSilverSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.866 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mtlgSilverSize ' range=':= _default_ * mtlgSilverSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.866 * _default_ * mtlgSilverSize ' range=':= _default_ * mtlgSilverSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -2569,16 +2569,16 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:precious.ore:1")'> <OreBlock block='Metallurgy:precious.ore:1' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.138 * _default_ * mtlgSilverSize ' range=':=  _default_ * mtlgSilverSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.138 * _default_ * mtlgSilverSize ' range=':=  _default_ * mtlgSilverSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.295  * _default_ * mtlgSilverFreq ' range=':=  _default_ * mtlgSilverFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 1.138 * _default_ * mtlgSilverSize ' range=':= _default_ * mtlgSilverSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.138 * _default_ * mtlgSilverSize ' range=':= _default_ * mtlgSilverSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.295  * _default_ * mtlgSilverFreq ' range=':= _default_ * mtlgSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='mtlgSilverHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60E1E1E1' drawBoundBox='false' boundBoxColor='0x60E1E1E1'>
                                 <Description>
                                     Single blocks, generously
@@ -2621,10 +2621,10 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:precious.ore:1")'> <OreBlock block='Metallurgy:precious.ore:1' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 5 * mtlgSilverSize ' range=':=  _default_ * mtlgSilverSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 6 * mtlgSilverFreq ' range=':=  _default_ * mtlgSilverFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 5 * mtlgSilverSize ' range=':= _default_ * mtlgSilverSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 6 * mtlgSilverFreq ' range=':= _default_ * mtlgSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -2646,21 +2646,21 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:precious.ore:2")'> <OreBlock block='Metallurgy:precious.ore:2' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.355 * _default_ * mtlgPlatinumFreq ' range=':=  _default_ * mtlgPlatinumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.708 * _default_ * mtlgPlatinumSize ' range=':=  _default_ * mtlgPlatinumSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.708 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * mtlgPlatinumSize ' range=':=  _default_ * mtlgPlatinumSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.708 * _default_ * mtlgPlatinumSize ' range=':=  _default_ * mtlgPlatinumSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.355 * _default_ * mtlgPlatinumFreq ' range=':= _default_ * mtlgPlatinumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.708 * _default_ * mtlgPlatinumSize ' range=':= _default_ * mtlgPlatinumSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.708 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mtlgPlatinumSize ' range=':= _default_ * mtlgPlatinumSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.708 * _default_ * mtlgPlatinumSize ' range=':= _default_ * mtlgPlatinumSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -2688,16 +2688,16 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:precious.ore:2")'> <OreBlock block='Metallurgy:precious.ore:2' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.842 * _default_ * mtlgPlatinumSize ' range=':=  _default_ * mtlgPlatinumSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.842 * _default_ * mtlgPlatinumSize ' range=':=  _default_ * mtlgPlatinumSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.709  * _default_ * mtlgPlatinumFreq ' range=':=  _default_ * mtlgPlatinumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 0.842 * _default_ * mtlgPlatinumSize ' range=':= _default_ * mtlgPlatinumSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.842 * _default_ * mtlgPlatinumSize ' range=':= _default_ * mtlgPlatinumSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.709  * _default_ * mtlgPlatinumFreq ' range=':= _default_ * mtlgPlatinumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='mtlgPlatinumHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60B8D6DB' drawBoundBox='false' boundBoxColor='0x60B8D6DB'>
                                 <Description>
                                     Single blocks, generously
@@ -2740,10 +2740,10 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:precious.ore:2")'> <OreBlock block='Metallurgy:precious.ore:2' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3 * mtlgPlatinumSize ' range=':=  _default_ * mtlgPlatinumSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 3 * mtlgPlatinumFreq ' range=':=  _default_ * mtlgPlatinumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 3 * mtlgPlatinumSize ' range=':= _default_ * mtlgPlatinumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 3 * mtlgPlatinumFreq ' range=':= _default_ * mtlgPlatinumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -2765,21 +2765,21 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore")'> <OreBlock block='Metallurgy:fantasy.ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.649 * _default_ * mtlgPromethiumFreq ' range=':=  _default_ * mtlgPromethiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.866 * _default_ * mtlgPromethiumSize ' range=':=  _default_ * mtlgPromethiumSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.866 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * mtlgPromethiumSize ' range=':=  _default_ * mtlgPromethiumSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.866 * _default_ * mtlgPromethiumSize ' range=':=  _default_ * mtlgPromethiumSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.649 * _default_ * mtlgPromethiumFreq ' range=':= _default_ * mtlgPromethiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.866 * _default_ * mtlgPromethiumSize ' range=':= _default_ * mtlgPromethiumSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.866 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mtlgPromethiumSize ' range=':= _default_ * mtlgPromethiumSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.866 * _default_ * mtlgPromethiumSize ' range=':= _default_ * mtlgPromethiumSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -2807,16 +2807,16 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore")'> <OreBlock block='Metallurgy:fantasy.ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.138 * _default_ * mtlgPromethiumSize ' range=':=  _default_ * mtlgPromethiumSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.138 * _default_ * mtlgPromethiumSize ' range=':=  _default_ * mtlgPromethiumSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.295  * _default_ * mtlgPromethiumFreq ' range=':=  _default_ * mtlgPromethiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 1.138 * _default_ * mtlgPromethiumSize ' range=':= _default_ * mtlgPromethiumSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.138 * _default_ * mtlgPromethiumSize ' range=':= _default_ * mtlgPromethiumSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.295  * _default_ * mtlgPromethiumFreq ' range=':= _default_ * mtlgPromethiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='mtlgPromethiumHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x605D8258' drawBoundBox='false' boundBoxColor='0x605D8258'>
                                 <Description>
                                     Single blocks, generously
@@ -2859,10 +2859,10 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore")'> <OreBlock block='Metallurgy:fantasy.ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 6 * mtlgPromethiumSize ' range=':=  _default_ * mtlgPromethiumSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 5 * mtlgPromethiumFreq ' range=':=  _default_ * mtlgPromethiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 6 * mtlgPromethiumSize ' range=':= _default_ * mtlgPromethiumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 5 * mtlgPromethiumFreq ' range=':= _default_ * mtlgPromethiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -2884,21 +2884,21 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:1")'> <OreBlock block='Metallurgy:fantasy.ore:1' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.530 * _default_ * mtlgDeepIronFreq ' range=':=  _default_ * mtlgDeepIronFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.809 * _default_ * mtlgDeepIronSize ' range=':=  _default_ * mtlgDeepIronSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.809 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * mtlgDeepIronSize ' range=':=  _default_ * mtlgDeepIronSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.809 * _default_ * mtlgDeepIronSize ' range=':=  _default_ * mtlgDeepIronSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.530 * _default_ * mtlgDeepIronFreq ' range=':= _default_ * mtlgDeepIronFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.809 * _default_ * mtlgDeepIronSize ' range=':= _default_ * mtlgDeepIronSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.809 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mtlgDeepIronSize ' range=':= _default_ * mtlgDeepIronSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.809 * _default_ * mtlgDeepIronSize ' range=':= _default_ * mtlgDeepIronSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -2926,16 +2926,16 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:1")'> <OreBlock block='Metallurgy:fantasy.ore:1' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.028 * _default_ * mtlgDeepIronSize ' range=':=  _default_ * mtlgDeepIronSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.028 * _default_ * mtlgDeepIronSize ' range=':=  _default_ * mtlgDeepIronSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.058  * _default_ * mtlgDeepIronFreq ' range=':=  _default_ * mtlgDeepIronFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 1.028 * _default_ * mtlgDeepIronSize ' range=':= _default_ * mtlgDeepIronSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.028 * _default_ * mtlgDeepIronSize ' range=':= _default_ * mtlgDeepIronSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.058  * _default_ * mtlgDeepIronFreq ' range=':= _default_ * mtlgDeepIronFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='mtlgDeepIronHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x604C5E6C' drawBoundBox='false' boundBoxColor='0x604C5E6C'>
                                 <Description>
                                     Single blocks, generously
@@ -2978,10 +2978,10 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:1")'> <OreBlock block='Metallurgy:fantasy.ore:1' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4 * mtlgDeepIronSize ' range=':=  _default_ * mtlgDeepIronSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 5 * mtlgDeepIronFreq ' range=':=  _default_ * mtlgDeepIronFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 4 * mtlgDeepIronSize ' range=':= _default_ * mtlgDeepIronSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 5 * mtlgDeepIronFreq ' range=':= _default_ * mtlgDeepIronFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -3003,21 +3003,21 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:2")'> <OreBlock block='Metallurgy:fantasy.ore:2' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.530 * _default_ * mtlgInfuscoliumFreq ' range=':=  _default_ * mtlgInfuscoliumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.809 * _default_ * mtlgInfuscoliumSize ' range=':=  _default_ * mtlgInfuscoliumSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.809 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * mtlgInfuscoliumSize ' range=':=  _default_ * mtlgInfuscoliumSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.809 * _default_ * mtlgInfuscoliumSize ' range=':=  _default_ * mtlgInfuscoliumSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.530 * _default_ * mtlgInfuscoliumFreq ' range=':= _default_ * mtlgInfuscoliumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.809 * _default_ * mtlgInfuscoliumSize ' range=':= _default_ * mtlgInfuscoliumSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.809 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mtlgInfuscoliumSize ' range=':= _default_ * mtlgInfuscoliumSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.809 * _default_ * mtlgInfuscoliumSize ' range=':= _default_ * mtlgInfuscoliumSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -3045,16 +3045,16 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:2")'> <OreBlock block='Metallurgy:fantasy.ore:2' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.028 * _default_ * mtlgInfuscoliumSize ' range=':=  _default_ * mtlgInfuscoliumSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.028 * _default_ * mtlgInfuscoliumSize ' range=':=  _default_ * mtlgInfuscoliumSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.058  * _default_ * mtlgInfuscoliumFreq ' range=':=  _default_ * mtlgInfuscoliumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 1.028 * _default_ * mtlgInfuscoliumSize ' range=':= _default_ * mtlgInfuscoliumSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.028 * _default_ * mtlgInfuscoliumSize ' range=':= _default_ * mtlgInfuscoliumSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.058  * _default_ * mtlgInfuscoliumFreq ' range=':= _default_ * mtlgInfuscoliumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='mtlgInfuscoliumHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x608B2656' drawBoundBox='false' boundBoxColor='0x608B2656'>
                                 <Description>
                                     Single blocks, generously
@@ -3097,10 +3097,10 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:2")'> <OreBlock block='Metallurgy:fantasy.ore:2' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4 * mtlgInfuscoliumSize ' range=':=  _default_ * mtlgInfuscoliumSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 5 * mtlgInfuscoliumFreq ' range=':=  _default_ * mtlgInfuscoliumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 4 * mtlgInfuscoliumSize ' range=':= _default_ * mtlgInfuscoliumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 5 * mtlgInfuscoliumFreq ' range=':= _default_ * mtlgInfuscoliumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -3122,21 +3122,21 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:4")'> <OreBlock block='Metallurgy:fantasy.ore:4' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.410 * _default_ * mtlgOureclaseFreq ' range=':=  _default_ * mtlgOureclaseFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.743 * _default_ * mtlgOureclaseSize ' range=':=  _default_ * mtlgOureclaseSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.743 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * mtlgOureclaseSize ' range=':=  _default_ * mtlgOureclaseSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.743 * _default_ * mtlgOureclaseSize ' range=':=  _default_ * mtlgOureclaseSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.410 * _default_ * mtlgOureclaseFreq ' range=':= _default_ * mtlgOureclaseFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.743 * _default_ * mtlgOureclaseSize ' range=':= _default_ * mtlgOureclaseSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.743 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mtlgOureclaseSize ' range=':= _default_ * mtlgOureclaseSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.743 * _default_ * mtlgOureclaseSize ' range=':= _default_ * mtlgOureclaseSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -3164,16 +3164,16 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:4")'> <OreBlock block='Metallurgy:fantasy.ore:4' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.905 * _default_ * mtlgOureclaseSize ' range=':=  _default_ * mtlgOureclaseSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.905 * _default_ * mtlgOureclaseSize ' range=':=  _default_ * mtlgOureclaseSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * mtlgOureclaseFreq ' range=':=  _default_ * mtlgOureclaseFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 0.905 * _default_ * mtlgOureclaseSize ' range=':= _default_ * mtlgOureclaseSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.905 * _default_ * mtlgOureclaseSize ' range=':= _default_ * mtlgOureclaseSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * mtlgOureclaseFreq ' range=':= _default_ * mtlgOureclaseFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='mtlgOureclaseHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x609A7607' drawBoundBox='false' boundBoxColor='0x609A7607'>
                                 <Description>
                                     Single blocks, generously
@@ -3216,10 +3216,10 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:4")'> <OreBlock block='Metallurgy:fantasy.ore:4' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3 * mtlgOureclaseSize ' range=':=  _default_ * mtlgOureclaseSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 4 * mtlgOureclaseFreq ' range=':=  _default_ * mtlgOureclaseFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 3 * mtlgOureclaseSize ' range=':= _default_ * mtlgOureclaseSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4 * mtlgOureclaseFreq ' range=':= _default_ * mtlgOureclaseFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -3241,21 +3241,21 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:5")'> <OreBlock block='Metallurgy:fantasy.ore:5' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.410 * _default_ * mtlgAstralSilverFreq ' range=':=  _default_ * mtlgAstralSilverFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.743 * _default_ * mtlgAstralSilverSize ' range=':=  _default_ * mtlgAstralSilverSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.743 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * mtlgAstralSilverSize ' range=':=  _default_ * mtlgAstralSilverSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.743 * _default_ * mtlgAstralSilverSize ' range=':=  _default_ * mtlgAstralSilverSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.410 * _default_ * mtlgAstralSilverFreq ' range=':= _default_ * mtlgAstralSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.743 * _default_ * mtlgAstralSilverSize ' range=':= _default_ * mtlgAstralSilverSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.743 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mtlgAstralSilverSize ' range=':= _default_ * mtlgAstralSilverSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.743 * _default_ * mtlgAstralSilverSize ' range=':= _default_ * mtlgAstralSilverSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -3284,16 +3284,16 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:5")'> <OreBlock block='Metallurgy:fantasy.ore:5' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.905 * _default_ * mtlgAstralSilverSize ' range=':=  _default_ * mtlgAstralSilverSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.905 * _default_ * mtlgAstralSilverSize ' range=':=  _default_ * mtlgAstralSilverSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * mtlgAstralSilverFreq ' range=':=  _default_ * mtlgAstralSilverFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 0.905 * _default_ * mtlgAstralSilverSize ' range=':= _default_ * mtlgAstralSilverSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.905 * _default_ * mtlgAstralSilverSize ' range=':= _default_ * mtlgAstralSilverSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * mtlgAstralSilverFreq ' range=':= _default_ * mtlgAstralSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='mtlgAstralSilverHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60ADC3C3' drawBoundBox='false' boundBoxColor='0x60ADC3C3'>
                                 <Description>
                                     Single blocks, generously
@@ -3336,10 +3336,10 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:5")'> <OreBlock block='Metallurgy:fantasy.ore:5' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3 * mtlgAstralSilverSize ' range=':=  _default_ * mtlgAstralSilverSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 4 * mtlgAstralSilverFreq ' range=':=  _default_ * mtlgAstralSilverFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 3 * mtlgAstralSilverSize ' range=':= _default_ * mtlgAstralSilverSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4 * mtlgAstralSilverFreq ' range=':= _default_ * mtlgAstralSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -3361,21 +3361,21 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:6")'> <OreBlock block='Metallurgy:fantasy.ore:6' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.355 * _default_ * mtlgCarmotFreq ' range=':=  _default_ * mtlgCarmotFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.708 * _default_ * mtlgCarmotSize ' range=':=  _default_ * mtlgCarmotSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.708 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * mtlgCarmotSize ' range=':=  _default_ * mtlgCarmotSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.708 * _default_ * mtlgCarmotSize ' range=':=  _default_ * mtlgCarmotSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.355 * _default_ * mtlgCarmotFreq ' range=':= _default_ * mtlgCarmotFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.708 * _default_ * mtlgCarmotSize ' range=':= _default_ * mtlgCarmotSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.708 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mtlgCarmotSize ' range=':= _default_ * mtlgCarmotSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.708 * _default_ * mtlgCarmotSize ' range=':= _default_ * mtlgCarmotSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -3403,16 +3403,16 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:6")'> <OreBlock block='Metallurgy:fantasy.ore:6' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.842 * _default_ * mtlgCarmotSize ' range=':=  _default_ * mtlgCarmotSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.842 * _default_ * mtlgCarmotSize ' range=':=  _default_ * mtlgCarmotSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.709  * _default_ * mtlgCarmotFreq ' range=':=  _default_ * mtlgCarmotFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 0.842 * _default_ * mtlgCarmotSize ' range=':= _default_ * mtlgCarmotSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.842 * _default_ * mtlgCarmotSize ' range=':= _default_ * mtlgCarmotSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.709  * _default_ * mtlgCarmotFreq ' range=':= _default_ * mtlgCarmotFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='mtlgCarmotHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60D7C986' drawBoundBox='false' boundBoxColor='0x60D7C986'>
                                 <Description>
                                     Single blocks, generously
@@ -3455,10 +3455,10 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:6")'> <OreBlock block='Metallurgy:fantasy.ore:6' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3 * mtlgCarmotSize ' range=':=  _default_ * mtlgCarmotSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 3 * mtlgCarmotFreq ' range=':=  _default_ * mtlgCarmotFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 3 * mtlgCarmotSize ' range=':= _default_ * mtlgCarmotSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 3 * mtlgCarmotFreq ' range=':= _default_ * mtlgCarmotFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -3480,21 +3480,21 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:7")'> <OreBlock block='Metallurgy:fantasy.ore:7' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.355 * _default_ * mtlgMithrilFreq ' range=':=  _default_ * mtlgMithrilFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.708 * _default_ * mtlgMithrilSize ' range=':=  _default_ * mtlgMithrilSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.708 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * mtlgMithrilSize ' range=':=  _default_ * mtlgMithrilSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.708 * _default_ * mtlgMithrilSize ' range=':=  _default_ * mtlgMithrilSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.355 * _default_ * mtlgMithrilFreq ' range=':= _default_ * mtlgMithrilFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.708 * _default_ * mtlgMithrilSize ' range=':= _default_ * mtlgMithrilSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.708 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mtlgMithrilSize ' range=':= _default_ * mtlgMithrilSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.708 * _default_ * mtlgMithrilSize ' range=':= _default_ * mtlgMithrilSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -3522,16 +3522,16 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:7")'> <OreBlock block='Metallurgy:fantasy.ore:7' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.842 * _default_ * mtlgMithrilSize ' range=':=  _default_ * mtlgMithrilSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.842 * _default_ * mtlgMithrilSize ' range=':=  _default_ * mtlgMithrilSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.709  * _default_ * mtlgMithrilFreq ' range=':=  _default_ * mtlgMithrilFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 0.842 * _default_ * mtlgMithrilSize ' range=':= _default_ * mtlgMithrilSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.842 * _default_ * mtlgMithrilSize ' range=':= _default_ * mtlgMithrilSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.709  * _default_ * mtlgMithrilFreq ' range=':= _default_ * mtlgMithrilFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='mtlgMithrilHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x609AF3F7' drawBoundBox='false' boundBoxColor='0x609AF3F7'>
                                 <Description>
                                     Single blocks, generously
@@ -3574,10 +3574,10 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:7")'> <OreBlock block='Metallurgy:fantasy.ore:7' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3 * mtlgMithrilSize ' range=':=  _default_ * mtlgMithrilSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 3 * mtlgMithrilFreq ' range=':=  _default_ * mtlgMithrilFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 3 * mtlgMithrilSize ' range=':= _default_ * mtlgMithrilSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 3 * mtlgMithrilFreq ' range=':= _default_ * mtlgMithrilFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -3599,21 +3599,21 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:8")'> <OreBlock block='Metallurgy:fantasy.ore:8' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.290 * _default_ * mtlgRubraciumFreq ' range=':=  _default_ * mtlgRubraciumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.662 * _default_ * mtlgRubraciumSize ' range=':=  _default_ * mtlgRubraciumSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.662 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * mtlgRubraciumSize ' range=':=  _default_ * mtlgRubraciumSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.662 * _default_ * mtlgRubraciumSize ' range=':=  _default_ * mtlgRubraciumSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.290 * _default_ * mtlgRubraciumFreq ' range=':= _default_ * mtlgRubraciumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.662 * _default_ * mtlgRubraciumSize ' range=':= _default_ * mtlgRubraciumSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.662 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mtlgRubraciumSize ' range=':= _default_ * mtlgRubraciumSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.662 * _default_ * mtlgRubraciumSize ' range=':= _default_ * mtlgRubraciumSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -3641,16 +3641,16 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:8")'> <OreBlock block='Metallurgy:fantasy.ore:8' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.761 * _default_ * mtlgRubraciumSize ' range=':=  _default_ * mtlgRubraciumSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.761 * _default_ * mtlgRubraciumSize ' range=':=  _default_ * mtlgRubraciumSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.579  * _default_ * mtlgRubraciumFreq ' range=':=  _default_ * mtlgRubraciumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 0.761 * _default_ * mtlgRubraciumSize ' range=':= _default_ * mtlgRubraciumSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.761 * _default_ * mtlgRubraciumSize ' range=':= _default_ * mtlgRubraciumSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.579  * _default_ * mtlgRubraciumFreq ' range=':= _default_ * mtlgRubraciumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='mtlgRubraciumHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60A1363C' drawBoundBox='false' boundBoxColor='0x60A1363C'>
                                 <Description>
                                     Single blocks, generously
@@ -3693,10 +3693,10 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:8")'> <OreBlock block='Metallurgy:fantasy.ore:8' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3 * mtlgRubraciumSize ' range=':=  _default_ * mtlgRubraciumSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2 * mtlgRubraciumFreq ' range=':=  _default_ * mtlgRubraciumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 3 * mtlgRubraciumSize ' range=':= _default_ * mtlgRubraciumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2 * mtlgRubraciumFreq ' range=':= _default_ * mtlgRubraciumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -3718,21 +3718,21 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:11")'> <OreBlock block='Metallurgy:fantasy.ore:11' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.335 * _default_ * mtlgOrichalcumFreq ' range=':=  _default_ * mtlgOrichalcumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.695 * _default_ * mtlgOrichalcumSize ' range=':=  _default_ * mtlgOrichalcumSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.695 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * mtlgOrichalcumSize ' range=':=  _default_ * mtlgOrichalcumSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.695 * _default_ * mtlgOrichalcumSize ' range=':=  _default_ * mtlgOrichalcumSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.335 * _default_ * mtlgOrichalcumFreq ' range=':= _default_ * mtlgOrichalcumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.695 * _default_ * mtlgOrichalcumSize ' range=':= _default_ * mtlgOrichalcumSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.695 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mtlgOrichalcumSize ' range=':= _default_ * mtlgOrichalcumSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.695 * _default_ * mtlgOrichalcumSize ' range=':= _default_ * mtlgOrichalcumSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -3760,16 +3760,16 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:11")'> <OreBlock block='Metallurgy:fantasy.ore:11' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.818 * _default_ * mtlgOrichalcumSize ' range=':=  _default_ * mtlgOrichalcumSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.818 * _default_ * mtlgOrichalcumSize ' range=':=  _default_ * mtlgOrichalcumSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.669  * _default_ * mtlgOrichalcumFreq ' range=':=  _default_ * mtlgOrichalcumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 0.818 * _default_ * mtlgOrichalcumSize ' range=':= _default_ * mtlgOrichalcumSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.818 * _default_ * mtlgOrichalcumSize ' range=':= _default_ * mtlgOrichalcumSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.669  * _default_ * mtlgOrichalcumFreq ' range=':= _default_ * mtlgOrichalcumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='mtlgOrichalcumHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60466432' drawBoundBox='false' boundBoxColor='0x60466432'>
                                 <Description>
                                     Single blocks, generously
@@ -3812,10 +3812,10 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:11")'> <OreBlock block='Metallurgy:fantasy.ore:11' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4 * mtlgOrichalcumSize ' range=':=  _default_ * mtlgOrichalcumSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2 * mtlgOrichalcumFreq ' range=':=  _default_ * mtlgOrichalcumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 4 * mtlgOrichalcumSize ' range=':= _default_ * mtlgOrichalcumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2 * mtlgOrichalcumFreq ' range=':= _default_ * mtlgOrichalcumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -3837,21 +3837,21 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:13")'> <OreBlock block='Metallurgy:fantasy.ore:13' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.290 * _default_ * mtlgAdamantineFreq ' range=':=  _default_ * mtlgAdamantineFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.662 * _default_ * mtlgAdamantineSize ' range=':=  _default_ * mtlgAdamantineSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.662 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * mtlgAdamantineSize ' range=':=  _default_ * mtlgAdamantineSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.662 * _default_ * mtlgAdamantineSize ' range=':=  _default_ * mtlgAdamantineSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.290 * _default_ * mtlgAdamantineFreq ' range=':= _default_ * mtlgAdamantineFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.662 * _default_ * mtlgAdamantineSize ' range=':= _default_ * mtlgAdamantineSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.662 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mtlgAdamantineSize ' range=':= _default_ * mtlgAdamantineSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.662 * _default_ * mtlgAdamantineSize ' range=':= _default_ * mtlgAdamantineSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -3879,16 +3879,16 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:13")'> <OreBlock block='Metallurgy:fantasy.ore:13' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.761 * _default_ * mtlgAdamantineSize ' range=':=  _default_ * mtlgAdamantineSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.761 * _default_ * mtlgAdamantineSize ' range=':=  _default_ * mtlgAdamantineSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.579  * _default_ * mtlgAdamantineFreq ' range=':=  _default_ * mtlgAdamantineFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 0.761 * _default_ * mtlgAdamantineSize ' range=':= _default_ * mtlgAdamantineSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.761 * _default_ * mtlgAdamantineSize ' range=':= _default_ * mtlgAdamantineSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.579  * _default_ * mtlgAdamantineFreq ' range=':= _default_ * mtlgAdamantineFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='mtlgAdamantineHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60AC0C0D' drawBoundBox='false' boundBoxColor='0x60AC0C0D'>
                                 <Description>
                                     Single blocks, generously
@@ -3931,10 +3931,10 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:13")'> <OreBlock block='Metallurgy:fantasy.ore:13' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3 * mtlgAdamantineSize ' range=':=  _default_ * mtlgAdamantineSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2 * mtlgAdamantineFreq ' range=':=  _default_ * mtlgAdamantineFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 3 * mtlgAdamantineSize ' range=':= _default_ * mtlgAdamantineSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2 * mtlgAdamantineFreq ' range=':= _default_ * mtlgAdamantineFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -3956,21 +3956,21 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:14")'> <OreBlock block='Metallurgy:fantasy.ore:14' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.290 * _default_ * mtlgAtlarusFreq ' range=':=  _default_ * mtlgAtlarusFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.662 * _default_ * mtlgAtlarusSize ' range=':=  _default_ * mtlgAtlarusSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.662 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * mtlgAtlarusSize ' range=':=  _default_ * mtlgAtlarusSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.662 * _default_ * mtlgAtlarusSize ' range=':=  _default_ * mtlgAtlarusSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.290 * _default_ * mtlgAtlarusFreq ' range=':= _default_ * mtlgAtlarusFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.662 * _default_ * mtlgAtlarusSize ' range=':= _default_ * mtlgAtlarusSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.662 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mtlgAtlarusSize ' range=':= _default_ * mtlgAtlarusSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.662 * _default_ * mtlgAtlarusSize ' range=':= _default_ * mtlgAtlarusSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -3998,16 +3998,16 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:14")'> <OreBlock block='Metallurgy:fantasy.ore:14' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.761 * _default_ * mtlgAtlarusSize ' range=':=  _default_ * mtlgAtlarusSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.761 * _default_ * mtlgAtlarusSize ' range=':=  _default_ * mtlgAtlarusSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.579  * _default_ * mtlgAtlarusFreq ' range=':=  _default_ * mtlgAtlarusFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 0.761 * _default_ * mtlgAtlarusSize ' range=':= _default_ * mtlgAtlarusSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.761 * _default_ * mtlgAtlarusSize ' range=':= _default_ * mtlgAtlarusSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.579  * _default_ * mtlgAtlarusFreq ' range=':= _default_ * mtlgAtlarusFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='mtlgAtlarusHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60C4B117' drawBoundBox='false' boundBoxColor='0x60C4B117'>
                                 <Description>
                                     Single blocks, generously
@@ -4050,10 +4050,10 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:14")'> <OreBlock block='Metallurgy:fantasy.ore:14' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3 * mtlgAtlarusSize ' range=':=  _default_ * mtlgAtlarusSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2 * mtlgAtlarusFreq ' range=':=  _default_ * mtlgAtlarusFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 3 * mtlgAtlarusSize ' range=':= _default_ * mtlgAtlarusSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2 * mtlgAtlarusFreq ' range=':= _default_ * mtlgAtlarusFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -4107,21 +4107,21 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.870 * _default_ * mtlgIgnatiusFreq ' range=':=  _default_ * mtlgIgnatiusFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.955 * _default_ * mtlgIgnatiusSize ' range=':=  _default_ * mtlgIgnatiusSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.955 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * mtlgIgnatiusSize ' range=':=  _default_ * mtlgIgnatiusSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.955 * _default_ * mtlgIgnatiusSize ' range=':=  _default_ * mtlgIgnatiusSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.870 * _default_ * mtlgIgnatiusFreq ' range=':= _default_ * mtlgIgnatiusFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.955 * _default_ * mtlgIgnatiusSize ' range=':= _default_ * mtlgIgnatiusSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.955 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mtlgIgnatiusSize ' range=':= _default_ * mtlgIgnatiusSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.955 * _default_ * mtlgIgnatiusSize ' range=':= _default_ * mtlgIgnatiusSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -4149,16 +4149,16 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.318 * _default_ * mtlgIgnatiusSize ' range=':=  _default_ * mtlgIgnatiusSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.318 * _default_ * mtlgIgnatiusSize ' range=':=  _default_ * mtlgIgnatiusSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.738  * _default_ * mtlgIgnatiusFreq ' range=':=  _default_ * mtlgIgnatiusFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 1.318 * _default_ * mtlgIgnatiusSize ' range=':= _default_ * mtlgIgnatiusSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.318 * _default_ * mtlgIgnatiusSize ' range=':= _default_ * mtlgIgnatiusSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.738  * _default_ * mtlgIgnatiusFreq ' range=':= _default_ * mtlgIgnatiusFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='mtlgIgnatiusHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60EE810A' drawBoundBox='false' boundBoxColor='0x60EE810A'>
                                 <Description>
                                     Single blocks, generously
@@ -4201,10 +4201,10 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 6 * mtlgIgnatiusSize ' range=':=  _default_ * mtlgIgnatiusSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 9 * mtlgIgnatiusFreq ' range=':=  _default_ * mtlgIgnatiusFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 6 * mtlgIgnatiusSize ' range=':= _default_ * mtlgIgnatiusSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 9 * mtlgIgnatiusFreq ' range=':= _default_ * mtlgIgnatiusFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -4226,21 +4226,21 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.768 * _default_ * mtlgShadowIronFreq ' range=':=  _default_ * mtlgShadowIronFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.916 * _default_ * mtlgShadowIronSize ' range=':=  _default_ * mtlgShadowIronSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.916 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * mtlgShadowIronSize ' range=':=  _default_ * mtlgShadowIronSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.916 * _default_ * mtlgShadowIronSize ' range=':=  _default_ * mtlgShadowIronSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.768 * _default_ * mtlgShadowIronFreq ' range=':= _default_ * mtlgShadowIronFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.916 * _default_ * mtlgShadowIronSize ' range=':= _default_ * mtlgShadowIronSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.916 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mtlgShadowIronSize ' range=':= _default_ * mtlgShadowIronSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.916 * _default_ * mtlgShadowIronSize ' range=':= _default_ * mtlgShadowIronSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -4268,16 +4268,16 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.238 * _default_ * mtlgShadowIronSize ' range=':=  _default_ * mtlgShadowIronSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.238 * _default_ * mtlgShadowIronSize ' range=':=  _default_ * mtlgShadowIronSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.533  * _default_ * mtlgShadowIronFreq ' range=':=  _default_ * mtlgShadowIronFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 1.238 * _default_ * mtlgShadowIronSize ' range=':= _default_ * mtlgShadowIronSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.238 * _default_ * mtlgShadowIronSize ' range=':= _default_ * mtlgShadowIronSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.533  * _default_ * mtlgShadowIronFreq ' range=':= _default_ * mtlgShadowIronFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='mtlgShadowIronHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60634C3F' drawBoundBox='false' boundBoxColor='0x60634C3F'>
                                 <Description>
                                     Single blocks, generously
@@ -4320,10 +4320,10 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 6 * mtlgShadowIronSize ' range=':=  _default_ * mtlgShadowIronSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 7 * mtlgShadowIronFreq ' range=':=  _default_ * mtlgShadowIronFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 6 * mtlgShadowIronSize ' range=':= _default_ * mtlgShadowIronSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 7 * mtlgShadowIronFreq ' range=':= _default_ * mtlgShadowIronFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -4345,21 +4345,21 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.711 * _default_ * mtlgLemuriteFreq ' range=':=  _default_ * mtlgLemuriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.892 * _default_ * mtlgLemuriteSize ' range=':=  _default_ * mtlgLemuriteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.892 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * mtlgLemuriteSize ' range=':=  _default_ * mtlgLemuriteSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.892 * _default_ * mtlgLemuriteSize ' range=':=  _default_ * mtlgLemuriteSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.711 * _default_ * mtlgLemuriteFreq ' range=':= _default_ * mtlgLemuriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.892 * _default_ * mtlgLemuriteSize ' range=':= _default_ * mtlgLemuriteSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.892 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mtlgLemuriteSize ' range=':= _default_ * mtlgLemuriteSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.892 * _default_ * mtlgLemuriteSize ' range=':= _default_ * mtlgLemuriteSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -4387,16 +4387,16 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.191 * _default_ * mtlgLemuriteSize ' range=':=  _default_ * mtlgLemuriteSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.191 * _default_ * mtlgLemuriteSize ' range=':=  _default_ * mtlgLemuriteSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.419  * _default_ * mtlgLemuriteFreq ' range=':=  _default_ * mtlgLemuriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 1.191 * _default_ * mtlgLemuriteSize ' range=':= _default_ * mtlgLemuriteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.191 * _default_ * mtlgLemuriteSize ' range=':= _default_ * mtlgLemuriteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.419  * _default_ * mtlgLemuriteFreq ' range=':= _default_ * mtlgLemuriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='mtlgLemuriteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60B1B1B4' drawBoundBox='false' boundBoxColor='0x60B1B1B4'>
                                 <Description>
                                     Single blocks, generously
@@ -4439,10 +4439,10 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 6 * mtlgLemuriteSize ' range=':=  _default_ * mtlgLemuriteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 6 * mtlgLemuriteFreq ' range=':=  _default_ * mtlgLemuriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 6 * mtlgLemuriteSize ' range=':= _default_ * mtlgLemuriteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 6 * mtlgLemuriteFreq ' range=':= _default_ * mtlgLemuriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -4464,21 +4464,21 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.649 * _default_ * mtlgMidasiumFreq ' range=':=  _default_ * mtlgMidasiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.866 * _default_ * mtlgMidasiumSize ' range=':=  _default_ * mtlgMidasiumSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.866 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * mtlgMidasiumSize ' range=':=  _default_ * mtlgMidasiumSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.866 * _default_ * mtlgMidasiumSize ' range=':=  _default_ * mtlgMidasiumSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.649 * _default_ * mtlgMidasiumFreq ' range=':= _default_ * mtlgMidasiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.866 * _default_ * mtlgMidasiumSize ' range=':= _default_ * mtlgMidasiumSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.866 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mtlgMidasiumSize ' range=':= _default_ * mtlgMidasiumSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.866 * _default_ * mtlgMidasiumSize ' range=':= _default_ * mtlgMidasiumSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -4506,16 +4506,16 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.138 * _default_ * mtlgMidasiumSize ' range=':=  _default_ * mtlgMidasiumSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.138 * _default_ * mtlgMidasiumSize ' range=':=  _default_ * mtlgMidasiumSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.295  * _default_ * mtlgMidasiumFreq ' range=':=  _default_ * mtlgMidasiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 1.138 * _default_ * mtlgMidasiumSize ' range=':= _default_ * mtlgMidasiumSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.138 * _default_ * mtlgMidasiumSize ' range=':= _default_ * mtlgMidasiumSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.295  * _default_ * mtlgMidasiumFreq ' range=':= _default_ * mtlgMidasiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='mtlgMidasiumHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60F6B237' drawBoundBox='false' boundBoxColor='0x60F6B237'>
                                 <Description>
                                     Single blocks, generously
@@ -4558,10 +4558,10 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 6 * mtlgMidasiumSize ' range=':=  _default_ * mtlgMidasiumSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 5 * mtlgMidasiumFreq ' range=':=  _default_ * mtlgMidasiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 6 * mtlgMidasiumSize ' range=':= _default_ * mtlgMidasiumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 5 * mtlgMidasiumFreq ' range=':= _default_ * mtlgMidasiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -4583,21 +4583,21 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.627 * _default_ * mtlgVyroxeresFreq ' range=':=  _default_ * mtlgVyroxeresFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.856 * _default_ * mtlgVyroxeresSize ' range=':=  _default_ * mtlgVyroxeresSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.856 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * mtlgVyroxeresSize ' range=':=  _default_ * mtlgVyroxeresSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.856 * _default_ * mtlgVyroxeresSize ' range=':=  _default_ * mtlgVyroxeresSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.627 * _default_ * mtlgVyroxeresFreq ' range=':= _default_ * mtlgVyroxeresFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.856 * _default_ * mtlgVyroxeresSize ' range=':= _default_ * mtlgVyroxeresSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.856 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mtlgVyroxeresSize ' range=':= _default_ * mtlgVyroxeresSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.856 * _default_ * mtlgVyroxeresSize ' range=':= _default_ * mtlgVyroxeresSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -4625,16 +4625,16 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.119 * _default_ * mtlgVyroxeresSize ' range=':=  _default_ * mtlgVyroxeresSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.119 * _default_ * mtlgVyroxeresSize ' range=':=  _default_ * mtlgVyroxeresSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.251  * _default_ * mtlgVyroxeresFreq ' range=':=  _default_ * mtlgVyroxeresFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 1.119 * _default_ * mtlgVyroxeresSize ' range=':= _default_ * mtlgVyroxeresSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.119 * _default_ * mtlgVyroxeresSize ' range=':= _default_ * mtlgVyroxeresSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.251  * _default_ * mtlgVyroxeresFreq ' range=':= _default_ * mtlgVyroxeresFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='mtlgVyroxeresHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x6057D411' drawBoundBox='false' boundBoxColor='0x6057D411'>
                                 <Description>
                                     Single blocks, generously
@@ -4677,10 +4677,10 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 7 * mtlgVyroxeresSize ' range=':=  _default_ * mtlgVyroxeresSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 4 * mtlgVyroxeresFreq ' range=':=  _default_ * mtlgVyroxeresFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 7 * mtlgVyroxeresSize ' range=':= _default_ * mtlgVyroxeresSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4 * mtlgVyroxeresFreq ' range=':= _default_ * mtlgVyroxeresFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -4702,21 +4702,21 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.474 * _default_ * mtlgCeruclaseFreq ' range=':=  _default_ * mtlgCeruclaseFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.780 * _default_ * mtlgCeruclaseSize ' range=':=  _default_ * mtlgCeruclaseSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.780 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * mtlgCeruclaseSize ' range=':=  _default_ * mtlgCeruclaseSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.780 * _default_ * mtlgCeruclaseSize ' range=':=  _default_ * mtlgCeruclaseSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.474 * _default_ * mtlgCeruclaseFreq ' range=':= _default_ * mtlgCeruclaseFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.780 * _default_ * mtlgCeruclaseSize ' range=':= _default_ * mtlgCeruclaseSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.780 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mtlgCeruclaseSize ' range=':= _default_ * mtlgCeruclaseSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.780 * _default_ * mtlgCeruclaseSize ' range=':= _default_ * mtlgCeruclaseSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -4744,16 +4744,16 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.973 * _default_ * mtlgCeruclaseSize ' range=':=  _default_ * mtlgCeruclaseSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.973 * _default_ * mtlgCeruclaseSize ' range=':=  _default_ * mtlgCeruclaseSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * mtlgCeruclaseFreq ' range=':=  _default_ * mtlgCeruclaseFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 0.973 * _default_ * mtlgCeruclaseSize ' range=':= _default_ * mtlgCeruclaseSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.973 * _default_ * mtlgCeruclaseSize ' range=':= _default_ * mtlgCeruclaseSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * mtlgCeruclaseFreq ' range=':= _default_ * mtlgCeruclaseFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='mtlgCeruclaseHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x603F869C' drawBoundBox='false' boundBoxColor='0x603F869C'>
                                 <Description>
                                     Single blocks, generously
@@ -4796,10 +4796,10 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4 * mtlgCeruclaseSize ' range=':=  _default_ * mtlgCeruclaseSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 4 * mtlgCeruclaseFreq ' range=':=  _default_ * mtlgCeruclaseFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 4 * mtlgCeruclaseSize ' range=':= _default_ * mtlgCeruclaseSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4 * mtlgCeruclaseFreq ' range=':= _default_ * mtlgCeruclaseFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -4821,21 +4821,21 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.410 * _default_ * mtlgAlduoriteFreq ' range=':=  _default_ * mtlgAlduoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.743 * _default_ * mtlgAlduoriteSize ' range=':=  _default_ * mtlgAlduoriteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.743 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * mtlgAlduoriteSize ' range=':=  _default_ * mtlgAlduoriteSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.743 * _default_ * mtlgAlduoriteSize ' range=':=  _default_ * mtlgAlduoriteSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.410 * _default_ * mtlgAlduoriteFreq ' range=':= _default_ * mtlgAlduoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.743 * _default_ * mtlgAlduoriteSize ' range=':= _default_ * mtlgAlduoriteSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.743 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mtlgAlduoriteSize ' range=':= _default_ * mtlgAlduoriteSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.743 * _default_ * mtlgAlduoriteSize ' range=':= _default_ * mtlgAlduoriteSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -4863,16 +4863,16 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.905 * _default_ * mtlgAlduoriteSize ' range=':=  _default_ * mtlgAlduoriteSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.905 * _default_ * mtlgAlduoriteSize ' range=':=  _default_ * mtlgAlduoriteSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * mtlgAlduoriteFreq ' range=':=  _default_ * mtlgAlduoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 0.905 * _default_ * mtlgAlduoriteSize ' range=':= _default_ * mtlgAlduoriteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.905 * _default_ * mtlgAlduoriteSize ' range=':= _default_ * mtlgAlduoriteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * mtlgAlduoriteFreq ' range=':= _default_ * mtlgAlduoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='mtlgAlduoriteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x609FCED2' drawBoundBox='false' boundBoxColor='0x609FCED2'>
                                 <Description>
                                     Single blocks, generously
@@ -4915,10 +4915,10 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4 * mtlgAlduoriteSize ' range=':=  _default_ * mtlgAlduoriteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 3 * mtlgAlduoriteFreq ' range=':=  _default_ * mtlgAlduoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 4 * mtlgAlduoriteSize ' range=':= _default_ * mtlgAlduoriteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 3 * mtlgAlduoriteFreq ' range=':= _default_ * mtlgAlduoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -4940,21 +4940,21 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.410 * _default_ * mtlgKalendriteFreq ' range=':=  _default_ * mtlgKalendriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.743 * _default_ * mtlgKalendriteSize ' range=':=  _default_ * mtlgKalendriteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.743 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * mtlgKalendriteSize ' range=':=  _default_ * mtlgKalendriteSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.743 * _default_ * mtlgKalendriteSize ' range=':=  _default_ * mtlgKalendriteSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.410 * _default_ * mtlgKalendriteFreq ' range=':= _default_ * mtlgKalendriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.743 * _default_ * mtlgKalendriteSize ' range=':= _default_ * mtlgKalendriteSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.743 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mtlgKalendriteSize ' range=':= _default_ * mtlgKalendriteSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.743 * _default_ * mtlgKalendriteSize ' range=':= _default_ * mtlgKalendriteSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -4982,16 +4982,16 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.905 * _default_ * mtlgKalendriteSize ' range=':=  _default_ * mtlgKalendriteSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.905 * _default_ * mtlgKalendriteSize ' range=':=  _default_ * mtlgKalendriteSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * mtlgKalendriteFreq ' range=':=  _default_ * mtlgKalendriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 0.905 * _default_ * mtlgKalendriteSize ' range=':= _default_ * mtlgKalendriteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.905 * _default_ * mtlgKalendriteSize ' range=':= _default_ * mtlgKalendriteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * mtlgKalendriteFreq ' range=':= _default_ * mtlgKalendriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='mtlgKalendriteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60AB6AB9' drawBoundBox='false' boundBoxColor='0x60AB6AB9'>
                                 <Description>
                                     Single blocks, generously
@@ -5034,10 +5034,10 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4 * mtlgKalendriteSize ' range=':=  _default_ * mtlgKalendriteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 3 * mtlgKalendriteFreq ' range=':=  _default_ * mtlgKalendriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 4 * mtlgKalendriteSize ' range=':= _default_ * mtlgKalendriteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 3 * mtlgKalendriteFreq ' range=':= _default_ * mtlgKalendriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -5059,21 +5059,21 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.290 * _default_ * mtlgVulcaniteFreq ' range=':=  _default_ * mtlgVulcaniteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.662 * _default_ * mtlgVulcaniteSize ' range=':=  _default_ * mtlgVulcaniteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.662 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * mtlgVulcaniteSize ' range=':=  _default_ * mtlgVulcaniteSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.662 * _default_ * mtlgVulcaniteSize ' range=':=  _default_ * mtlgVulcaniteSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.290 * _default_ * mtlgVulcaniteFreq ' range=':= _default_ * mtlgVulcaniteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.662 * _default_ * mtlgVulcaniteSize ' range=':= _default_ * mtlgVulcaniteSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.662 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mtlgVulcaniteSize ' range=':= _default_ * mtlgVulcaniteSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.662 * _default_ * mtlgVulcaniteSize ' range=':= _default_ * mtlgVulcaniteSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -5101,16 +5101,16 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.761 * _default_ * mtlgVulcaniteSize ' range=':=  _default_ * mtlgVulcaniteSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.761 * _default_ * mtlgVulcaniteSize ' range=':=  _default_ * mtlgVulcaniteSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.579  * _default_ * mtlgVulcaniteFreq ' range=':=  _default_ * mtlgVulcaniteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 0.761 * _default_ * mtlgVulcaniteSize ' range=':= _default_ * mtlgVulcaniteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.761 * _default_ * mtlgVulcaniteSize ' range=':= _default_ * mtlgVulcaniteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.579  * _default_ * mtlgVulcaniteFreq ' range=':= _default_ * mtlgVulcaniteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='mtlgVulcaniteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60E66922' drawBoundBox='false' boundBoxColor='0x60E66922'>
                                 <Description>
                                     Single blocks, generously
@@ -5153,10 +5153,10 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3 * mtlgVulcaniteSize ' range=':=  _default_ * mtlgVulcaniteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2 * mtlgVulcaniteFreq ' range=':=  _default_ * mtlgVulcaniteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 3 * mtlgVulcaniteSize ' range=':= _default_ * mtlgVulcaniteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2 * mtlgVulcaniteFreq ' range=':= _default_ * mtlgVulcaniteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -5178,21 +5178,21 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.290 * _default_ * mtlgSanguiniteFreq ' range=':=  _default_ * mtlgSanguiniteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.662 * _default_ * mtlgSanguiniteSize ' range=':=  _default_ * mtlgSanguiniteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.662 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * mtlgSanguiniteSize ' range=':=  _default_ * mtlgSanguiniteSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.662 * _default_ * mtlgSanguiniteSize ' range=':=  _default_ * mtlgSanguiniteSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.290 * _default_ * mtlgSanguiniteFreq ' range=':= _default_ * mtlgSanguiniteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.662 * _default_ * mtlgSanguiniteSize ' range=':= _default_ * mtlgSanguiniteSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.662 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mtlgSanguiniteSize ' range=':= _default_ * mtlgSanguiniteSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.662 * _default_ * mtlgSanguiniteSize ' range=':= _default_ * mtlgSanguiniteSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -5220,16 +5220,16 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.761 * _default_ * mtlgSanguiniteSize ' range=':=  _default_ * mtlgSanguiniteSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.761 * _default_ * mtlgSanguiniteSize ' range=':=  _default_ * mtlgSanguiniteSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.579  * _default_ * mtlgSanguiniteFreq ' range=':=  _default_ * mtlgSanguiniteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 0.761 * _default_ * mtlgSanguiniteSize ' range=':= _default_ * mtlgSanguiniteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.761 * _default_ * mtlgSanguiniteSize ' range=':= _default_ * mtlgSanguiniteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.579  * _default_ * mtlgSanguiniteFreq ' range=':= _default_ * mtlgSanguiniteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='mtlgSanguiniteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60C30506' drawBoundBox='false' boundBoxColor='0x60C30506'>
                                 <Description>
                                     Single blocks, generously
@@ -5272,10 +5272,10 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3 * mtlgSanguiniteSize ' range=':=  _default_ * mtlgSanguiniteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2 * mtlgSanguiniteFreq ' range=':=  _default_ * mtlgSanguiniteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 3 * mtlgSanguiniteSize ' range=':= _default_ * mtlgSanguiniteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2 * mtlgSanguiniteFreq ' range=':= _default_ * mtlgSanguiniteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -5329,21 +5329,21 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:ender.ore")'> <OreBlock block='Metallurgy:ender.ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.580 * _default_ * mtlgEximiteFreq ' range=':=  _default_ * mtlgEximiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.834 * _default_ * mtlgEximiteSize ' range=':=  _default_ * mtlgEximiteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.834 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * mtlgEximiteSize ' range=':=  _default_ * mtlgEximiteSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.834 * _default_ * mtlgEximiteSize ' range=':=  _default_ * mtlgEximiteSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.580 * _default_ * mtlgEximiteFreq ' range=':= _default_ * mtlgEximiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.834 * _default_ * mtlgEximiteSize ' range=':= _default_ * mtlgEximiteSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.834 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mtlgEximiteSize ' range=':= _default_ * mtlgEximiteSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.834 * _default_ * mtlgEximiteSize ' range=':= _default_ * mtlgEximiteSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -5371,16 +5371,16 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:ender.ore")'> <OreBlock block='Metallurgy:ender.ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.076 * _default_ * mtlgEximiteSize ' range=':=  _default_ * mtlgEximiteSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.076 * _default_ * mtlgEximiteSize ' range=':=  _default_ * mtlgEximiteSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.159  * _default_ * mtlgEximiteFreq ' range=':=  _default_ * mtlgEximiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 1.076 * _default_ * mtlgEximiteSize ' range=':= _default_ * mtlgEximiteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.076 * _default_ * mtlgEximiteSize ' range=':= _default_ * mtlgEximiteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.159  * _default_ * mtlgEximiteFreq ' range=':= _default_ * mtlgEximiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='mtlgEximiteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x607B5994' drawBoundBox='false' boundBoxColor='0x607B5994'>
                                 <Description>
                                     Single blocks, generously
@@ -5423,10 +5423,10 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:ender.ore")'> <OreBlock block='Metallurgy:ender.ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4 * mtlgEximiteSize ' range=':=  _default_ * mtlgEximiteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 6 * mtlgEximiteFreq ' range=':=  _default_ * mtlgEximiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 4 * mtlgEximiteSize ' range=':= _default_ * mtlgEximiteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 6 * mtlgEximiteFreq ' range=':= _default_ * mtlgEximiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -5448,21 +5448,21 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:ender.ore")'> <OreBlock block='Metallurgy:ender.ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.355 * _default_ * mtlgMeutoiteFreq ' range=':=  _default_ * mtlgMeutoiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.708 * _default_ * mtlgMeutoiteSize ' range=':=  _default_ * mtlgMeutoiteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.708 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * mtlgMeutoiteSize ' range=':=  _default_ * mtlgMeutoiteSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.708 * _default_ * mtlgMeutoiteSize ' range=':=  _default_ * mtlgMeutoiteSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.355 * _default_ * mtlgMeutoiteFreq ' range=':= _default_ * mtlgMeutoiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.708 * _default_ * mtlgMeutoiteSize ' range=':= _default_ * mtlgMeutoiteSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.708 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mtlgMeutoiteSize ' range=':= _default_ * mtlgMeutoiteSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.708 * _default_ * mtlgMeutoiteSize ' range=':= _default_ * mtlgMeutoiteSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -5490,16 +5490,16 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:ender.ore")'> <OreBlock block='Metallurgy:ender.ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.842 * _default_ * mtlgMeutoiteSize ' range=':=  _default_ * mtlgMeutoiteSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.842 * _default_ * mtlgMeutoiteSize ' range=':=  _default_ * mtlgMeutoiteSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.709  * _default_ * mtlgMeutoiteFreq ' range=':=  _default_ * mtlgMeutoiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 0.842 * _default_ * mtlgMeutoiteSize ' range=':= _default_ * mtlgMeutoiteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.842 * _default_ * mtlgMeutoiteSize ' range=':= _default_ * mtlgMeutoiteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.709  * _default_ * mtlgMeutoiteFreq ' range=':= _default_ * mtlgMeutoiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='mtlgMeutoiteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x605E5168' drawBoundBox='false' boundBoxColor='0x605E5168'>
                                 <Description>
                                     Single blocks, generously
@@ -5542,10 +5542,10 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:ender.ore")'> <OreBlock block='Metallurgy:ender.ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4 * mtlgMeutoiteSize ' range=':=  _default_ * mtlgMeutoiteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 6 * mtlgMeutoiteFreq ' range=':=  _default_ * mtlgMeutoiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 4 * mtlgMeutoiteSize ' range=':= _default_ * mtlgMeutoiteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 6 * mtlgMeutoiteFreq ' range=':= _default_ * mtlgMeutoiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>

--- a/src/main/resources/config/modules/MineChem.xml
+++ b/src/main/resources/config/modules/MineChem.xml
@@ -111,21 +111,21 @@
                             <IfCondition condition=':= ?blockExists("minechem:tile.oreUranium")'> <OreBlock block='minechem:tile.oreUranium' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.335 * _default_ * mchmUraniumFreq ' range=':=  _default_ * mchmUraniumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.695 * _default_ * mchmUraniumSize ' range=':=  _default_ * mchmUraniumSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 17.5 ' range=':=  12.5 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.695 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * mchmUraniumSize ' range=':=  _default_ * mchmUraniumSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.695 * _default_ * mchmUraniumSize ' range=':=  _default_ * mchmUraniumSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.335 * _default_ * mchmUraniumFreq ' range=':= _default_ * mchmUraniumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.695 * _default_ * mchmUraniumSize ' range=':= _default_ * mchmUraniumSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 17.5 ' range=':= 12.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.695 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mchmUraniumSize ' range=':= _default_ * mchmUraniumSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.695 * _default_ * mchmUraniumSize ' range=':= _default_ * mchmUraniumSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -153,16 +153,16 @@
                             <IfCondition condition=':= ?blockExists("minechem:tile.oreUranium")'> <OreBlock block='minechem:tile.oreUranium' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.818 * _default_ * mchmUraniumSize ' range=':=  _default_ * mchmUraniumSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.818 * _default_ * mchmUraniumSize ' range=':=  _default_ * mchmUraniumSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.669  * _default_ * mchmUraniumFreq ' range=':=  _default_ * mchmUraniumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 17.5 ' range=':=  12.5 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 0.818 * _default_ * mchmUraniumSize ' range=':= _default_ * mchmUraniumSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.818 * _default_ * mchmUraniumSize ' range=':= _default_ * mchmUraniumSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.669  * _default_ * mchmUraniumFreq ' range=':= _default_ * mchmUraniumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 17.5 ' range=':= 12.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='mchmUraniumHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60ACFE91' drawBoundBox='false' boundBoxColor='0x60ACFE91'>
                                 <Description>
                                     Single blocks, generously
@@ -205,10 +205,10 @@
                             <IfCondition condition=':= ?blockExists("minechem:tile.oreUranium")'> <OreBlock block='minechem:tile.oreUranium' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4 * mchmUraniumSize ' range=':=  _default_ * mchmUraniumSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2 * mchmUraniumFreq ' range=':=  _default_ * mchmUraniumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 17.5 ' range=':=  12.5 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 4 * mchmUraniumSize ' range=':= _default_ * mchmUraniumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2 * mchmUraniumFreq ' range=':= _default_ * mchmUraniumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 17.5 ' range=':= 12.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>

--- a/src/main/resources/config/modules/MinecraftComesAlive.xml
+++ b/src/main/resources/config/modules/MinecraftComesAlive.xml
@@ -113,21 +113,21 @@
                             <IfCondition condition=':= ?blockExists("MCA:tile.roseGoldOre")'> <OreBlock block='MCA:tile.roseGoldOre' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.649 * _default_ * mccaRoseGoldFreq ' range=':=  _default_ * mccaRoseGoldFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.866 * _default_ * mccaRoseGoldSize ' range=':=  _default_ * mccaRoseGoldSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 26 ' range=':=  14 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.866 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * mccaRoseGoldSize ' range=':=  _default_ * mccaRoseGoldSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.866 * _default_ * mccaRoseGoldSize ' range=':=  _default_ * mccaRoseGoldSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.649 * _default_ * mccaRoseGoldFreq ' range=':= _default_ * mccaRoseGoldFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.866 * _default_ * mccaRoseGoldSize ' range=':= _default_ * mccaRoseGoldSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 26 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.866 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * mccaRoseGoldSize ' range=':= _default_ * mccaRoseGoldSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.866 * _default_ * mccaRoseGoldSize ' range=':= _default_ * mccaRoseGoldSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -155,16 +155,16 @@
                             <IfCondition condition=':= ?blockExists("MCA:tile.roseGoldOre")'> <OreBlock block='MCA:tile.roseGoldOre' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.138 * _default_ * mccaRoseGoldSize ' range=':=  _default_ * mccaRoseGoldSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.138 * _default_ * mccaRoseGoldSize ' range=':=  _default_ * mccaRoseGoldSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.295  * _default_ * mccaRoseGoldFreq ' range=':=  _default_ * mccaRoseGoldFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 26 ' range=':=  14 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 1.138 * _default_ * mccaRoseGoldSize ' range=':= _default_ * mccaRoseGoldSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.138 * _default_ * mccaRoseGoldSize ' range=':= _default_ * mccaRoseGoldSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.295  * _default_ * mccaRoseGoldFreq ' range=':= _default_ * mccaRoseGoldFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 26 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='mccaRoseGoldHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FFDDA2' drawBoundBox='false' boundBoxColor='0x60FFDDA2'>
                                 <Description>
                                     Single blocks, generously
@@ -207,10 +207,10 @@
                             <IfCondition condition=':= ?blockExists("MCA:tile.roseGoldOre")'> <OreBlock block='MCA:tile.roseGoldOre' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 6 * mccaRoseGoldSize ' range=':=  _default_ * mccaRoseGoldSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 5 * mccaRoseGoldFreq ' range=':=  _default_ * mccaRoseGoldFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 26 ' range=':=  14 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 6 * mccaRoseGoldSize ' range=':= _default_ * mccaRoseGoldSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 5 * mccaRoseGoldFreq ' range=':= _default_ * mccaRoseGoldFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 26 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>

--- a/src/main/resources/config/modules/PamsHarvestCraft.xml
+++ b/src/main/resources/config/modules/PamsHarvestCraft.xml
@@ -116,21 +116,21 @@
                             <IfCondition condition=':= ?blockExists("harvestcraft:salt")'> <OreBlock block='harvestcraft:salt' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 4.287 * _default_ * hvstSaltFreq ' range=':=  _default_ * hvstSaltFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.625 * _default_ * hvstSaltSize ' range=':=  _default_ * hvstSaltSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.625 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * hvstSaltSize ' range=':=  _default_ * hvstSaltSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.625 * _default_ * hvstSaltSize ' range=':=  _default_ * hvstSaltSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 4.287 * _default_ * hvstSaltFreq ' range=':= _default_ * hvstSaltFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.625 * _default_ * hvstSaltSize ' range=':= _default_ * hvstSaltSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.625 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * hvstSaltSize ' range=':= _default_ * hvstSaltSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.625 * _default_ * hvstSaltSize ' range=':= _default_ * hvstSaltSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -158,16 +158,16 @@
                             <IfCondition condition=':= ?blockExists("harvestcraft:salt")'> <OreBlock block='harvestcraft:salt' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.702 * _default_ * hvstSaltSize ' range=':=  _default_ * hvstSaltSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.702 * _default_ * hvstSaltSize ' range=':=  _default_ * hvstSaltSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 2.896  * _default_ * hvstSaltFreq ' range=':=  _default_ * hvstSaltFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 1.702 * _default_ * hvstSaltSize ' range=':= _default_ * hvstSaltSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.702 * _default_ * hvstSaltSize ' range=':= _default_ * hvstSaltSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 2.896  * _default_ * hvstSaltFreq ' range=':= _default_ * hvstSaltFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='hvstSaltHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x6090927C' drawBoundBox='false' boundBoxColor='0x6090927C'>
                                 <Description>
                                     Single blocks, generously
@@ -210,10 +210,10 @@
                             <IfCondition condition=':= ?blockExists("harvestcraft:salt")'> <OreBlock block='harvestcraft:salt' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 5 * hvstSaltSize ' range=':=  _default_ * hvstSaltSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 30 * hvstSaltFreq ' range=':=  _default_ * hvstSaltFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 5 * hvstSaltSize ' range=':= _default_ * hvstSaltSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 30 * hvstSaltFreq ' range=':= _default_ * hvstSaltFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>

--- a/src/main/resources/config/modules/ProjectRed.xml
+++ b/src/main/resources/config/modules/ProjectRed.xml
@@ -355,21 +355,21 @@
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * predRubyFreq ' range=':=  _default_ * predRubyFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * predRubySize ' range=':=  _default_ * predRubySize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 16 ' range=':=  4 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * predRubySize ' range=':=  _default_ * predRubySize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * predRubySize ' range=':=  _default_ * predRubySize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * predRubyFreq ' range=':= _default_ * predRubyFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * predRubySize ' range=':= _default_ * predRubySize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 16 ' range=':= 4 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * predRubySize ' range=':= _default_ * predRubySize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * predRubySize ' range=':= _default_ * predRubySize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
 
                         <!-- Configuring contained material. -->
@@ -377,8 +377,8 @@
                             <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore")'> <Replaces block='ProjRed|Exploration:projectred.exploration.ore' weight='1.0' /> </IfCondition>
-                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * predRubySize  * 0.5 ' range=':=  _default_ * predRubySize  * 0.5 ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * predRubySize  * 0.5 ' range=':=  _default_ * predRubySize  * 0.5 ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * predRubySize  * 0.5 ' range=':= _default_ * predRubySize  * 0.5 ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * predRubySize  * 0.5 ' range=':= _default_ * predRubySize  * 0.5 ' type='normal' />
                             <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
                         </Veins>
                     </IfCondition>
@@ -407,16 +407,16 @@
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.486 * _default_ * predRubySize ' range=':=  _default_ * predRubySize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.486 * _default_ * predRubySize ' range=':=  _default_ * predRubySize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.236  * _default_ * predRubyFreq ' range=':=  _default_ * predRubyFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 16 ' range=':=  4 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 0.486 * _default_ * predRubySize ' range=':= _default_ * predRubySize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.486 * _default_ * predRubySize ' range=':= _default_ * predRubySize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.236  * _default_ * predRubyFreq ' range=':= _default_ * predRubyFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 16 ' range=':= 4 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='predRubyHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60900113' drawBoundBox='false' boundBoxColor='0x60900113'>
                                 <Description>
                                     Single blocks, generously
@@ -459,10 +459,10 @@
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 1 * predRubySize ' range=':=  _default_ * predRubySize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1 * predRubyFreq ' range=':=  _default_ * predRubyFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 16 ' range=':=  4 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 1 * predRubySize ' range=':= _default_ * predRubySize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1 * predRubyFreq ' range=':= _default_ * predRubyFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 16 ' range=':= 4 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -484,21 +484,21 @@
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:1")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:1' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * predSapphireFreq ' range=':=  _default_ * predSapphireFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * predSapphireSize ' range=':=  _default_ * predSapphireSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 16 ' range=':=  4 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * predSapphireSize ' range=':=  _default_ * predSapphireSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * predSapphireSize ' range=':=  _default_ * predSapphireSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * predSapphireFreq ' range=':= _default_ * predSapphireFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * predSapphireSize ' range=':= _default_ * predSapphireSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 16 ' range=':= 4 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * predSapphireSize ' range=':= _default_ * predSapphireSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * predSapphireSize ' range=':= _default_ * predSapphireSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
 
                         <!-- Configuring contained material. -->
@@ -506,8 +506,8 @@
                             <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:1")'> <Replaces block='ProjRed|Exploration:projectred.exploration.ore:1' weight='1.0' /> </IfCondition>
-                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * predSapphireSize  * 0.5 ' range=':=  _default_ * predSapphireSize  * 0.5 ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * predSapphireSize  * 0.5 ' range=':=  _default_ * predSapphireSize  * 0.5 ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * predSapphireSize  * 0.5 ' range=':= _default_ * predSapphireSize  * 0.5 ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * predSapphireSize  * 0.5 ' range=':= _default_ * predSapphireSize  * 0.5 ' type='normal' />
                             <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
                         </Veins>
                     </IfCondition>
@@ -536,16 +536,16 @@
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:1")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:1' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.486 * _default_ * predSapphireSize ' range=':=  _default_ * predSapphireSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.486 * _default_ * predSapphireSize ' range=':=  _default_ * predSapphireSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.236  * _default_ * predSapphireFreq ' range=':=  _default_ * predSapphireFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 16 ' range=':=  4 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 0.486 * _default_ * predSapphireSize ' range=':= _default_ * predSapphireSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.486 * _default_ * predSapphireSize ' range=':= _default_ * predSapphireSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.236  * _default_ * predSapphireFreq ' range=':= _default_ * predSapphireFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 16 ' range=':= 4 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='predSapphireHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x600011C8' drawBoundBox='false' boundBoxColor='0x600011C8'>
                                 <Description>
                                     Single blocks, generously
@@ -588,10 +588,10 @@
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:1")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:1' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 1 * predSapphireSize ' range=':=  _default_ * predSapphireSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1 * predSapphireFreq ' range=':=  _default_ * predSapphireFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 16 ' range=':=  4 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 1 * predSapphireSize ' range=':= _default_ * predSapphireSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1 * predSapphireFreq ' range=':= _default_ * predSapphireFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 16 ' range=':= 4 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -613,21 +613,21 @@
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:2")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:2' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * predPeridotFreq ' range=':=  _default_ * predPeridotFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * predPeridotSize ' range=':=  _default_ * predPeridotSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 22 ' range=':=  6 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * predPeridotSize ' range=':=  _default_ * predPeridotSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * predPeridotSize ' range=':=  _default_ * predPeridotSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * predPeridotFreq ' range=':= _default_ * predPeridotFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * predPeridotSize ' range=':= _default_ * predPeridotSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 22 ' range=':= 6 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * predPeridotSize ' range=':= _default_ * predPeridotSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * predPeridotSize ' range=':= _default_ * predPeridotSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
 
                         <!-- Configuring contained material. -->
@@ -635,8 +635,8 @@
                             <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:2")'> <Replaces block='ProjRed|Exploration:projectred.exploration.ore:2' weight='1.0' /> </IfCondition>
-                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * predPeridotSize  * 0.5 ' range=':=  _default_ * predPeridotSize  * 0.5 ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * predPeridotSize  * 0.5 ' range=':=  _default_ * predPeridotSize  * 0.5 ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * predPeridotSize  * 0.5 ' range=':= _default_ * predPeridotSize  * 0.5 ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * predPeridotSize  * 0.5 ' range=':= _default_ * predPeridotSize  * 0.5 ' type='normal' />
                             <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
                         </Veins>
                     </IfCondition>
@@ -665,16 +665,16 @@
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:2")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:2' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.486 * _default_ * predPeridotSize ' range=':=  _default_ * predPeridotSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.486 * _default_ * predPeridotSize ' range=':=  _default_ * predPeridotSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.236  * _default_ * predPeridotFreq ' range=':=  _default_ * predPeridotFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 22 ' range=':=  6 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 0.486 * _default_ * predPeridotSize ' range=':= _default_ * predPeridotSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.486 * _default_ * predPeridotSize ' range=':= _default_ * predPeridotSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.236  * _default_ * predPeridotFreq ' range=':= _default_ * predPeridotFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 22 ' range=':= 6 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='predPeridotHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60057529' drawBoundBox='false' boundBoxColor='0x60057529'>
                                 <Description>
                                     Single blocks, generously
@@ -717,10 +717,10 @@
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:2")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:2' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 1 * predPeridotSize ' range=':=  _default_ * predPeridotSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1 * predPeridotFreq ' range=':=  _default_ * predPeridotFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 22 ' range=':=  6 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 1 * predPeridotSize ' range=':= _default_ * predPeridotSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1 * predPeridotFreq ' range=':= _default_ * predPeridotFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 22 ' range=':= 6 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -742,21 +742,21 @@
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:3")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:3' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.948 * _default_ * predCopperFreq ' range=':=  _default_ * predCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.982 * _default_ * predCopperSize ' range=':=  _default_ * predCopperSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 35 ' range=':=  29 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.982 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * predCopperSize ' range=':=  _default_ * predCopperSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.982 * _default_ * predCopperSize ' range=':=  _default_ * predCopperSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.948 * _default_ * predCopperFreq ' range=':= _default_ * predCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.982 * _default_ * predCopperSize ' range=':= _default_ * predCopperSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 35 ' range=':= 29 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.982 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * predCopperSize ' range=':= _default_ * predCopperSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.982 * _default_ * predCopperSize ' range=':= _default_ * predCopperSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -784,16 +784,16 @@
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:3")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:3' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.375 * _default_ * predCopperSize ' range=':=  _default_ * predCopperSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.375 * _default_ * predCopperSize ' range=':=  _default_ * predCopperSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.892  * _default_ * predCopperFreq ' range=':=  _default_ * predCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 35 ' range=':=  29 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 1.375 * _default_ * predCopperSize ' range=':= _default_ * predCopperSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.375 * _default_ * predCopperSize ' range=':= _default_ * predCopperSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.892  * _default_ * predCopperFreq ' range=':= _default_ * predCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 35 ' range=':= 29 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='predCopperHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
                                 <Description>
                                     Single blocks, generously
@@ -836,10 +836,10 @@
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:3")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:3' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 8 * predCopperSize ' range=':=  _default_ * predCopperSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 8 * predCopperFreq ' range=':=  _default_ * predCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 35 ' range=':=  29 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 8 * predCopperSize ' range=':= _default_ * predCopperSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 8 * predCopperFreq ' range=':= _default_ * predCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 35 ' range=':= 29 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -861,21 +861,21 @@
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:4")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:4' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.749 * _default_ * predTinFreq ' range=':=  _default_ * predTinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.908 * _default_ * predTinSize ' range=':=  _default_ * predTinSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 27 ' range=':=  21 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.908 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * predTinSize ' range=':=  _default_ * predTinSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.908 * _default_ * predTinSize ' range=':=  _default_ * predTinSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.749 * _default_ * predTinFreq ' range=':= _default_ * predTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.908 * _default_ * predTinSize ' range=':= _default_ * predTinSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 27 ' range=':= 21 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.908 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * predTinSize ' range=':= _default_ * predTinSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.908 * _default_ * predTinSize ' range=':= _default_ * predTinSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -903,16 +903,16 @@
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:4")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:4' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.223 * _default_ * predTinSize ' range=':=  _default_ * predTinSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.223 * _default_ * predTinSize ' range=':=  _default_ * predTinSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.496  * _default_ * predTinFreq ' range=':=  _default_ * predTinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 27 ' range=':=  21 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 1.223 * _default_ * predTinSize ' range=':= _default_ * predTinSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.223 * _default_ * predTinSize ' range=':= _default_ * predTinSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.496  * _default_ * predTinFreq ' range=':= _default_ * predTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 27 ' range=':= 21 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='predTinHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60E8E8E8'>
                                 <Description>
                                     Single blocks, generously
@@ -955,10 +955,10 @@
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:4")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:4' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 8 * predTinSize ' range=':=  _default_ * predTinSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 5 * predTinFreq ' range=':=  _default_ * predTinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 27 ' range=':=  21 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 8 * predTinSize ' range=':= _default_ * predTinSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 5 * predTinFreq ' range=':= _default_ * predTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 27 ' range=':= 21 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -980,21 +980,21 @@
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:5")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:5' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.237 * _default_ * predSilverFreq ' range=':=  _default_ * predSilverFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.619 * _default_ * predSilverSize ' range=':=  _default_ * predSilverSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.619 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * predSilverSize ' range=':=  _default_ * predSilverSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.619 * _default_ * predSilverSize ' range=':=  _default_ * predSilverSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.237 * _default_ * predSilverFreq ' range=':= _default_ * predSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.619 * _default_ * predSilverSize ' range=':= _default_ * predSilverSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.619 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * predSilverSize ' range=':= _default_ * predSilverSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.619 * _default_ * predSilverSize ' range=':= _default_ * predSilverSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -1022,16 +1022,16 @@
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:5")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:5' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.688 * _default_ * predSilverSize ' range=':=  _default_ * predSilverSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.688 * _default_ * predSilverSize ' range=':=  _default_ * predSilverSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.473  * _default_ * predSilverFreq ' range=':=  _default_ * predSilverFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 0.688 * _default_ * predSilverSize ' range=':= _default_ * predSilverSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.688 * _default_ * predSilverSize ' range=':= _default_ * predSilverSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.473  * _default_ * predSilverFreq ' range=':= _default_ * predSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='predSilverHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60E3F2F7' drawBoundBox='false' boundBoxColor='0x60E3F2F7'>
                                 <Description>
                                     Single blocks, generously
@@ -1074,10 +1074,10 @@
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:5")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:5' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4 * predSilverSize ' range=':=  _default_ * predSilverSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1 * predSilverFreq ' range=':=  _default_ * predSilverFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 19 ' range=':=  13 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 4 * predSilverSize ' range=':= _default_ * predSilverSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1 * predSilverFreq ' range=':= _default_ * predSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -1099,21 +1099,21 @@
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:6")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:6' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.878 * _default_ * predElectrotineFreq ' range=':=  _default_ * predElectrotineFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.958 * _default_ * predElectrotineSize ' range=':=  _default_ * predElectrotineSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 11 ' range=':=  5 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= -_default_ ' range=':=  -_default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.958 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * predElectrotineSize ' range=':=  _default_ * predElectrotineSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.958 * _default_ * predElectrotineSize ' range=':=  _default_ * predElectrotineSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.878 * _default_ * predElectrotineFreq ' range=':= _default_ * predElectrotineFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.958 * _default_ * predElectrotineSize ' range=':= _default_ * predElectrotineSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 11 ' range=':= 5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= -_default_ ' range=':= -_default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.958 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * predElectrotineSize ' range=':= _default_ * predElectrotineSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.958 * _default_ * predElectrotineSize ' range=':= _default_ * predElectrotineSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -1141,16 +1141,16 @@
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:6")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:6' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.973 * _default_ * predElectrotineSize ' range=':=  _default_ * predElectrotineSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.973 * _default_ * predElectrotineSize ' range=':=  _default_ * predElectrotineSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * predElectrotineFreq ' range=':=  _default_ * predElectrotineFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 11 ' range=':=  5 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 0.973 * _default_ * predElectrotineSize ' range=':= _default_ * predElectrotineSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.973 * _default_ * predElectrotineSize ' range=':= _default_ * predElectrotineSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * predElectrotineFreq ' range=':= _default_ * predElectrotineFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 11 ' range=':= 5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='predElectrotineHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x6001FFFC' drawBoundBox='false' boundBoxColor='0x6001FFFC'>
                                 <Description>
                                     Single blocks, generously
@@ -1193,10 +1193,10 @@
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:6")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:6' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 8 * predElectrotineSize ' range=':=  _default_ * predElectrotineSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2 * predElectrotineFreq ' range=':=  _default_ * predElectrotineFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 11 ' range=':=  5 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 8 * predElectrotineSize ' range=':= _default_ * predElectrotineSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2 * predElectrotineFreq ' range=':= _default_ * predElectrotineFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 11 ' range=':= 5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -1218,21 +1218,21 @@
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.stone")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.stone' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.474 * _default_ * predMarbleFreq ' range=':=  _default_ * predMarbleFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.780 * _default_ * predMarbleSize ' range=':=  _default_ * predMarbleSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 48 ' range=':=  16 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.780 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * predMarbleSize ' range=':=  _default_ * predMarbleSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.780 * _default_ * predMarbleSize ' range=':=  _default_ * predMarbleSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.474 * _default_ * predMarbleFreq ' range=':= _default_ * predMarbleFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.780 * _default_ * predMarbleSize ' range=':= _default_ * predMarbleSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 48 ' range=':= 16 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.780 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * predMarbleSize ' range=':= _default_ * predMarbleSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.780 * _default_ * predMarbleSize ' range=':= _default_ * predMarbleSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -1260,16 +1260,16 @@
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.stone")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.stone' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.973 * _default_ * predMarbleSize ' range=':=  _default_ * predMarbleSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.973 * _default_ * predMarbleSize ' range=':=  _default_ * predMarbleSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * predMarbleFreq ' range=':=  _default_ * predMarbleFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 48 ' range=':=  16 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 0.973 * _default_ * predMarbleSize ' range=':= _default_ * predMarbleSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.973 * _default_ * predMarbleSize ' range=':= _default_ * predMarbleSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * predMarbleFreq ' range=':= _default_ * predMarbleFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 48 ' range=':= 16 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='predMarbleHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FFFFFF' drawBoundBox='false' boundBoxColor='0x60FFFFFF'>
                                 <Description>
                                     Single blocks, generously
@@ -1312,10 +1312,10 @@
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.stone")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.stone' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 16 * predMarbleSize ' range=':=  _default_ * predMarbleSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1 * predMarbleFreq ' range=':=  _default_ * predMarbleFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 48 ' range=':=  16 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 16 * predMarbleSize ' range=':= _default_ * predMarbleSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1 * predMarbleFreq ' range=':= _default_ * predMarbleFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 48 ' range=':= 16 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>

--- a/src/main/resources/config/modules/RailCraft.xml
+++ b/src/main/resources/config/modules/RailCraft.xml
@@ -1,7 +1,7 @@
 <!-- =================================================================
      Custom Ore Generation "RailCraft" Module: This configuration
-     covers poor iron, poor gold, poor copper, poor tin, poor lead,
-     saltpeter, firestone, sulfur, and abyssal ores.
+     covers abyssal ores, poor iron, poor gold, poor copper, poor tin,
+     poor lead, saltpeter, firestone, and sulfur.
      ================================================================= -->
 
 
@@ -31,6 +31,30 @@
                 <Choice value=':= ?true' displayValue='Yes' description='Use Custom Ore Generation to handle RailCraft ores.'/>
                 <Choice value=':= ?false' displayValue='No' description='RailCraft ores will be handled by the mod itself.'/>
             </OptionChoice>
+
+            <!-- Abyssal Ores Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='rlcrAbyssalOresDist'  displayState=':= if(?enableRailCraft, "shown", "hidden")' displayGroup='groupRailCraft'>
+                    <Description> Controls how Abyssal Ores is generated </Description>
+                    <DisplayName>RailCraft Abyssal Ores</DisplayName>
+                    <Choice value='Geode' displayValue='Geode'>
+                        <Description>
+                            Multi-layered deposit in a spherical shape.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Abyssal Ores is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='rlcrAbyssalOresFreq' default='1'  min='0' max='5' displayState=':= if(?enableRailCraft, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupRailCraft'>
+                    <Description> Frequency multiplier for RailCraft Abyssal Ores distributions </Description>
+                    <DisplayName>RailCraft Abyssal Ores Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='rlcrAbyssalOresSize' default='1'  min='0' max='5' displayState=':= if(?enableRailCraft, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupRailCraft'>
+                    <Description> Size multiplier for RailCraft Abyssal Ores distributions </Description>
+                    <DisplayName>RailCraft Abyssal Ores Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Abyssal Ores Configuration UI Complete -->
+
 
             <!-- Poor Iron Configuration UI Starting -->
             <ConfigSection>
@@ -303,30 +327,6 @@
             </ConfigSection>
             <!-- Sulfur Configuration UI Complete -->
 
-
-            <!-- Abyssal Ores Configuration UI Starting -->
-            <ConfigSection>
-                <OptionChoice name='rlcrAbyssalOresDist'  displayState=':= if(?enableRailCraft, "shown", "hidden")' displayGroup='groupRailCraft'>
-                    <Description> Controls how Abyssal Ores is generated </Description>
-                    <DisplayName>RailCraft Abyssal Ores</DisplayName>
-                    <Choice value='Geode' displayValue='Geode'>
-                        <Description>
-                            Multi-layered deposit in a spherical shape.
-                        </Description>
-                    </Choice>
-                    <Choice value='none' displayValue='None' description='Abyssal Ores is not generated in the world.'/>
-                </OptionChoice>
-                <OptionNumeric name='rlcrAbyssalOresFreq' default='1'  min='0' max='5' displayState=':= if(?enableRailCraft, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupRailCraft'>
-                    <Description> Frequency multiplier for RailCraft Abyssal Ores distributions </Description>
-                    <DisplayName>RailCraft Abyssal Ores Freq.</DisplayName>
-                </OptionNumeric>
-                <OptionNumeric name='rlcrAbyssalOresSize' default='1'  min='0' max='5' displayState=':= if(?enableRailCraft, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupRailCraft'>
-                    <Description> Size multiplier for RailCraft Abyssal Ores distributions </Description>
-                    <DisplayName>RailCraft Abyssal Ores Size</DisplayName>
-                </OptionNumeric>
-            </ConfigSection>
-            <!-- Abyssal Ores Configuration UI Complete -->
-
         </ConfigSection>
         <!-- Setup Screen Complete -->
 
@@ -342,7 +342,7 @@
                 <!-- Starting Original "Overworld" Block Removal -->
 
                 <IfCondition condition=':= ?blockExists("minecraft:sand")'>
-                    <Substitute name='rlcrOverworldBlockSubstitute0' block='minecraft:sand'>
+                    <Substitute name='rlcrOverworldBlockSubstitute4' block='minecraft:sand'>
                         <Description>
                             Replace vanilla-generated ore clusters.
                         </Description>
@@ -357,7 +357,7 @@
 
 
                 <IfCondition condition=':= ?blockExists("minecraft:stone")'>
-                    <Substitute name='rlcrOverworldBlockSubstitute2' block='minecraft:stone'>
+                    <Substitute name='rlcrOverworldBlockSubstitute6' block='minecraft:stone'>
                         <Description>
                             Replace vanilla-generated ore clusters.
                         </Description>
@@ -373,7 +373,6 @@
                         <IfCondition condition=':= ?blockExists("Railcraft:ore:2")'> <Replaces block='Railcraft:ore:2' weight='1.0' /> </IfCondition>
                         <IfCondition condition=':= ?blockExists("Railcraft:ore:3")'> <Replaces block='Railcraft:ore:3' weight='1.0' /> </IfCondition>
                         <IfCondition condition=':= ?blockExists("Railcraft:ore:4")'> <Replaces block='Railcraft:ore:4' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("Railcraft:ore:5")'> <Replaces block='Railcraft:ore:5' weight='1.0' /> </IfCondition>
                         <IfCondition condition=':= ?blockExists("Railcraft:ore:7")'> <Replaces block='Railcraft:ore:7' weight='1.0' /> </IfCondition>
                         <IfCondition condition=':= ?blockExists("Railcraft:ore:8")'> <Replaces block='Railcraft:ore:8' weight='1.0' /> </IfCondition>
                         <IfCondition condition=':= ?blockExists("Railcraft:ore:9")'> <Replaces block='Railcraft:ore:9' weight='1.0' /> </IfCondition>
@@ -383,6 +382,94 @@
                 <!-- Original "Overworld" Block Removal Complete -->
 
                 <!-- Adding blocks -->
+
+                <!-- Begin Abyssal Ores Generation -->
+
+                <!-- Starting Geode Preset for Abyssal Ores. -->
+                <ConfigSection>
+                    <IfCondition condition=':= rlcrAbyssalOresDist = "Geode"'>
+                        <Veins name='rlcrAbyssalOresGeodeShell'  inherits='PresetSmallDeposits' seed='0x9668' drawWireframe='true' wireframeColor='0x60000000' drawBoundBox='false' boundBoxColor='0x60000000'>
+                            <Description>
+                                Multi-layered deposit.  On the
+                                outside is a shell, usually made  of
+                                some form of stone.  Within  this
+                                shell is sprinkled ores.  Inside both
+                                is an air pocket from  which the
+                                enterprising miner can  look for the
+                                contained ores.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Railcraft:cube:6")'> <OreBlock block='Railcraft:cube:6' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:sand")'> <Replaces block='minecraft:sand' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:lava")'> <Replaces block='minecraft:lava' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:water")'> <Replaces block='minecraft:water' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:air")'> <Replaces block='minecraft:air' weight='1.0' /> </IfCondition>
+                            <Biome name='Ocean'  />
+                            <Biome name='Deep Ocean'  />
+                            <Setting name='MotherlodeFrequency' avg=':= _default_ * 0.5 * rlcrAbyssalOresFreq ' range=':= _default_ * rlcrAbyssalOresFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= _default_ * 6  * rlcrAbyssalOresSize ' range=':= _default_ * 6 * rlcrAbyssalOresSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 30 ' range=':= 10 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                        </Veins>
+                        <Veins name='rlcrAbyssalOresGeodeOre'  inherits='rlcrAbyssalOresGeodeShell' seed='0x9668' drawWireframe='true' wireframeColor='0x60000000' drawBoundBox='false' boundBoxColor='0x60000000'>
+                            <Description>
+                                Multi-layered deposit.  On the
+                                outside is a shell, usually made  of
+                                some form of stone.  Within  this
+                                shell is sprinkled ores.  Inside both
+                                is an air pocket from  which the
+                                enterprising miner can  look for the
+                                contained ores.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Railcraft:ore:2")'> <OreBlock block='Railcraft:ore:2' weight='0.0167' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("Railcraft:ore:3")'> <OreBlock block='Railcraft:ore:3' weight='0.0167' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("Railcraft:ore:4")'> <OreBlock block='Railcraft:ore:4' weight='0.05' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:sand")'> <Replaces block='minecraft:sand' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:lava")'> <Replaces block='minecraft:lava' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:water")'> <Replaces block='minecraft:water' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:air")'> <Replaces block='minecraft:air' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("Railcraft:cube:6")'> <Replaces block='Railcraft:cube:6' weight='1.0' /> </IfCondition>
+                            <Setting name='MotherlodeSize' avg=':= _default_ * 0.5' range=':= _default_ * 0.5' type='uniform' />
+                        </Veins>
+                        <Veins name='rlcrAbyssalOresGeodeBubble'  inherits='rlcrAbyssalOresGeodeOre' seed='0x9668' drawWireframe='true' wireframeColor='0x60000000' drawBoundBox='false' boundBoxColor='0x60000000'>
+                            <Description>
+                                Multi-layered deposit.  On the
+                                outside is a shell, usually made  of
+                                some form of stone.  Within  this
+                                shell is sprinkled ores.  Inside both
+                                is an air pocket from  which the
+                                enterprising miner can  look for the
+                                contained ores.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("minecraft:air")'> <OreBlock block='minecraft:air' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("Railcraft:cube:6")'> <Replaces block='Railcraft:cube:6' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("Railcraft:ore:2")'> <Replaces block='Railcraft:ore:2' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("Railcraft:ore:3")'> <Replaces block='Railcraft:ore:3' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("Railcraft:ore:4")'> <Replaces block='Railcraft:ore:4' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:sand")'> <Replaces block='minecraft:sand' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:lava")'> <Replaces block='minecraft:lava' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:water")'> <Replaces block='minecraft:water' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:air")'> <Replaces block='minecraft:air' weight='1.0' /> </IfCondition>
+                            <Setting name='MotherlodeSize' avg=':= _default_ * 0.5' range=':= _default_ * 0.5' type='uniform' />
+                        </Veins>
+
+                        <!-- Beginning "Preferred" configuration. -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Geode Preset for Abyssal Ores is complete. -->
+
+                <!-- End Abyssal Ores Generation -->
+
 
                 <!-- Begin Poor Iron Generation -->
 
@@ -404,21 +491,21 @@
                             <IfCondition condition=':= ?blockExists("Railcraft:ore:7")'> <OreBlock block='Railcraft:ore:7' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 7.921 * _default_ * rlcrPoorIronFreq ' range=':=  _default_ * rlcrPoorIronFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.993 * _default_ * rlcrPoorIronSize ' range=':=  _default_ * rlcrPoorIronSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 40 ' range=':=  4 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.993 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * rlcrPoorIronSize ' range=':=  _default_ * rlcrPoorIronSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.993 * _default_ * rlcrPoorIronSize ' range=':=  _default_ * rlcrPoorIronSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 7.921 * _default_ * rlcrPoorIronFreq ' range=':= _default_ * rlcrPoorIronFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.993 * _default_ * rlcrPoorIronSize ' range=':= _default_ * rlcrPoorIronSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 40 ' range=':= 4 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.993 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * rlcrPoorIronSize ' range=':= _default_ * rlcrPoorIronSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.993 * _default_ * rlcrPoorIronSize ' range=':= _default_ * rlcrPoorIronSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -446,16 +533,16 @@
                             <IfCondition condition=':= ?blockExists("Railcraft:ore:7")'> <OreBlock block='Railcraft:ore:7' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 2.313 * _default_ * rlcrPoorIronSize ' range=':=  _default_ * rlcrPoorIronSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 2.313 * _default_ * rlcrPoorIronSize ' range=':=  _default_ * rlcrPoorIronSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 5.351  * _default_ * rlcrPoorIronFreq ' range=':=  _default_ * rlcrPoorIronFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 40 ' range=':=  4 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 2.313 * _default_ * rlcrPoorIronSize ' range=':= _default_ * rlcrPoorIronSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 2.313 * _default_ * rlcrPoorIronSize ' range=':= _default_ * rlcrPoorIronSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 5.351  * _default_ * rlcrPoorIronFreq ' range=':= _default_ * rlcrPoorIronFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 40 ' range=':= 4 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='rlcrPoorIronHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60DDC2AF' drawBoundBox='false' boundBoxColor='0x60DDC2AF'>
                                 <Description>
                                     Single blocks, generously
@@ -498,10 +585,10 @@
                             <IfCondition condition=':= ?blockExists("Railcraft:ore:7")'> <OreBlock block='Railcraft:ore:7' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 16 * rlcrPoorIronSize ' range=':=  _default_ * rlcrPoorIronSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 32 * rlcrPoorIronFreq ' range=':=  _default_ * rlcrPoorIronFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 40 ' range=':=  4 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 16 * rlcrPoorIronSize ' range=':= _default_ * rlcrPoorIronSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 32 * rlcrPoorIronFreq ' range=':= _default_ * rlcrPoorIronFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 40 ' range=':= 4 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -530,21 +617,21 @@
                             <IfCondition condition=':= ?blockExists("Railcraft:ore:8")'> <OreBlock block='Railcraft:ore:8' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.980 * _default_ * rlcrPoorGoldFreq ' range=':=  _default_ * rlcrPoorGoldFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.256 * _default_ * rlcrPoorGoldSize ' range=':=  _default_ * rlcrPoorGoldSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 15 ' range=':=  1 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.256 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * rlcrPoorGoldSize ' range=':=  _default_ * rlcrPoorGoldSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.256 * _default_ * rlcrPoorGoldSize ' range=':=  _default_ * rlcrPoorGoldSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.980 * _default_ * rlcrPoorGoldFreq ' range=':= _default_ * rlcrPoorGoldFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.256 * _default_ * rlcrPoorGoldSize ' range=':= _default_ * rlcrPoorGoldSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 15 ' range=':= 1 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.256 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * rlcrPoorGoldSize ' range=':= _default_ * rlcrPoorGoldSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.256 * _default_ * rlcrPoorGoldSize ' range=':= _default_ * rlcrPoorGoldSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -572,16 +659,16 @@
                             <IfCondition condition=':= ?blockExists("Railcraft:ore:8")'> <OreBlock block='Railcraft:ore:8' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.157 * _default_ * rlcrPoorGoldSize ' range=':=  _default_ * rlcrPoorGoldSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.157 * _default_ * rlcrPoorGoldSize ' range=':=  _default_ * rlcrPoorGoldSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.338  * _default_ * rlcrPoorGoldFreq ' range=':=  _default_ * rlcrPoorGoldFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 15 ' range=':=  1 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 1.157 * _default_ * rlcrPoorGoldSize ' range=':= _default_ * rlcrPoorGoldSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.157 * _default_ * rlcrPoorGoldSize ' range=':= _default_ * rlcrPoorGoldSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.338  * _default_ * rlcrPoorGoldFreq ' range=':= _default_ * rlcrPoorGoldFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 15 ' range=':= 1 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='rlcrPoorGoldHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60EAEF57' drawBoundBox='false' boundBoxColor='0x60EAEF57'>
                                 <Description>
                                     Single blocks, generously
@@ -624,10 +711,10 @@
                             <IfCondition condition=':= ?blockExists("Railcraft:ore:8")'> <OreBlock block='Railcraft:ore:8' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 1 * rlcrPoorGoldSize ' range=':=  _default_ * rlcrPoorGoldSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 32 * rlcrPoorGoldFreq ' range=':=  _default_ * rlcrPoorGoldFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 15 ' range=':=  1 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 1 * rlcrPoorGoldSize ' range=':= _default_ * rlcrPoorGoldSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 32 * rlcrPoorGoldFreq ' range=':= _default_ * rlcrPoorGoldFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 15 ' range=':= 1 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -656,21 +743,21 @@
                             <IfCondition condition=':= ?blockExists("Railcraft:ore:9")'> <OreBlock block='Railcraft:ore:9' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 5.601 * _default_ * rlcrPoorCopperFreq ' range=':=  _default_ * rlcrPoorCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.776 * _default_ * rlcrPoorCopperSize ' range=':=  _default_ * rlcrPoorCopperSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 60 ' range=':=  3 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.776 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * rlcrPoorCopperSize ' range=':=  _default_ * rlcrPoorCopperSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.776 * _default_ * rlcrPoorCopperSize ' range=':=  _default_ * rlcrPoorCopperSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 5.601 * _default_ * rlcrPoorCopperFreq ' range=':= _default_ * rlcrPoorCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.776 * _default_ * rlcrPoorCopperSize ' range=':= _default_ * rlcrPoorCopperSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 60 ' range=':= 3 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.776 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * rlcrPoorCopperSize ' range=':= _default_ * rlcrPoorCopperSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.776 * _default_ * rlcrPoorCopperSize ' range=':= _default_ * rlcrPoorCopperSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -698,16 +785,16 @@
                             <IfCondition condition=':= ?blockExists("Railcraft:ore:9")'> <OreBlock block='Railcraft:ore:9' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.945 * _default_ * rlcrPoorCopperSize ' range=':=  _default_ * rlcrPoorCopperSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.945 * _default_ * rlcrPoorCopperSize ' range=':=  _default_ * rlcrPoorCopperSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 3.784  * _default_ * rlcrPoorCopperFreq ' range=':=  _default_ * rlcrPoorCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 60 ' range=':=  3 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 1.945 * _default_ * rlcrPoorCopperSize ' range=':= _default_ * rlcrPoorCopperSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.945 * _default_ * rlcrPoorCopperSize ' range=':= _default_ * rlcrPoorCopperSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 3.784  * _default_ * rlcrPoorCopperFreq ' range=':= _default_ * rlcrPoorCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 60 ' range=':= 3 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='rlcrPoorCopperHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
                                 <Description>
                                     Single blocks, generously
@@ -750,10 +837,10 @@
                             <IfCondition condition=':= ?blockExists("Railcraft:ore:9")'> <OreBlock block='Railcraft:ore:9' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 8 * rlcrPoorCopperSize ' range=':=  _default_ * rlcrPoorCopperSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 32 * rlcrPoorCopperFreq ' range=':=  _default_ * rlcrPoorCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 60 ' range=':=  3 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 8 * rlcrPoorCopperSize ' range=':= _default_ * rlcrPoorCopperSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 32 * rlcrPoorCopperFreq ' range=':= _default_ * rlcrPoorCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 60 ' range=':= 3 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -782,21 +869,21 @@
                             <IfCondition condition=':= ?blockExists("Railcraft:ore:10")'> <OreBlock block='Railcraft:ore:10' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 2.801 * _default_ * rlcrPoorTinFreq ' range=':=  _default_ * rlcrPoorTinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.410 * _default_ * rlcrPoorTinSize ' range=':=  _default_ * rlcrPoorTinSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 50 ' range=':=  2 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.410 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * rlcrPoorTinSize ' range=':=  _default_ * rlcrPoorTinSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.410 * _default_ * rlcrPoorTinSize ' range=':=  _default_ * rlcrPoorTinSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 2.801 * _default_ * rlcrPoorTinFreq ' range=':= _default_ * rlcrPoorTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.410 * _default_ * rlcrPoorTinSize ' range=':= _default_ * rlcrPoorTinSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 50 ' range=':= 2 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.410 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * rlcrPoorTinSize ' range=':= _default_ * rlcrPoorTinSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.410 * _default_ * rlcrPoorTinSize ' range=':= _default_ * rlcrPoorTinSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -824,16 +911,16 @@
                             <IfCondition condition=':= ?blockExists("Railcraft:ore:10")'> <OreBlock block='Railcraft:ore:10' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.375 * _default_ * rlcrPoorTinSize ' range=':=  _default_ * rlcrPoorTinSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.375 * _default_ * rlcrPoorTinSize ' range=':=  _default_ * rlcrPoorTinSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.892  * _default_ * rlcrPoorTinFreq ' range=':=  _default_ * rlcrPoorTinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 50 ' range=':=  2 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 1.375 * _default_ * rlcrPoorTinSize ' range=':= _default_ * rlcrPoorTinSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.375 * _default_ * rlcrPoorTinSize ' range=':= _default_ * rlcrPoorTinSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.892  * _default_ * rlcrPoorTinFreq ' range=':= _default_ * rlcrPoorTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 50 ' range=':= 2 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='rlcrPoorTinHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60E8E8E8'>
                                 <Description>
                                     Single blocks, generously
@@ -876,10 +963,10 @@
                             <IfCondition condition=':= ?blockExists("Railcraft:ore:10")'> <OreBlock block='Railcraft:ore:10' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 2 * rlcrPoorTinSize ' range=':=  _default_ * rlcrPoorTinSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 32 * rlcrPoorTinFreq ' range=':=  _default_ * rlcrPoorTinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 50 ' range=':=  2 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 2 * rlcrPoorTinSize ' range=':= _default_ * rlcrPoorTinSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 32 * rlcrPoorTinFreq ' range=':= _default_ * rlcrPoorTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 50 ' range=':= 2 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -908,21 +995,21 @@
                             <IfCondition condition=':= ?blockExists("Railcraft:ore:11")'> <OreBlock block='Railcraft:ore:11' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 4.851 * _default_ * rlcrPoorLeadFreq ' range=':=  _default_ * rlcrPoorLeadFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.693 * _default_ * rlcrPoorLeadSize ' range=':=  _default_ * rlcrPoorLeadSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 30 ' range=':=  3 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.693 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * rlcrPoorLeadSize ' range=':=  _default_ * rlcrPoorLeadSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.693 * _default_ * rlcrPoorLeadSize ' range=':=  _default_ * rlcrPoorLeadSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 4.851 * _default_ * rlcrPoorLeadFreq ' range=':= _default_ * rlcrPoorLeadFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.693 * _default_ * rlcrPoorLeadSize ' range=':= _default_ * rlcrPoorLeadSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 30 ' range=':= 3 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.693 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * rlcrPoorLeadSize ' range=':= _default_ * rlcrPoorLeadSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.693 * _default_ * rlcrPoorLeadSize ' range=':= _default_ * rlcrPoorLeadSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -950,16 +1037,16 @@
                             <IfCondition condition=':= ?blockExists("Railcraft:ore:11")'> <OreBlock block='Railcraft:ore:11' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.810 * _default_ * rlcrPoorLeadSize ' range=':=  _default_ * rlcrPoorLeadSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.810 * _default_ * rlcrPoorLeadSize ' range=':=  _default_ * rlcrPoorLeadSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 3.277  * _default_ * rlcrPoorLeadFreq ' range=':=  _default_ * rlcrPoorLeadFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 30 ' range=':=  3 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 1.810 * _default_ * rlcrPoorLeadSize ' range=':= _default_ * rlcrPoorLeadSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.810 * _default_ * rlcrPoorLeadSize ' range=':= _default_ * rlcrPoorLeadSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 3.277  * _default_ * rlcrPoorLeadFreq ' range=':= _default_ * rlcrPoorLeadFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 30 ' range=':= 3 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='rlcrPoorLeadHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60818EBE' drawBoundBox='false' boundBoxColor='0x60818EBE'>
                                 <Description>
                                     Single blocks, generously
@@ -1002,10 +1089,10 @@
                             <IfCondition condition=':= ?blockExists("Railcraft:ore:11")'> <OreBlock block='Railcraft:ore:11' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 6 * rlcrPoorLeadSize ' range=':=  _default_ * rlcrPoorLeadSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 32 * rlcrPoorLeadFreq ' range=':=  _default_ * rlcrPoorLeadFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 30 ' range=':=  3 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 6 * rlcrPoorLeadSize ' range=':= _default_ * rlcrPoorLeadSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 32 * rlcrPoorLeadFreq ' range=':= _default_ * rlcrPoorLeadFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 30 ' range=':= 3 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -1035,21 +1122,21 @@
                             <IfCondition condition=':= ?blockExists("minecraft:sand")'> <Replaces block='minecraft:sand' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
                             <BiomeType name='Desert'  minRainfall='0' maxRainfall='0.1' minTemperature='1.5' maxTemperature='2.0' />
-                            <Setting name='MotherlodeFrequency' avg=':= 2.801 * _default_ * rlcrSaltpeterFreq ' range=':=  _default_ * rlcrSaltpeterFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.410 * _default_ * rlcrSaltpeterSize ' range=':=  _default_ * rlcrSaltpeterSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 75 ' range=':=  25 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.410 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * rlcrSaltpeterSize ' range=':=  _default_ * rlcrSaltpeterSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.410 * _default_ * rlcrSaltpeterSize ' range=':=  _default_ * rlcrSaltpeterSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 2.801 * _default_ * rlcrSaltpeterFreq ' range=':= _default_ * rlcrSaltpeterFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.410 * _default_ * rlcrSaltpeterSize ' range=':= _default_ * rlcrSaltpeterSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 75 ' range=':= 25 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.410 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * rlcrSaltpeterSize ' range=':= _default_ * rlcrSaltpeterSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.410 * _default_ * rlcrSaltpeterSize ' range=':= _default_ * rlcrSaltpeterSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -1078,16 +1165,16 @@
                             <IfCondition condition=':= ?blockExists("minecraft:sand")'> <Replaces block='minecraft:sand' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
                             <BiomeType name='Desert'  minRainfall='0' maxRainfall='0.1' minTemperature='1.5' maxTemperature='2.0' />
-                            <Setting name='CloudRadius' avg=':= 1.375 * _default_ * rlcrSaltpeterSize ' range=':=  _default_ * rlcrSaltpeterSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.375 * _default_ * rlcrSaltpeterSize ' range=':=  _default_ * rlcrSaltpeterSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.892  * _default_ * rlcrSaltpeterFreq ' range=':=  _default_ * rlcrSaltpeterFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 75 ' range=':=  25 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 1.375 * _default_ * rlcrSaltpeterSize ' range=':= _default_ * rlcrSaltpeterSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.375 * _default_ * rlcrSaltpeterSize ' range=':= _default_ * rlcrSaltpeterSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.892  * _default_ * rlcrSaltpeterFreq ' range=':= _default_ * rlcrSaltpeterFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 75 ' range=':= 25 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='rlcrSaltpeterHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60CED0BA' drawBoundBox='false' boundBoxColor='0x60CED0BA'>
                                 <Description>
                                     Single blocks, generously
@@ -1131,10 +1218,10 @@
                             <IfCondition condition=':= ?blockExists("minecraft:sand")'> <Replaces block='minecraft:sand' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
                             <BiomeType name='Desert'  minRainfall='0' maxRainfall='0.1' minTemperature='1.5' maxTemperature='2.0' />
-                            <Setting name='Size' avg=':= 1 * rlcrSaltpeterSize ' range=':=  _default_ * rlcrSaltpeterSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 64 * rlcrSaltpeterFreq ' range=':=  _default_ * rlcrSaltpeterFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 75 ' range=':=  25 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 1 * rlcrSaltpeterSize ' range=':= _default_ * rlcrSaltpeterSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 64 * rlcrSaltpeterFreq ' range=':= _default_ * rlcrSaltpeterFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 75 ' range=':= 25 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -1143,133 +1230,12 @@
                 <!-- End Saltpeter Generation -->
 
 
-                <!-- Begin Firestone Generation -->
-
-                <!-- Starting SmallDeposits Preset for Firestone. -->
-                <ConfigSection>
-                    <IfCondition condition=':= rlcrFirestoneDist = "SmallDeposits"'>
-                        <Veins name='rlcrFirestoneVeins'  inherits='PresetSmallDeposits' drawWireframe='true' wireframeColor='0x60C64E0D' drawBoundBox='false' boundBoxColor='0x60C64E0D'>
-                            <Description>
-                                Small motherlodes without any
-                                branches.  Similar to the  deposits
-                                produced by StandardGen
-                                distributions.
-                            </Description>
-                            <IfCondition condition=':= ?blockExists("Railcraft:ore:5")'> <OreBlock block='Railcraft:ore:5' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
-                            <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.191 * _default_ * rlcrFirestoneFreq ' range=':=  _default_ * rlcrFirestoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.576 * _default_ * rlcrFirestoneSize ' range=':=  _default_ * rlcrFirestoneSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 16 ' range=':=  15 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.576 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * rlcrFirestoneSize ' range=':=  _default_ * rlcrFirestoneSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.576 * _default_ * rlcrFirestoneSize ' range=':=  _default_ * rlcrFirestoneSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        </Veins>
-                    </IfCondition>
-                </ConfigSection>
-                <!-- SmallDeposits Preset for Firestone is complete. -->
-
-
-                <!-- Starting Cloud Preset for Firestone. -->
-                <ConfigSection>
-                    <IfCondition condition=':= rlcrFirestoneDist = "Cloud"'>
-                        <Cloud name='rlcrFirestoneCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60C64E0D' drawBoundBox='false' boundBoxColor='0x60C64E0D'>
-                            <Description>
-                                Large irregular clouds filled  lightly
-                                with ore.  These are  huge, spanning
-                                several adjacent  chunks, and
-                                consequently rather  rare.  They
-                                contain a sizeable  amount of ore, but
-                                it takes some  time and effort to mine
-                                due to  low density. The intent for
-                                strategic clouds is that the  player
-                                will need to actively  search for one
-                                and then set up a  semi-permanent
-                                mining base and  spend some time
-                                actually mining  the ore.
-                            </Description>
-                            <IfCondition condition=':= ?blockExists("Railcraft:ore:5")'> <OreBlock block='Railcraft:ore:5' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
-                            <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.486 * _default_ * rlcrFirestoneSize ' range=':=  _default_ * rlcrFirestoneSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.486 * _default_ * rlcrFirestoneSize ' range=':=  _default_ * rlcrFirestoneSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.236  * _default_ * rlcrFirestoneFreq ' range=':=  _default_ * rlcrFirestoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 16 ' range=':=  15 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Veins name='rlcrFirestoneHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60C64E0D' drawBoundBox='false' boundBoxColor='0x60C64E0D'>
-                                <Description>
-                                    Single blocks, generously
-                                    scattered through all heights
-                                    (density is about that of  vanilla
-                                    iron ore). They will  replace dirt
-                                    and sandstone  (but not grass or
-                                    sand), so  they can be found
-                                    nearer to  the surface than most
-                                    ores.  Intened to be used as a
-                                    child  distribution for large,
-                                    rare  strategic deposits that
-                                    would  otherwise be very difficult
-                                    to find.  Note that the  frequency
-                                    is multiplied by  ground level to
-                                    maintain a  constant density, but
-                                    not by  ore frequency because it
-                                    is  assumed that the frequency of
-                                    the parent distribution will
-                                    already be scaled by that.
-                                </Description>
-                                <IfCondition condition=':= ?blockExists("Railcraft:ore:5")'> <OreBlock block='Railcraft:ore:5' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
-                            </Veins>
-                        </Cloud>
-                    </IfCondition>
-                </ConfigSection>
-                <!-- Cloud Preset for Firestone is complete. -->
-
-
-                <!-- Starting Vanilla Preset for Firestone. -->
-                <ConfigSection>
-                    <IfCondition condition=':= rlcrFirestoneDist = "Vanilla"'>
-                        <StandardGen name='rlcrFirestoneStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60C64E0D' drawBoundBox='false' boundBoxColor='0x60C64E0D'>
-                            <Description>
-                                A master preset for standardgen  ore
-                                distributions.
-                            </Description>
-                            <IfCondition condition=':= ?blockExists("Railcraft:ore:5")'> <OreBlock block='Railcraft:ore:5' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
-                            <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 1 * rlcrFirestoneSize ' range=':=  _default_ * rlcrFirestoneSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1 * rlcrFirestoneFreq ' range=':=  _default_ * rlcrFirestoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 16 ' range=':=  15 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        </StandardGen>
-                    </IfCondition>
-                </ConfigSection>
-                <!-- Vanilla Preset for Firestone is complete. -->
-
-                <!-- End Firestone Generation -->
-
-
                 <!-- Begin Sulfur Generation -->
 
                 <!-- Starting PipeVeins Preset for Sulfur. -->
                 <ConfigSection>
                     <IfCondition condition=':= rlcrSulfurDist = "PipeVeins"'>
-                        <Veins name='rlcrSulfurVeins'  inherits='PresetPipeVeins' seed='0x504F' drawWireframe='true' wireframeColor='0x60FFE25C' drawBoundBox='false' boundBoxColor='0x60FFE25C'>
+                        <Veins name='rlcrSulfurVeins'  inherits='PresetPipeVeins' seed='0xEE54' drawWireframe='true' wireframeColor='0x60FFE25C' drawBoundBox='false' boundBoxColor='0x60FFE25C'>
                             <Description>
                                 Short sparsely filled veins  sloping
                                 up from near the bottom  of the map.
@@ -1277,30 +1243,30 @@
                             <IfCondition condition=':= ?blockExists("Railcraft:ore")'> <OreBlock block='Railcraft:ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.872 * _default_ * rlcrSulfurFreq ' range=':=  _default_ * rlcrSulfurFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.956 * _default_ * rlcrSulfurSize ' range=':=  _default_ * rlcrSulfurSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 11 ' range=':=  5 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.956 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * rlcrSulfurSize ' range=':=  _default_ * rlcrSulfurSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.956 * _default_ * rlcrSulfurSize ' range=':=  _default_ * rlcrSulfurSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.872 * _default_ * rlcrSulfurFreq ' range=':= _default_ * rlcrSulfurFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.956 * _default_ * rlcrSulfurSize ' range=':= _default_ * rlcrSulfurSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 11 ' range=':= 5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.956 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * rlcrSulfurSize ' range=':= _default_ * rlcrSulfurSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.956 * _default_ * rlcrSulfurSize ' range=':= _default_ * rlcrSulfurSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
 
                         <!-- Configuring contained material. -->
-                        <Veins name='rlcrSulfurVeinsPipe'  inherits='rlcrSulfurVeins' seed='0x504F' drawWireframe='true' wireframeColor='0x60FFE25C' drawBoundBox='false' boundBoxColor='0x60FFE25C'>
+                        <Veins name='rlcrSulfurVeinsPipe'  inherits='rlcrSulfurVeins' seed='0xEE54' drawWireframe='true' wireframeColor='0x60FFE25C' drawBoundBox='false' boundBoxColor='0x60FFE25C'>
                             <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("Railcraft:ore")'> <Replaces block='Railcraft:ore' weight='1.0' /> </IfCondition>
-                            <Setting name='MotherlodeSize' avg=':= 0.956 * _default_ * rlcrSulfurSize  * 0.5 ' range=':=  _default_ * rlcrSulfurSize  * 0.5 ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.956 * _default_ * rlcrSulfurSize  * 0.5 ' range=':=  _default_ * rlcrSulfurSize  * 0.5 ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.956 * _default_ * rlcrSulfurSize  * 0.5 ' range=':= _default_ * rlcrSulfurSize  * 0.5 ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.956 * _default_ * rlcrSulfurSize  * 0.5 ' range=':= _default_ * rlcrSulfurSize  * 0.5 ' type='normal' />
                             <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
                         </Veins>
                     </IfCondition>
@@ -1329,16 +1295,16 @@
                             <IfCondition condition=':= ?blockExists("Railcraft:ore")'> <OreBlock block='Railcraft:ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.223 * _default_ * rlcrSulfurSize ' range=':=  _default_ * rlcrSulfurSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.223 * _default_ * rlcrSulfurSize ' range=':=  _default_ * rlcrSulfurSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.496  * _default_ * rlcrSulfurFreq ' range=':=  _default_ * rlcrSulfurFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 11 ' range=':=  5 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 1.223 * _default_ * rlcrSulfurSize ' range=':= _default_ * rlcrSulfurSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.223 * _default_ * rlcrSulfurSize ' range=':= _default_ * rlcrSulfurSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.496  * _default_ * rlcrSulfurFreq ' range=':= _default_ * rlcrSulfurFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 11 ' range=':= 5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='rlcrSulfurHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FFE25C' drawBoundBox='false' boundBoxColor='0x60FFE25C'>
                                 <Description>
                                     Single blocks, generously
@@ -1381,10 +1347,10 @@
                             <IfCondition condition=':= ?blockExists("Railcraft:ore")'> <OreBlock block='Railcraft:ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 10 * rlcrSulfurSize ' range=':=  _default_ * rlcrSulfurSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 4 * rlcrSulfurFreq ' range=':=  _default_ * rlcrSulfurFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 11 ' range=':=  5 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 10 * rlcrSulfurSize ' range=':= _default_ * rlcrSulfurSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4 * rlcrSulfurFreq ' range=':= _default_ * rlcrSulfurFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 11 ' range=':= 5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -1392,117 +1358,163 @@
 
                 <!-- End Sulfur Generation -->
 
-
-                <!-- Begin Abyssal Ores Generation -->
-
-                <!-- Starting Geode Preset for Abyssal Ores. -->
-                <ConfigSection>
-                    <IfCondition condition=':= rlcrAbyssalOresDist = "Geode"'>
-                        <Veins name='rlcrAbyssalOresGeodeShell'  inherits='PresetSmallDeposits' seed='0x9668' drawWireframe='true' wireframeColor='0x60000000' drawBoundBox='false' boundBoxColor='0x60000000'>
-                            <Description>
-                                Multi-layered deposit.  On the
-                                outside is a shell, usually made  of
-                                some form of stone.  Within  this
-                                shell is sprinkled ores.  Inside both
-                                is an air pocket from  which the
-                                enterprising miner can  look for the
-                                contained ores.
-                            </Description>
-                            <IfCondition condition=':= ?blockExists("Railcraft:cube:6")'> <OreBlock block='Railcraft:cube:6' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
-                            <Biome name='Ocean'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.5 * rlcrAbyssalOresFreq ' range=':=  _default_ * rlcrAbyssalOresFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= _default_ * rlcrAbyssalOresSize  * 3 ' range=':=  _default_ * rlcrAbyssalOresSize  * 3 ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 20 ' range=':=  4 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * rlcrAbyssalOresSize ' range=':=  _default_ * rlcrAbyssalOresSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= _default_ * rlcrAbyssalOresSize ' range=':=  _default_ * rlcrAbyssalOresSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        </Veins>
-                        <Veins name='rlcrAbyssalOresGeodeOre'  inherits='rlcrAbyssalOresGeodeShell' seed='0x9668' drawWireframe='true' wireframeColor='0x60000000' drawBoundBox='false' boundBoxColor='0x60000000'>
-                            <Description>
-                                Multi-layered deposit.  On the
-                                outside is a shell, usually made  of
-                                some form of stone.  Within  this
-                                shell is sprinkled ores.  Inside both
-                                is an air pocket from  which the
-                                enterprising miner can  look for the
-                                contained ores.
-                            </Description>
-                            <IfCondition condition=':= ?blockExists("Railcraft:ore:2")'> <OreBlock block='Railcraft:ore:2' weight='0.05' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("Railcraft:ore:3")'> <OreBlock block='Railcraft:ore:3' weight='0.05' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("Railcraft:ore:4")'> <OreBlock block='Railcraft:ore:4' weight='0.15' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("Railcraft:cube:6")'> <Replaces block='Railcraft:cube:6' weight='1.0' /> </IfCondition>
-                            <Biome name='Ocean'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.5 * rlcrAbyssalOresFreq ' range=':=  _default_ * rlcrAbyssalOresFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= _default_ * rlcrAbyssalOresSize  * 0.5 ' range=':=  _default_ * rlcrAbyssalOresSize  * 0.5 ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 20 ' range=':=  4 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * rlcrAbyssalOresSize ' range=':=  _default_ * rlcrAbyssalOresSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= _default_ * rlcrAbyssalOresSize ' range=':=  _default_ * rlcrAbyssalOresSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        </Veins>
-                        <Veins name='rlcrAbyssalOresGeodeBubble'  inherits='rlcrAbyssalOresGeodeOre' seed='0x9668' drawWireframe='true' wireframeColor='0x60000000' drawBoundBox='false' boundBoxColor='0x60000000'>
-                            <Description>
-                                Multi-layered deposit.  On the
-                                outside is a shell, usually made  of
-                                some form of stone.  Within  this
-                                shell is sprinkled ores.  Inside both
-                                is an air pocket from  which the
-                                enterprising miner can  look for the
-                                contained ores.
-                            </Description>
-                            <IfCondition condition=':= ?blockExists("minecraft:air")'> <OreBlock block='minecraft:air' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("Railcraft:cube:6")'> <Replaces block='Railcraft:cube:6' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("Railcraft:ore:2")'> <Replaces block='Railcraft:ore:2' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("Railcraft:ore:3")'> <Replaces block='Railcraft:ore:3' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("Railcraft:ore:4")'> <Replaces block='Railcraft:ore:4' weight='1.0' /> </IfCondition>
-                            <Biome name='Ocean'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.5 * rlcrAbyssalOresFreq ' range=':=  _default_ * rlcrAbyssalOresFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= _default_ * rlcrAbyssalOresSize  * 0.5 ' range=':=  _default_ * rlcrAbyssalOresSize  * 0.5 ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 20 ' range=':=  4 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * rlcrAbyssalOresSize ' range=':=  _default_ * rlcrAbyssalOresSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= _default_ * rlcrAbyssalOresSize ' range=':=  _default_ * rlcrAbyssalOresSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                        </Veins>
-
-                        <!-- Beginning "Preferred" configuration. -->
-                    </IfCondition>
-                </ConfigSection>
-                <!-- Geode Preset for Abyssal Ores is complete. -->
-
-                <!-- End Abyssal Ores Generation -->
-
                 <!-- Finished adding blocks -->
 
             </IfCondition>
             <!-- Overworld Setup Complete -->
 
+
+
+
+
+            <!-- Nether Setup Beginning -->
+
+            <IfCondition condition=':= dimension.generator = "HellRandomLevelSource"'>
+
+                <!-- Starting Original "Nether" Block Removal -->
+
+                <IfCondition condition=':= ?blockExists("minecraft:stone")'>
+                    <Substitute name='rlcrNetherBlockSubstitute0' block='minecraft:stone'>
+                        <Description>
+                            Replace vanilla-generated ore clusters.
+                        </Description>
+                        <Comment>
+                            The global option  deferredPopulationRange
+                            must be large  enough to catch all ore
+                            clusters (>=  32).
+                        </Comment>
+                        <IfCondition condition=':= ?blockExists("Railcraft:ore:5")'> <Replaces block='Railcraft:ore:5' weight='1.0' /> </IfCondition>
+                    </Substitute>
+                </IfCondition>
+
+                <!-- Original "Nether" Block Removal Complete -->
+
+                <!-- Adding blocks -->
+
+                <!-- Begin Firestone Generation -->
+
+                <!-- Starting SmallDeposits Preset for Firestone. -->
+                <ConfigSection>
+                    <IfCondition condition=':= rlcrFirestoneDist = "SmallDeposits"'>
+                        <Veins name='rlcrFirestoneVeins'  inherits='PresetSmallDeposits' drawWireframe='true' wireframeColor='0x60C64E0D' drawBoundBox='false' boundBoxColor='0x60C64E0D'>
+                            <Description>
+                                Small motherlodes without any
+                                branches.  Similar to the  deposits
+                                produced by StandardGen
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Railcraft:ore:5")'> <OreBlock block='Railcraft:ore:5' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.191 * _default_ * rlcrFirestoneFreq ' range=':= _default_ * rlcrFirestoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.576 * _default_ * rlcrFirestoneSize ' range=':= _default_ * rlcrFirestoneSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 16 ' range=':= 15 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.576 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * rlcrFirestoneSize ' range=':= _default_ * rlcrFirestoneSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.576 * _default_ * rlcrFirestoneSize ' range=':= _default_ * rlcrFirestoneSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- SmallDeposits Preset for Firestone is complete. -->
+
+
+                <!-- Starting Cloud Preset for Firestone. -->
+                <ConfigSection>
+                    <IfCondition condition=':= rlcrFirestoneDist = "Cloud"'>
+                        <Cloud name='rlcrFirestoneCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60C64E0D' drawBoundBox='false' boundBoxColor='0x60C64E0D'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Railcraft:ore:5")'> <OreBlock block='Railcraft:ore:5' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.486 * _default_ * rlcrFirestoneSize ' range=':= _default_ * rlcrFirestoneSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.486 * _default_ * rlcrFirestoneSize ' range=':= _default_ * rlcrFirestoneSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.236  * _default_ * rlcrFirestoneFreq ' range=':= _default_ * rlcrFirestoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 16 ' range=':= 15 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Veins name='rlcrFirestoneHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60C64E0D' drawBoundBox='false' boundBoxColor='0x60C64E0D'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("Railcraft:ore:5")'> <OreBlock block='Railcraft:ore:5' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Firestone is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Firestone. -->
+                <ConfigSection>
+                    <IfCondition condition=':= rlcrFirestoneDist = "Vanilla"'>
+                        <StandardGen name='rlcrFirestoneStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60C64E0D' drawBoundBox='false' boundBoxColor='0x60C64E0D'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("Railcraft:ore:5")'> <OreBlock block='Railcraft:ore:5' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 1 * rlcrFirestoneSize ' range=':= _default_ * rlcrFirestoneSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1 * rlcrFirestoneFreq ' range=':= _default_ * rlcrFirestoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 16 ' range=':= 15 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Firestone is complete. -->
+
+                <!-- End Firestone Generation -->
+
+                <!-- Finished adding blocks -->
+
+            </IfCondition>
+            <!-- Nether Setup Complete -->
 
 
         </IfCondition>

--- a/src/main/resources/config/modules/ReactorCraft.xml
+++ b/src/main/resources/config/modules/ReactorCraft.xml
@@ -680,21 +680,21 @@
                             <BiomeType name='Mushroom'  />
                             <BiomeType name='Ocean'  />
                             <BiomeType name='River'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 2.425 * _default_ * recrPitchblendeFreq ' range=':=  1 * _default_ * recrPitchblendeFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.344 * _default_ * recrPitchblendeSize ' range=':=  1 * _default_ * recrPitchblendeSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 16 ' range=':=  8 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.344 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * recrPitchblendeSize ' range=':=  _default_ * recrPitchblendeSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.344 * _default_ * recrPitchblendeSize ' range=':=  1 * _default_ * recrPitchblendeSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 2.425 * _default_ * recrPitchblendeFreq ' range=':= 1 * _default_ * recrPitchblendeFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.344 * _default_ * recrPitchblendeSize ' range=':= 1 * _default_ * recrPitchblendeSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 16 ' range=':= 8 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.344 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * recrPitchblendeSize ' range=':= _default_ * recrPitchblendeSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.344 * _default_ * recrPitchblendeSize ' range=':= 1 * _default_ * recrPitchblendeSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -714,10 +714,10 @@
                             <BiomeType name='Mushroom'  />
                             <BiomeType name='Ocean'  />
                             <BiomeType name='River'  />
-                            <Setting name='Size' avg=':= 16 * recrPitchblendeSize ' range=':=  _default_ * recrPitchblendeSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 3 * recrPitchblendeFreq ' range=':=  _default_ * recrPitchblendeFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 16 ' range=':=  8 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 16 * recrPitchblendeSize ' range=':= _default_ * recrPitchblendeSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 3 * recrPitchblendeFreq ' range=':= _default_ * recrPitchblendeFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 16 ' range=':= 8 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -747,16 +747,16 @@
                             <BiomeType name='Mushroom'  />
                             <BiomeType name='Ocean'  />
                             <BiomeType name='River'  />
-                            <Setting name='CloudRadius' avg=':= 1.280 * _default_ * recrPitchblendeSize ' range=':=  _default_ * recrPitchblendeSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.280 * _default_ * recrPitchblendeSize ' range=':=  _default_ * recrPitchblendeSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.638  * _default_ * recrPitchblendeFreq ' range=':=  _default_ * recrPitchblendeFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 16 ' range=':=  8 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 1.280 * _default_ * recrPitchblendeSize ' range=':= _default_ * recrPitchblendeSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.280 * _default_ * recrPitchblendeSize ' range=':= _default_ * recrPitchblendeSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.638  * _default_ * recrPitchblendeFreq ' range=':= _default_ * recrPitchblendeFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 16 ' range=':= 8 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='recrPitchblendeHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60454454' drawBoundBox='false' boundBoxColor='0x60454454'>
                                 <Description>
                                     Single blocks, generously
@@ -803,21 +803,21 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:2")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:2' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.615 * _default_ * recrCadmiumFreq ' range=':=  1 * _default_ * recrCadmiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.851 * _default_ * recrCadmiumSize ' range=':=  1 * _default_ * recrCadmiumSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 22 ' range=':=  10 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.851 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * recrCadmiumSize ' range=':=  _default_ * recrCadmiumSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.851 * _default_ * recrCadmiumSize ' range=':=  1 * _default_ * recrCadmiumSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.615 * _default_ * recrCadmiumFreq ' range=':= 1 * _default_ * recrCadmiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.851 * _default_ * recrCadmiumSize ' range=':= 1 * _default_ * recrCadmiumSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 22 ' range=':= 10 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.851 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * recrCadmiumSize ' range=':= _default_ * recrCadmiumSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.851 * _default_ * recrCadmiumSize ' range=':= 1 * _default_ * recrCadmiumSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -835,10 +835,10 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:2")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:2' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 9 * recrCadmiumSize ' range=':=  _default_ * recrCadmiumSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 3 * recrCadmiumFreq ' range=':=  _default_ * recrCadmiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 22 ' range=':=  10 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 9 * recrCadmiumSize ' range=':= _default_ * recrCadmiumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 3 * recrCadmiumFreq ' range=':= _default_ * recrCadmiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 22 ' range=':= 10 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -866,16 +866,16 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:2")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:2' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.109 * _default_ * recrCadmiumSize ' range=':=  _default_ * recrCadmiumSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.109 * _default_ * recrCadmiumSize ' range=':=  _default_ * recrCadmiumSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.229  * _default_ * recrCadmiumFreq ' range=':=  _default_ * recrCadmiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 22 ' range=':=  10 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 1.109 * _default_ * recrCadmiumSize ' range=':= _default_ * recrCadmiumSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.109 * _default_ * recrCadmiumSize ' range=':= _default_ * recrCadmiumSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.229  * _default_ * recrCadmiumFreq ' range=':= _default_ * recrCadmiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 22 ' range=':= 10 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='recrCadmiumHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x607184A4' drawBoundBox='false' boundBoxColor='0x607184A4'>
                                 <Description>
                                     Single blocks, generously
@@ -922,21 +922,21 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:3")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:3' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.443 * _default_ * recrIndiumFreq ' range=':=  1 * _default_ * recrIndiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.762 * _default_ * recrIndiumSize ' range=':=  1 * _default_ * recrIndiumSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 11 ' range=':=  16 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.762 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * recrIndiumSize ' range=':=  _default_ * recrIndiumSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.762 * _default_ * recrIndiumSize ' range=':=  1 * _default_ * recrIndiumSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.443 * _default_ * recrIndiumFreq ' range=':= 1 * _default_ * recrIndiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.762 * _default_ * recrIndiumSize ' range=':= 1 * _default_ * recrIndiumSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 11 ' range=':= 16 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.762 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * recrIndiumSize ' range=':= _default_ * recrIndiumSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.762 * _default_ * recrIndiumSize ' range=':= 1 * _default_ * recrIndiumSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -954,10 +954,10 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:3")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:3' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 7 * recrIndiumSize ' range=':=  _default_ * recrIndiumSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2 * recrIndiumFreq ' range=':=  _default_ * recrIndiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 11 ' range=':=  16 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 7 * recrIndiumSize ' range=':= _default_ * recrIndiumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2 * recrIndiumFreq ' range=':= _default_ * recrIndiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 11 ' range=':= 16 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -985,16 +985,16 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:3")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:3' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.941 * _default_ * recrIndiumSize ' range=':=  _default_ * recrIndiumSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.941 * _default_ * recrIndiumSize ' range=':=  _default_ * recrIndiumSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.885  * _default_ * recrIndiumFreq ' range=':=  _default_ * recrIndiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 11 ' range=':=  16 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 0.941 * _default_ * recrIndiumSize ' range=':= _default_ * recrIndiumSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.941 * _default_ * recrIndiumSize ' range=':= _default_ * recrIndiumSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.885  * _default_ * recrIndiumFreq ' range=':= _default_ * recrIndiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 11 ' range=':= 16 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='recrIndiumHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x607A7C89' drawBoundBox='false' boundBoxColor='0x607A7C89'>
                                 <Description>
                                     Single blocks, generously
@@ -1041,21 +1041,21 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:4")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:4' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.503 * _default_ * recrSilverFreq ' range=':=  1 * _default_ * recrSilverFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.795 * _default_ * recrSilverSize ' range=':=  1 * _default_ * recrSilverSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 28 ' range=':=  12 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.795 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * recrSilverSize ' range=':=  _default_ * recrSilverSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.795 * _default_ * recrSilverSize ' range=':=  1 * _default_ * recrSilverSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.503 * _default_ * recrSilverFreq ' range=':= 1 * _default_ * recrSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.795 * _default_ * recrSilverSize ' range=':= 1 * _default_ * recrSilverSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 28 ' range=':= 12 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.795 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * recrSilverSize ' range=':= _default_ * recrSilverSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.795 * _default_ * recrSilverSize ' range=':= 1 * _default_ * recrSilverSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -1073,10 +1073,10 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:4")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:4' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 9 * recrSilverSize ' range=':=  _default_ * recrSilverSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2 * recrSilverFreq ' range=':=  _default_ * recrSilverFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 28 ' range=':=  12 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 9 * recrSilverSize ' range=':= _default_ * recrSilverSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2 * recrSilverFreq ' range=':= _default_ * recrSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 28 ' range=':= 12 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -1104,16 +1104,16 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:4")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:4' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.002 * _default_ * recrSilverSize ' range=':=  _default_ * recrSilverSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.002 * _default_ * recrSilverSize ' range=':=  _default_ * recrSilverSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.003  * _default_ * recrSilverFreq ' range=':=  _default_ * recrSilverFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 28 ' range=':=  12 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 1.002 * _default_ * recrSilverSize ' range=':= _default_ * recrSilverSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.002 * _default_ * recrSilverSize ' range=':= _default_ * recrSilverSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.003  * _default_ * recrSilverFreq ' range=':= _default_ * recrSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 28 ' range=':= 12 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='recrSilverHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60E3F2F7' drawBoundBox='false' boundBoxColor='0x60E3F2F7'>
                                 <Description>
                                     Single blocks, generously
@@ -1167,21 +1167,21 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:7")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:7' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 2.425 * _default_ * recrCalciteFreq ' range=':=  1 * _default_ * recrCalciteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.344 * _default_ * recrCalciteSize ' range=':=  1 * _default_ * recrCalciteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.344 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * recrCalciteSize ' range=':=  _default_ * recrCalciteSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.344 * _default_ * recrCalciteSize ' range=':=  1 * _default_ * recrCalciteSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 2.425 * _default_ * recrCalciteFreq ' range=':= 1 * _default_ * recrCalciteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.344 * _default_ * recrCalciteSize ' range=':= 1 * _default_ * recrCalciteSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.344 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * recrCalciteSize ' range=':= _default_ * recrCalciteSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.344 * _default_ * recrCalciteSize ' range=':= 1 * _default_ * recrCalciteSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -1199,10 +1199,10 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:7")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:7' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4 * recrCalciteSize ' range=':=  _default_ * recrCalciteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 12 * recrCalciteFreq ' range=':=  _default_ * recrCalciteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 4 * recrCalciteSize ' range=':= _default_ * recrCalciteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 12 * recrCalciteFreq ' range=':= _default_ * recrCalciteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -1230,16 +1230,16 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:7")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:7' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.280 * _default_ * recrCalciteSize ' range=':=  _default_ * recrCalciteSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.280 * _default_ * recrCalciteSize ' range=':=  _default_ * recrCalciteSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.638  * _default_ * recrCalciteFreq ' range=':=  _default_ * recrCalciteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 1.280 * _default_ * recrCalciteSize ' range=':= _default_ * recrCalciteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.280 * _default_ * recrCalciteSize ' range=':= _default_ * recrCalciteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.638  * _default_ * recrCalciteFreq ' range=':= _default_ * recrCalciteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='recrCalciteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FEA219' drawBoundBox='false' boundBoxColor='0x60FEA219'>
                                 <Description>
                                     Single blocks, generously
@@ -1293,21 +1293,21 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:8")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:8' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 3.705 * _default_ * recrMagnetiteFreq ' range=':=  1 * _default_ * recrMagnetiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.547 * _default_ * recrMagnetiteSize ' range=':=  1 * _default_ * recrMagnetiteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 94 ' range=':=  34 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.547 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * recrMagnetiteSize ' range=':=  _default_ * recrMagnetiteSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.547 * _default_ * recrMagnetiteSize ' range=':=  1 * _default_ * recrMagnetiteSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 3.705 * _default_ * recrMagnetiteFreq ' range=':= 1 * _default_ * recrMagnetiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.547 * _default_ * recrMagnetiteSize ' range=':= 1 * _default_ * recrMagnetiteSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 94 ' range=':= 34 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.547 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * recrMagnetiteSize ' range=':= _default_ * recrMagnetiteSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.547 * _default_ * recrMagnetiteSize ' range=':= 1 * _default_ * recrMagnetiteSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -1325,10 +1325,10 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:8")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:8' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 16 * recrMagnetiteSize ' range=':=  _default_ * recrMagnetiteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 7 * recrMagnetiteFreq ' range=':=  _default_ * recrMagnetiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 94 ' range=':=  34 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 16 * recrMagnetiteSize ' range=':= _default_ * recrMagnetiteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 7 * recrMagnetiteFreq ' range=':= _default_ * recrMagnetiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 94 ' range=':= 34 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -1356,16 +1356,16 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:8")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:8' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.582 * _default_ * recrMagnetiteSize ' range=':=  _default_ * recrMagnetiteSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.582 * _default_ * recrMagnetiteSize ' range=':=  _default_ * recrMagnetiteSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 2.503  * _default_ * recrMagnetiteFreq ' range=':=  _default_ * recrMagnetiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 94 ' range=':=  34 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 1.582 * _default_ * recrMagnetiteSize ' range=':= _default_ * recrMagnetiteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.582 * _default_ * recrMagnetiteSize ' range=':= _default_ * recrMagnetiteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 2.503  * _default_ * recrMagnetiteFreq ' range=':= _default_ * recrMagnetiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 94 ' range=':= 34 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='recrMagnetiteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60212121' drawBoundBox='false' boundBoxColor='0x60212121'>
                                 <Description>
                                     Single blocks, generously
@@ -1412,21 +1412,21 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.410 * _default_ * recrBlueFluoriteFreq ' range=':=  1 * _default_ * recrBlueFluoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.743 * _default_ * recrBlueFluoriteSize ' range=':=  1 * _default_ * recrBlueFluoriteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.743 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * recrBlueFluoriteSize ' range=':=  _default_ * recrBlueFluoriteSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.743 * _default_ * recrBlueFluoriteSize ' range=':=  1 * _default_ * recrBlueFluoriteSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.410 * _default_ * recrBlueFluoriteFreq ' range=':= 1 * _default_ * recrBlueFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.743 * _default_ * recrBlueFluoriteSize ' range=':= 1 * _default_ * recrBlueFluoriteSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.743 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * recrBlueFluoriteSize ' range=':= _default_ * recrBlueFluoriteSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.743 * _default_ * recrBlueFluoriteSize ' range=':= 1 * _default_ * recrBlueFluoriteSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -1445,10 +1445,10 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 1 * recrBlueFluoriteSize ' range=':=  _default_ * recrBlueFluoriteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.5 * recrBlueFluoriteFreq ' range=':=  _default_ * recrBlueFluoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 1 * recrBlueFluoriteSize ' range=':= _default_ * recrBlueFluoriteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.5 * recrBlueFluoriteFreq ' range=':= _default_ * recrBlueFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -1476,16 +1476,16 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.905 * _default_ * recrBlueFluoriteSize ' range=':=  _default_ * recrBlueFluoriteSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.905 * _default_ * recrBlueFluoriteSize ' range=':=  _default_ * recrBlueFluoriteSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * recrBlueFluoriteFreq ' range=':=  _default_ * recrBlueFluoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 0.905 * _default_ * recrBlueFluoriteSize ' range=':= _default_ * recrBlueFluoriteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.905 * _default_ * recrBlueFluoriteSize ' range=':= _default_ * recrBlueFluoriteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * recrBlueFluoriteFreq ' range=':= _default_ * recrBlueFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='recrBlueFluoriteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60283270' drawBoundBox='false' boundBoxColor='0x60283270'>
                                 <Description>
                                     Single blocks, generously
@@ -1532,21 +1532,21 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:1")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:1' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.410 * _default_ * recrPinkFluoriteFreq ' range=':=  1 * _default_ * recrPinkFluoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.743 * _default_ * recrPinkFluoriteSize ' range=':=  1 * _default_ * recrPinkFluoriteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.743 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * recrPinkFluoriteSize ' range=':=  _default_ * recrPinkFluoriteSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.743 * _default_ * recrPinkFluoriteSize ' range=':=  1 * _default_ * recrPinkFluoriteSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.410 * _default_ * recrPinkFluoriteFreq ' range=':= 1 * _default_ * recrPinkFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.743 * _default_ * recrPinkFluoriteSize ' range=':= 1 * _default_ * recrPinkFluoriteSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.743 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * recrPinkFluoriteSize ' range=':= _default_ * recrPinkFluoriteSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.743 * _default_ * recrPinkFluoriteSize ' range=':= 1 * _default_ * recrPinkFluoriteSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -1565,10 +1565,10 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:1")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:1' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 1 * recrPinkFluoriteSize ' range=':=  _default_ * recrPinkFluoriteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.5 * recrPinkFluoriteFreq ' range=':=  _default_ * recrPinkFluoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 1 * recrPinkFluoriteSize ' range=':= _default_ * recrPinkFluoriteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.5 * recrPinkFluoriteFreq ' range=':= _default_ * recrPinkFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -1596,16 +1596,16 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:1")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:1' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.905 * _default_ * recrPinkFluoriteSize ' range=':=  _default_ * recrPinkFluoriteSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.905 * _default_ * recrPinkFluoriteSize ' range=':=  _default_ * recrPinkFluoriteSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * recrPinkFluoriteFreq ' range=':=  _default_ * recrPinkFluoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 0.905 * _default_ * recrPinkFluoriteSize ' range=':= _default_ * recrPinkFluoriteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.905 * _default_ * recrPinkFluoriteSize ' range=':= _default_ * recrPinkFluoriteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * recrPinkFluoriteFreq ' range=':= _default_ * recrPinkFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='recrPinkFluoriteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x607A5970' drawBoundBox='false' boundBoxColor='0x607A5970'>
                                 <Description>
                                     Single blocks, generously
@@ -1652,21 +1652,21 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:2")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:2' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.410 * _default_ * recrOrangeFluoriteFreq ' range=':=  1 * _default_ * recrOrangeFluoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.743 * _default_ * recrOrangeFluoriteSize ' range=':=  1 * _default_ * recrOrangeFluoriteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.743 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * recrOrangeFluoriteSize ' range=':=  _default_ * recrOrangeFluoriteSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.743 * _default_ * recrOrangeFluoriteSize ' range=':=  1 * _default_ * recrOrangeFluoriteSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.410 * _default_ * recrOrangeFluoriteFreq ' range=':= 1 * _default_ * recrOrangeFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.743 * _default_ * recrOrangeFluoriteSize ' range=':= 1 * _default_ * recrOrangeFluoriteSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.743 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * recrOrangeFluoriteSize ' range=':= _default_ * recrOrangeFluoriteSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.743 * _default_ * recrOrangeFluoriteSize ' range=':= 1 * _default_ * recrOrangeFluoriteSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -1685,10 +1685,10 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:2")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:2' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 1 * recrOrangeFluoriteSize ' range=':=  _default_ * recrOrangeFluoriteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.5 * recrOrangeFluoriteFreq ' range=':=  _default_ * recrOrangeFluoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 1 * recrOrangeFluoriteSize ' range=':= _default_ * recrOrangeFluoriteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.5 * recrOrangeFluoriteFreq ' range=':= _default_ * recrOrangeFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -1716,16 +1716,16 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:2")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:2' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.905 * _default_ * recrOrangeFluoriteSize ' range=':=  _default_ * recrOrangeFluoriteSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.905 * _default_ * recrOrangeFluoriteSize ' range=':=  _default_ * recrOrangeFluoriteSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * recrOrangeFluoriteFreq ' range=':=  _default_ * recrOrangeFluoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 0.905 * _default_ * recrOrangeFluoriteSize ' range=':= _default_ * recrOrangeFluoriteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.905 * _default_ * recrOrangeFluoriteSize ' range=':= _default_ * recrOrangeFluoriteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * recrOrangeFluoriteFreq ' range=':= _default_ * recrOrangeFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='recrOrangeFluoriteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x607A5927' drawBoundBox='false' boundBoxColor='0x607A5927'>
                                 <Description>
                                     Single blocks, generously
@@ -1773,21 +1773,21 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:3")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:3' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.410 * _default_ * recrMagentaFluoriteFreq ' range=':=  1 * _default_ * recrMagentaFluoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.743 * _default_ * recrMagentaFluoriteSize ' range=':=  1 * _default_ * recrMagentaFluoriteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.743 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * recrMagentaFluoriteSize ' range=':=  _default_ * recrMagentaFluoriteSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.743 * _default_ * recrMagentaFluoriteSize ' range=':=  1 * _default_ * recrMagentaFluoriteSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.410 * _default_ * recrMagentaFluoriteFreq ' range=':= 1 * _default_ * recrMagentaFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.743 * _default_ * recrMagentaFluoriteSize ' range=':= 1 * _default_ * recrMagentaFluoriteSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.743 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * recrMagentaFluoriteSize ' range=':= _default_ * recrMagentaFluoriteSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.743 * _default_ * recrMagentaFluoriteSize ' range=':= 1 * _default_ * recrMagentaFluoriteSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -1806,10 +1806,10 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:3")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:3' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 1 * recrMagentaFluoriteSize ' range=':=  _default_ * recrMagentaFluoriteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.5 * recrMagentaFluoriteFreq ' range=':=  _default_ * recrMagentaFluoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 1 * recrMagentaFluoriteSize ' range=':= _default_ * recrMagentaFluoriteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.5 * recrMagentaFluoriteFreq ' range=':= _default_ * recrMagentaFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -1837,16 +1837,16 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:3")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:3' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.905 * _default_ * recrMagentaFluoriteSize ' range=':=  _default_ * recrMagentaFluoriteSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.905 * _default_ * recrMagentaFluoriteSize ' range=':=  _default_ * recrMagentaFluoriteSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * recrMagentaFluoriteFreq ' range=':=  _default_ * recrMagentaFluoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 0.905 * _default_ * recrMagentaFluoriteSize ' range=':= _default_ * recrMagentaFluoriteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.905 * _default_ * recrMagentaFluoriteSize ' range=':= _default_ * recrMagentaFluoriteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * recrMagentaFluoriteFreq ' range=':= _default_ * recrMagentaFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='recrMagentaFluoriteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60602774' drawBoundBox='false' boundBoxColor='0x60602774'>
                                 <Description>
                                     Single blocks, generously
@@ -1893,21 +1893,21 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:4")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:4' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.410 * _default_ * recrGreenFluoriteFreq ' range=':=  1 * _default_ * recrGreenFluoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.743 * _default_ * recrGreenFluoriteSize ' range=':=  1 * _default_ * recrGreenFluoriteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.743 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * recrGreenFluoriteSize ' range=':=  _default_ * recrGreenFluoriteSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.743 * _default_ * recrGreenFluoriteSize ' range=':=  1 * _default_ * recrGreenFluoriteSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.410 * _default_ * recrGreenFluoriteFreq ' range=':= 1 * _default_ * recrGreenFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.743 * _default_ * recrGreenFluoriteSize ' range=':= 1 * _default_ * recrGreenFluoriteSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.743 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * recrGreenFluoriteSize ' range=':= _default_ * recrGreenFluoriteSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.743 * _default_ * recrGreenFluoriteSize ' range=':= 1 * _default_ * recrGreenFluoriteSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -1926,10 +1926,10 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:4")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:4' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 1 * recrGreenFluoriteSize ' range=':=  _default_ * recrGreenFluoriteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.5 * recrGreenFluoriteFreq ' range=':=  _default_ * recrGreenFluoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 1 * recrGreenFluoriteSize ' range=':= _default_ * recrGreenFluoriteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.5 * recrGreenFluoriteFreq ' range=':= _default_ * recrGreenFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -1957,16 +1957,16 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:4")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:4' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.905 * _default_ * recrGreenFluoriteSize ' range=':=  _default_ * recrGreenFluoriteSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.905 * _default_ * recrGreenFluoriteSize ' range=':=  _default_ * recrGreenFluoriteSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * recrGreenFluoriteFreq ' range=':=  _default_ * recrGreenFluoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 0.905 * _default_ * recrGreenFluoriteSize ' range=':= _default_ * recrGreenFluoriteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.905 * _default_ * recrGreenFluoriteSize ' range=':= _default_ * recrGreenFluoriteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * recrGreenFluoriteFreq ' range=':= _default_ * recrGreenFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='recrGreenFluoriteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60347D3B' drawBoundBox='false' boundBoxColor='0x60347D3B'>
                                 <Description>
                                     Single blocks, generously
@@ -2013,21 +2013,21 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:5")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:5' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.410 * _default_ * recrRedFluoriteFreq ' range=':=  1 * _default_ * recrRedFluoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.743 * _default_ * recrRedFluoriteSize ' range=':=  1 * _default_ * recrRedFluoriteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.743 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * recrRedFluoriteSize ' range=':=  _default_ * recrRedFluoriteSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.743 * _default_ * recrRedFluoriteSize ' range=':=  1 * _default_ * recrRedFluoriteSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.410 * _default_ * recrRedFluoriteFreq ' range=':= 1 * _default_ * recrRedFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.743 * _default_ * recrRedFluoriteSize ' range=':= 1 * _default_ * recrRedFluoriteSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.743 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * recrRedFluoriteSize ' range=':= _default_ * recrRedFluoriteSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.743 * _default_ * recrRedFluoriteSize ' range=':= 1 * _default_ * recrRedFluoriteSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -2045,10 +2045,10 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:5")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:5' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 1 * recrRedFluoriteSize ' range=':=  _default_ * recrRedFluoriteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.5 * recrRedFluoriteFreq ' range=':=  _default_ * recrRedFluoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 1 * recrRedFluoriteSize ' range=':= _default_ * recrRedFluoriteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.5 * recrRedFluoriteFreq ' range=':= _default_ * recrRedFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -2076,16 +2076,16 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:5")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:5' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.905 * _default_ * recrRedFluoriteSize ' range=':=  _default_ * recrRedFluoriteSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.905 * _default_ * recrRedFluoriteSize ' range=':=  _default_ * recrRedFluoriteSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * recrRedFluoriteFreq ' range=':=  _default_ * recrRedFluoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 0.905 * _default_ * recrRedFluoriteSize ' range=':= _default_ * recrRedFluoriteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.905 * _default_ * recrRedFluoriteSize ' range=':= _default_ * recrRedFluoriteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * recrRedFluoriteFreq ' range=':= _default_ * recrRedFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='recrRedFluoriteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60974747' drawBoundBox='false' boundBoxColor='0x60974747'>
                                 <Description>
                                     Single blocks, generously
@@ -2132,21 +2132,21 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:6")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:6' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.410 * _default_ * recrWhiteFluoriteFreq ' range=':=  1 * _default_ * recrWhiteFluoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.743 * _default_ * recrWhiteFluoriteSize ' range=':=  1 * _default_ * recrWhiteFluoriteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.743 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * recrWhiteFluoriteSize ' range=':=  _default_ * recrWhiteFluoriteSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.743 * _default_ * recrWhiteFluoriteSize ' range=':=  1 * _default_ * recrWhiteFluoriteSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.410 * _default_ * recrWhiteFluoriteFreq ' range=':= 1 * _default_ * recrWhiteFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.743 * _default_ * recrWhiteFluoriteSize ' range=':= 1 * _default_ * recrWhiteFluoriteSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.743 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * recrWhiteFluoriteSize ' range=':= _default_ * recrWhiteFluoriteSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.743 * _default_ * recrWhiteFluoriteSize ' range=':= 1 * _default_ * recrWhiteFluoriteSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -2165,10 +2165,10 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:6")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:6' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 1 * recrWhiteFluoriteSize ' range=':=  _default_ * recrWhiteFluoriteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.5 * recrWhiteFluoriteFreq ' range=':=  _default_ * recrWhiteFluoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 1 * recrWhiteFluoriteSize ' range=':= _default_ * recrWhiteFluoriteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.5 * recrWhiteFluoriteFreq ' range=':= _default_ * recrWhiteFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -2196,16 +2196,16 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:6")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:6' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.905 * _default_ * recrWhiteFluoriteSize ' range=':=  _default_ * recrWhiteFluoriteSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.905 * _default_ * recrWhiteFluoriteSize ' range=':=  _default_ * recrWhiteFluoriteSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * recrWhiteFluoriteFreq ' range=':=  _default_ * recrWhiteFluoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 0.905 * _default_ * recrWhiteFluoriteSize ' range=':= _default_ * recrWhiteFluoriteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.905 * _default_ * recrWhiteFluoriteSize ' range=':= _default_ * recrWhiteFluoriteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * recrWhiteFluoriteFreq ' range=':= _default_ * recrWhiteFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='recrWhiteFluoriteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60969696' drawBoundBox='false' boundBoxColor='0x60969696'>
                                 <Description>
                                     Single blocks, generously
@@ -2252,21 +2252,21 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:7")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:7' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.410 * _default_ * recrYellowFluoriteFreq ' range=':=  1 * _default_ * recrYellowFluoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.743 * _default_ * recrYellowFluoriteSize ' range=':=  1 * _default_ * recrYellowFluoriteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.743 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * recrYellowFluoriteSize ' range=':=  _default_ * recrYellowFluoriteSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.743 * _default_ * recrYellowFluoriteSize ' range=':=  1 * _default_ * recrYellowFluoriteSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.410 * _default_ * recrYellowFluoriteFreq ' range=':= 1 * _default_ * recrYellowFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.743 * _default_ * recrYellowFluoriteSize ' range=':= 1 * _default_ * recrYellowFluoriteSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.743 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * recrYellowFluoriteSize ' range=':= _default_ * recrYellowFluoriteSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.743 * _default_ * recrYellowFluoriteSize ' range=':= 1 * _default_ * recrYellowFluoriteSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -2285,10 +2285,10 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:7")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:7' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 1 * recrYellowFluoriteSize ' range=':=  _default_ * recrYellowFluoriteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.5 * recrYellowFluoriteFreq ' range=':=  _default_ * recrYellowFluoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 1 * recrYellowFluoriteSize ' range=':= _default_ * recrYellowFluoriteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.5 * recrYellowFluoriteFreq ' range=':= _default_ * recrYellowFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -2316,16 +2316,16 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:7")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:7' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.905 * _default_ * recrYellowFluoriteSize ' range=':=  _default_ * recrYellowFluoriteSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.905 * _default_ * recrYellowFluoriteSize ' range=':=  _default_ * recrYellowFluoriteSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * recrYellowFluoriteFreq ' range=':=  _default_ * recrYellowFluoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 46 ' range=':=  14 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 0.905 * _default_ * recrYellowFluoriteSize ' range=':= _default_ * recrYellowFluoriteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.905 * _default_ * recrYellowFluoriteSize ' range=':= _default_ * recrYellowFluoriteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * recrYellowFluoriteFreq ' range=':= _default_ * recrYellowFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='recrYellowFluoriteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60978834' drawBoundBox='false' boundBoxColor='0x60978834'>
                                 <Description>
                                     Single blocks, generously
@@ -2413,21 +2413,21 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:6")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:6' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 2.425 * _default_ * recrAmmoniumChlorideFreq ' range=':=  1 * _default_ * recrAmmoniumChlorideFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.344 * _default_ * recrAmmoniumChlorideSize ' range=':=  1 * _default_ * recrAmmoniumChlorideSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 32 ' range=':=  0 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.344 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * recrAmmoniumChlorideSize ' range=':=  _default_ * recrAmmoniumChlorideSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.344 * _default_ * recrAmmoniumChlorideSize ' range=':=  1 * _default_ * recrAmmoniumChlorideSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 2.425 * _default_ * recrAmmoniumChlorideFreq ' range=':= 1 * _default_ * recrAmmoniumChlorideFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.344 * _default_ * recrAmmoniumChlorideSize ' range=':= 1 * _default_ * recrAmmoniumChlorideSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 32 ' range=':= 0 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.344 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * recrAmmoniumChlorideSize ' range=':= _default_ * recrAmmoniumChlorideSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.344 * _default_ * recrAmmoniumChlorideSize ' range=':= 1 * _default_ * recrAmmoniumChlorideSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -2446,10 +2446,10 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:6")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:6' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 8 * recrAmmoniumChlorideSize ' range=':=  _default_ * recrAmmoniumChlorideSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 6 * recrAmmoniumChlorideFreq ' range=':=  _default_ * recrAmmoniumChlorideFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 32 ' range=':=  0 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 8 * recrAmmoniumChlorideSize ' range=':= _default_ * recrAmmoniumChlorideSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 6 * recrAmmoniumChlorideFreq ' range=':= _default_ * recrAmmoniumChlorideFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 32 ' range=':= 0 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -2477,16 +2477,16 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:6")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:6' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.280 * _default_ * recrAmmoniumChlorideSize ' range=':=  _default_ * recrAmmoniumChlorideSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.280 * _default_ * recrAmmoniumChlorideSize ' range=':=  _default_ * recrAmmoniumChlorideSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.638  * _default_ * recrAmmoniumChlorideFreq ' range=':=  _default_ * recrAmmoniumChlorideFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 32 ' range=':=  0 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 1.280 * _default_ * recrAmmoniumChlorideSize ' range=':= _default_ * recrAmmoniumChlorideSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.280 * _default_ * recrAmmoniumChlorideSize ' range=':= _default_ * recrAmmoniumChlorideSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.638  * _default_ * recrAmmoniumChlorideFreq ' range=':= _default_ * recrAmmoniumChlorideFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 32 ' range=':= 0 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='recrAmmoniumChlorideHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FFFFFF' drawBoundBox='false' boundBoxColor='0x60FFFFFF'>
                                 <Description>
                                     Single blocks, generously
@@ -2533,21 +2533,21 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:9")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:9' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.715 * _default_ * recrThoriteFreq ' range=':=  1 * _default_ * recrThoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.197 * _default_ * recrThoriteSize ' range=':=  1 * _default_ * recrThoriteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 18.5 ' range=':=  13.5 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.197 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * recrThoriteSize ' range=':=  _default_ * recrThoriteSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.197 * _default_ * recrThoriteSize ' range=':=  1 * _default_ * recrThoriteSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.715 * _default_ * recrThoriteFreq ' range=':= 1 * _default_ * recrThoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.197 * _default_ * recrThoriteSize ' range=':= 1 * _default_ * recrThoriteSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 18.5 ' range=':= 13.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.197 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * recrThoriteSize ' range=':= _default_ * recrThoriteSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.197 * _default_ * recrThoriteSize ' range=':= 1 * _default_ * recrThoriteSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -2565,10 +2565,10 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:9")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:9' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 24 * recrThoriteSize ' range=':=  _default_ * recrThoriteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1 * recrThoriteFreq ' range=':=  _default_ * recrThoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 18.5 ' range=':=  13.5 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 24 * recrThoriteSize ' range=':= _default_ * recrThoriteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1 * recrThoriteFreq ' range=':= _default_ * recrThoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 18.5 ' range=':= 13.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -2596,16 +2596,16 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:9")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:9' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.076 * _default_ * recrThoriteSize ' range=':=  _default_ * recrThoriteSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.076 * _default_ * recrThoriteSize ' range=':=  _default_ * recrThoriteSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.159  * _default_ * recrThoriteFreq ' range=':=  _default_ * recrThoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 18.5 ' range=':=  13.5 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 1.076 * _default_ * recrThoriteSize ' range=':= _default_ * recrThoriteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.076 * _default_ * recrThoriteSize ' range=':= _default_ * recrThoriteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.159  * _default_ * recrThoriteFreq ' range=':= _default_ * recrThoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 18.5 ' range=':= 13.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='recrThoriteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x6054A228' drawBoundBox='false' boundBoxColor='0x6054A228'>
                                 <Description>
                                     Single blocks, generously
@@ -2691,21 +2691,21 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:5")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:5' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 3.430 * _default_ * recrEndPitchblendeFreq ' range=':=  1 * _default_ * recrEndPitchblendeFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.508 * _default_ * recrEndPitchblendeSize ' range=':=  1 * _default_ * recrEndPitchblendeSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 34.5 ' range=':=  29.5 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.508 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * recrEndPitchblendeSize ' range=':=  _default_ * recrEndPitchblendeSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.508 * _default_ * recrEndPitchblendeSize ' range=':=  1 * _default_ * recrEndPitchblendeSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 3.430 * _default_ * recrEndPitchblendeFreq ' range=':= 1 * _default_ * recrEndPitchblendeFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.508 * _default_ * recrEndPitchblendeSize ' range=':= 1 * _default_ * recrEndPitchblendeSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 34.5 ' range=':= 29.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.508 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * recrEndPitchblendeSize ' range=':= _default_ * recrEndPitchblendeSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.508 * _default_ * recrEndPitchblendeSize ' range=':= 1 * _default_ * recrEndPitchblendeSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -2724,10 +2724,10 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:5")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:5' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 16 * recrEndPitchblendeSize ' range=':=  _default_ * recrEndPitchblendeSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 6 * recrEndPitchblendeFreq ' range=':=  _default_ * recrEndPitchblendeFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 34.5 ' range=':=  29.5 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 16 * recrEndPitchblendeSize ' range=':= _default_ * recrEndPitchblendeSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 6 * recrEndPitchblendeFreq ' range=':= _default_ * recrEndPitchblendeFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 34.5 ' range=':= 29.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -2755,16 +2755,16 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:5")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:5' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.522 * _default_ * recrEndPitchblendeSize ' range=':=  _default_ * recrEndPitchblendeSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.522 * _default_ * recrEndPitchblendeSize ' range=':=  _default_ * recrEndPitchblendeSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 2.317  * _default_ * recrEndPitchblendeFreq ' range=':=  _default_ * recrEndPitchblendeFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 34.5 ' range=':=  29.5 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 1.522 * _default_ * recrEndPitchblendeSize ' range=':= _default_ * recrEndPitchblendeSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.522 * _default_ * recrEndPitchblendeSize ' range=':= _default_ * recrEndPitchblendeSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 2.317  * _default_ * recrEndPitchblendeFreq ' range=':= _default_ * recrEndPitchblendeFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 34.5 ' range=':= 29.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='recrEndPitchblendeHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60454454' drawBoundBox='false' boundBoxColor='0x60454454'>
                                 <Description>
                                     Single blocks, generously

--- a/src/main/resources/config/modules/SimpleOres.xml
+++ b/src/main/resources/config/modules/SimpleOres.xml
@@ -250,21 +250,21 @@
                             <IfCondition condition=':= ?blockExists("simpleores:copper_ore")'> <OreBlock block='simpleores:copper_ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.854 * _default_ * smpoCopperFreq ' range=':=  _default_ * smpoCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.228 * _default_ * smpoCopperSize ' range=':=  _default_ * smpoCopperSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 48 ' range=':=  42 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.228 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * smpoCopperSize ' range=':=  _default_ * smpoCopperSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.228 * _default_ * smpoCopperSize ' range=':=  _default_ * smpoCopperSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.854 * _default_ * smpoCopperFreq ' range=':= _default_ * smpoCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.228 * _default_ * smpoCopperSize ' range=':= _default_ * smpoCopperSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 48 ' range=':= 42 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.228 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * smpoCopperSize ' range=':= _default_ * smpoCopperSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.228 * _default_ * smpoCopperSize ' range=':= _default_ * smpoCopperSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -292,16 +292,16 @@
                             <IfCondition condition=':= ?blockExists("simpleores:copper_ore")'> <OreBlock block='simpleores:copper_ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.924 * _default_ * smpoCopperSize ' range=':=  _default_ * smpoCopperSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.924 * _default_ * smpoCopperSize ' range=':=  _default_ * smpoCopperSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 3.702  * _default_ * smpoCopperFreq ' range=':=  _default_ * smpoCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 48 ' range=':=  42 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 1.924 * _default_ * smpoCopperSize ' range=':= _default_ * smpoCopperSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.924 * _default_ * smpoCopperSize ' range=':= _default_ * smpoCopperSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 3.702  * _default_ * smpoCopperFreq ' range=':= _default_ * smpoCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 48 ' range=':= 42 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='smpoCopperHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
                                 <Description>
                                     Single blocks, generously
@@ -344,10 +344,10 @@
                             <IfCondition condition=':= ?blockExists("simpleores:copper_ore")'> <OreBlock block='simpleores:copper_ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 7 * smpoCopperSize ' range=':=  _default_ * smpoCopperSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 35 * smpoCopperFreq ' range=':=  _default_ * smpoCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 48 ' range=':=  42 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 7 * smpoCopperSize ' range=':= _default_ * smpoCopperSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 35 * smpoCopperFreq ' range=':= _default_ * smpoCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 48 ' range=':= 42 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -369,21 +369,21 @@
                             <IfCondition condition=':= ?blockExists("simpleores:tin_ore")'> <OreBlock block='simpleores:tin_ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.716 * _default_ * smpoTinFreq ' range=':=  _default_ * smpoTinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.197 * _default_ * smpoTinSize ' range=':=  _default_ * smpoTinSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 48 ' range=':=  42 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.197 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * smpoTinSize ' range=':=  _default_ * smpoTinSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.197 * _default_ * smpoTinSize ' range=':=  _default_ * smpoTinSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.716 * _default_ * smpoTinFreq ' range=':= _default_ * smpoTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.197 * _default_ * smpoTinSize ' range=':= _default_ * smpoTinSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 48 ' range=':= 42 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.197 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * smpoTinSize ' range=':= _default_ * smpoTinSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.197 * _default_ * smpoTinSize ' range=':= _default_ * smpoTinSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -411,16 +411,16 @@
                             <IfCondition condition=':= ?blockExists("simpleores:tin_ore")'> <OreBlock block='simpleores:tin_ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.851 * _default_ * smpoTinSize ' range=':=  _default_ * smpoTinSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.851 * _default_ * smpoTinSize ' range=':=  _default_ * smpoTinSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 3.427  * _default_ * smpoTinFreq ' range=':=  _default_ * smpoTinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 48 ' range=':=  42 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 1.851 * _default_ * smpoTinSize ' range=':= _default_ * smpoTinSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.851 * _default_ * smpoTinSize ' range=':= _default_ * smpoTinSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 3.427  * _default_ * smpoTinFreq ' range=':= _default_ * smpoTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 48 ' range=':= 42 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='smpoTinHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
                                 <Description>
                                     Single blocks, generously
@@ -463,10 +463,10 @@
                             <IfCondition condition=':= ?blockExists("simpleores:tin_ore")'> <OreBlock block='simpleores:tin_ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 7 * smpoTinSize ' range=':=  _default_ * smpoTinSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 30 * smpoTinFreq ' range=':=  _default_ * smpoTinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 48 ' range=':=  42 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 7 * smpoTinSize ' range=':= _default_ * smpoTinSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 30 * smpoTinFreq ' range=':= _default_ * smpoTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 48 ' range=':= 42 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -488,21 +488,21 @@
                             <IfCondition condition=':= ?blockExists("simpleores:mythril_ore")'> <OreBlock block='simpleores:mythril_ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.670 * _default_ * smpoMythrilFreq ' range=':=  _default_ * smpoMythrilFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.875 * _default_ * smpoMythrilSize ' range=':=  _default_ * smpoMythrilSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 20 ' range=':=  15 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.875 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * smpoMythrilSize ' range=':=  _default_ * smpoMythrilSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.875 * _default_ * smpoMythrilSize ' range=':=  _default_ * smpoMythrilSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.670 * _default_ * smpoMythrilFreq ' range=':= _default_ * smpoMythrilFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.875 * _default_ * smpoMythrilSize ' range=':= _default_ * smpoMythrilSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 20 ' range=':= 15 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.875 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * smpoMythrilSize ' range=':= _default_ * smpoMythrilSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.875 * _default_ * smpoMythrilSize ' range=':= _default_ * smpoMythrilSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -530,16 +530,16 @@
                             <IfCondition condition=':= ?blockExists("simpleores:mythril_ore")'> <OreBlock block='simpleores:mythril_ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.157 * _default_ * smpoMythrilSize ' range=':=  _default_ * smpoMythrilSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.157 * _default_ * smpoMythrilSize ' range=':=  _default_ * smpoMythrilSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.338  * _default_ * smpoMythrilFreq ' range=':=  _default_ * smpoMythrilFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 20 ' range=':=  15 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 1.157 * _default_ * smpoMythrilSize ' range=':= _default_ * smpoMythrilSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.157 * _default_ * smpoMythrilSize ' range=':= _default_ * smpoMythrilSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.338  * _default_ * smpoMythrilFreq ' range=':= _default_ * smpoMythrilFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 20 ' range=':= 15 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='smpoMythrilHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x6079AFD2' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
                                 <Description>
                                     Single blocks, generously
@@ -582,10 +582,10 @@
                             <IfCondition condition=':= ?blockExists("simpleores:mythril_ore")'> <OreBlock block='simpleores:mythril_ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4 * smpoMythrilSize ' range=':=  _default_ * smpoMythrilSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 8 * smpoMythrilFreq ' range=':=  _default_ * smpoMythrilFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 20 ' range=':=  15 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 4 * smpoMythrilSize ' range=':= _default_ * smpoMythrilSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 8 * smpoMythrilFreq ' range=':= _default_ * smpoMythrilFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 20 ' range=':= 15 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -607,21 +607,21 @@
                             <IfCondition condition=':= ?blockExists("simpleores:adamantium_ore")'> <OreBlock block='simpleores:adamantium_ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.474 * _default_ * smpoAdamantiumFreq ' range=':=  _default_ * smpoAdamantiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.780 * _default_ * smpoAdamantiumSize ' range=':=  _default_ * smpoAdamantiumSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 13 ' range=':=  7 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.780 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * smpoAdamantiumSize ' range=':=  _default_ * smpoAdamantiumSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.780 * _default_ * smpoAdamantiumSize ' range=':=  _default_ * smpoAdamantiumSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.474 * _default_ * smpoAdamantiumFreq ' range=':= _default_ * smpoAdamantiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.780 * _default_ * smpoAdamantiumSize ' range=':= _default_ * smpoAdamantiumSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 13 ' range=':= 7 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.780 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * smpoAdamantiumSize ' range=':= _default_ * smpoAdamantiumSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.780 * _default_ * smpoAdamantiumSize ' range=':= _default_ * smpoAdamantiumSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -649,16 +649,16 @@
                             <IfCondition condition=':= ?blockExists("simpleores:adamantium_ore")'> <OreBlock block='simpleores:adamantium_ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.973 * _default_ * smpoAdamantiumSize ' range=':=  _default_ * smpoAdamantiumSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.973 * _default_ * smpoAdamantiumSize ' range=':=  _default_ * smpoAdamantiumSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * smpoAdamantiumFreq ' range=':=  _default_ * smpoAdamantiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 13 ' range=':=  7 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 0.973 * _default_ * smpoAdamantiumSize ' range=':= _default_ * smpoAdamantiumSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.973 * _default_ * smpoAdamantiumSize ' range=':= _default_ * smpoAdamantiumSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * smpoAdamantiumFreq ' range=':= _default_ * smpoAdamantiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 13 ' range=':= 7 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='smpoAdamantiumHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60159800' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
                                 <Description>
                                     Single blocks, generously
@@ -701,10 +701,10 @@
                             <IfCondition condition=':= ?blockExists("simpleores:adamantium_ore")'> <OreBlock block='simpleores:adamantium_ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4 * smpoAdamantiumSize ' range=':=  _default_ * smpoAdamantiumSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 4 * smpoAdamantiumFreq ' range=':=  _default_ * smpoAdamantiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 13 ' range=':=  7 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 4 * smpoAdamantiumSize ' range=':= _default_ * smpoAdamantiumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4 * smpoAdamantiumFreq ' range=':= _default_ * smpoAdamantiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 13 ' range=':= 7 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -750,7 +750,7 @@
                 <!-- Starting PipeVeins Preset for Onyx. -->
                 <ConfigSection>
                     <IfCondition condition=':= smpoOnyxDist = "PipeVeins"'>
-                        <Veins name='smpoOnyxVeins'  inherits='PresetPipeVeins' seed='0x3996' drawWireframe='true' wireframeColor='0x60232323' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                        <Veins name='smpoOnyxVeins'  inherits='PresetPipeVeins' seed='0x1523' drawWireframe='true' wireframeColor='0x60232323' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
                             <Description>
                                 Short sparsely filled veins  sloping
                                 up from near the bottom  of the map.
@@ -758,30 +758,30 @@
                             <IfCondition condition=':= ?blockExists("simpleores:onyx_ore")'> <OreBlock block='simpleores:onyx_ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.474 * _default_ * smpoOnyxFreq ' range=':=  _default_ * smpoOnyxFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.780 * _default_ * smpoOnyxSize ' range=':=  _default_ * smpoOnyxSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 72 ' range=':=  56 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.780 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * smpoOnyxSize ' range=':=  _default_ * smpoOnyxSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.780 * _default_ * smpoOnyxSize ' range=':=  _default_ * smpoOnyxSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.474 * _default_ * smpoOnyxFreq ' range=':= _default_ * smpoOnyxFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.780 * _default_ * smpoOnyxSize ' range=':= _default_ * smpoOnyxSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 72 ' range=':= 56 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.780 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * smpoOnyxSize ' range=':= _default_ * smpoOnyxSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.780 * _default_ * smpoOnyxSize ' range=':= _default_ * smpoOnyxSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
 
                         <!-- Configuring contained material. -->
-                        <Veins name='smpoOnyxVeinsPipe'  inherits='smpoOnyxVeins' seed='0x3996' drawWireframe='true' wireframeColor='0x60232323' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                        <Veins name='smpoOnyxVeinsPipe'  inherits='smpoOnyxVeins' seed='0x1523' drawWireframe='true' wireframeColor='0x60232323' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <OreBlock block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("simpleores:onyx_ore")'> <Replaces block='simpleores:onyx_ore' weight='1.0' /> </IfCondition>
-                            <Setting name='MotherlodeSize' avg=':= 0.780 * _default_ * smpoOnyxSize  * 0.5 ' range=':=  _default_ * smpoOnyxSize  * 0.5 ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.780 * _default_ * smpoOnyxSize  * 0.5 ' range=':=  _default_ * smpoOnyxSize  * 0.5 ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.780 * _default_ * smpoOnyxSize  * 0.5 ' range=':= _default_ * smpoOnyxSize  * 0.5 ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.780 * _default_ * smpoOnyxSize  * 0.5 ' range=':= _default_ * smpoOnyxSize  * 0.5 ' type='normal' />
                             <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
                         </Veins>
                     </IfCondition>
@@ -810,16 +810,16 @@
                             <IfCondition condition=':= ?blockExists("simpleores:onyx_ore")'> <OreBlock block='simpleores:onyx_ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.973 * _default_ * smpoOnyxSize ' range=':=  _default_ * smpoOnyxSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.973 * _default_ * smpoOnyxSize ' range=':=  _default_ * smpoOnyxSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * smpoOnyxFreq ' range=':=  _default_ * smpoOnyxFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 72 ' range=':=  56 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 0.973 * _default_ * smpoOnyxSize ' range=':= _default_ * smpoOnyxSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.973 * _default_ * smpoOnyxSize ' range=':= _default_ * smpoOnyxSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * smpoOnyxFreq ' range=':= _default_ * smpoOnyxFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 72 ' range=':= 56 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='smpoOnyxHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60232323' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
                                 <Description>
                                     Single blocks, generously
@@ -862,10 +862,10 @@
                             <IfCondition condition=':= ?blockExists("simpleores:onyx_ore")'> <OreBlock block='simpleores:onyx_ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 7 * smpoOnyxSize ' range=':=  _default_ * smpoOnyxSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 5 * smpoOnyxFreq ' range=':=  _default_ * smpoOnyxFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 72 ' range=':=  56 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 7 * smpoOnyxSize ' range=':= _default_ * smpoOnyxSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 5 * smpoOnyxFreq ' range=':= _default_ * smpoOnyxFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 72 ' range=':= 56 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>

--- a/src/main/resources/config/modules/Thaumcraft4.xml
+++ b/src/main/resources/config/modules/Thaumcraft4.xml
@@ -363,21 +363,21 @@
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:7")'> <OreBlock block='Thaumcraft:blockCustomOre:7' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.990 * _default_ * thm4AmberFreq ' range=':=  _default_ * thm4AmberFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.997 * _default_ * thm4AmberSize ' range=':=  _default_ * thm4AmberSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 50 ' range=':=  16 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.997 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * thm4AmberSize ' range=':=  _default_ * thm4AmberSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.997 * _default_ * thm4AmberSize ' range=':=  _default_ * thm4AmberSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.990 * _default_ * thm4AmberFreq ' range=':= _default_ * thm4AmberFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.997 * _default_ * thm4AmberSize ' range=':= _default_ * thm4AmberSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 50 ' range=':= 16 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.997 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * thm4AmberSize ' range=':= _default_ * thm4AmberSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.997 * _default_ * thm4AmberSize ' range=':= _default_ * thm4AmberSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -405,16 +405,16 @@
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:7")'> <OreBlock block='Thaumcraft:blockCustomOre:7' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.818 * _default_ * thm4AmberSize ' range=':=  _default_ * thm4AmberSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.818 * _default_ * thm4AmberSize ' range=':=  _default_ * thm4AmberSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.669  * _default_ * thm4AmberFreq ' range=':=  _default_ * thm4AmberFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 50 ' range=':=  16 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 0.818 * _default_ * thm4AmberSize ' range=':= _default_ * thm4AmberSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.818 * _default_ * thm4AmberSize ' range=':= _default_ * thm4AmberSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.669  * _default_ * thm4AmberFreq ' range=':= _default_ * thm4AmberFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 50 ' range=':= 16 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='thm4AmberHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FE9D1B' drawBoundBox='false' boundBoxColor='0x60FE9D1B'>
                                 <Description>
                                     Single blocks, generously
@@ -457,10 +457,10 @@
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:7")'> <OreBlock block='Thaumcraft:blockCustomOre:7' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 1 * thm4AmberSize ' range=':=  _default_ * thm4AmberSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 8 * thm4AmberFreq ' range=':=  _default_ * thm4AmberFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 50 ' range=':=  16 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 1 * thm4AmberSize ' range=':= _default_ * thm4AmberSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 8 * thm4AmberFreq ' range=':= _default_ * thm4AmberFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 50 ' range=':= 16 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -489,21 +489,21 @@
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre")'> <OreBlock block='Thaumcraft:blockCustomOre' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.213 * _default_ * thm4CinnabarFreq ' range=':=  _default_ * thm4CinnabarFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.066 * _default_ * thm4CinnabarSize ' range=':=  _default_ * thm4CinnabarSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.066 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * thm4CinnabarSize ' range=':=  _default_ * thm4CinnabarSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.066 * _default_ * thm4CinnabarSize ' range=':=  _default_ * thm4CinnabarSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.213 * _default_ * thm4CinnabarFreq ' range=':= _default_ * thm4CinnabarFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.066 * _default_ * thm4CinnabarSize ' range=':= _default_ * thm4CinnabarSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.066 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * thm4CinnabarSize ' range=':= _default_ * thm4CinnabarSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.066 * _default_ * thm4CinnabarSize ' range=':= _default_ * thm4CinnabarSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -531,16 +531,16 @@
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre")'> <OreBlock block='Thaumcraft:blockCustomOre' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.905 * _default_ * thm4CinnabarSize ' range=':=  _default_ * thm4CinnabarSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.905 * _default_ * thm4CinnabarSize ' range=':=  _default_ * thm4CinnabarSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * thm4CinnabarFreq ' range=':=  _default_ * thm4CinnabarFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 0.905 * _default_ * thm4CinnabarSize ' range=':= _default_ * thm4CinnabarSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.905 * _default_ * thm4CinnabarSize ' range=':= _default_ * thm4CinnabarSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * thm4CinnabarFreq ' range=':= _default_ * thm4CinnabarFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='thm4CinnabarHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60831C20' drawBoundBox='false' boundBoxColor='0x60831C20'>
                                 <Description>
                                     Single blocks, generously
@@ -583,10 +583,10 @@
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre")'> <OreBlock block='Thaumcraft:blockCustomOre' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 1 * thm4CinnabarSize ' range=':=  _default_ * thm4CinnabarSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 12 * thm4CinnabarFreq ' range=':=  _default_ * thm4CinnabarFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 1 * thm4CinnabarSize ' range=':= _default_ * thm4CinnabarSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 12 * thm4CinnabarFreq ' range=':= _default_ * thm4CinnabarFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -616,21 +616,21 @@
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:1")'> <OreBlock block='Thaumcraft:blockCustomOre:1' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.783 * _default_ * thm4AirInfusedStoneFreq ' range=':=  _default_ * thm4AirInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * thm4AirInfusedStoneSize ' range=':=  _default_ * thm4AirInfusedStoneSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.922 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * thm4AirInfusedStoneSize ' range=':=  _default_ * thm4AirInfusedStoneSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.922 * _default_ * thm4AirInfusedStoneSize ' range=':=  _default_ * thm4AirInfusedStoneSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.783 * _default_ * thm4AirInfusedStoneFreq ' range=':= _default_ * thm4AirInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * thm4AirInfusedStoneSize ' range=':= _default_ * thm4AirInfusedStoneSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.922 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * thm4AirInfusedStoneSize ' range=':= _default_ * thm4AirInfusedStoneSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.922 * _default_ * thm4AirInfusedStoneSize ' range=':= _default_ * thm4AirInfusedStoneSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
 
                         <!-- Beginning "Preferred" configuration. -->
@@ -642,21 +642,21 @@
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:1")'> <OreBlock block='Thaumcraft:blockCustomOre:1' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <BiomeType name='Plains'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.783 * _default_ * thm4AirInfusedStoneFreq ' range=':=  _default_ * thm4AirInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * thm4AirInfusedStoneSize ' range=':=  _default_ * thm4AirInfusedStoneSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.922 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * thm4AirInfusedStoneSize ' range=':=  _default_ * thm4AirInfusedStoneSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.922 * _default_ * thm4AirInfusedStoneSize ' range=':=  _default_ * thm4AirInfusedStoneSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.783 * _default_ * thm4AirInfusedStoneFreq ' range=':= _default_ * thm4AirInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * thm4AirInfusedStoneSize ' range=':= _default_ * thm4AirInfusedStoneSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.922 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * thm4AirInfusedStoneSize ' range=':= _default_ * thm4AirInfusedStoneSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.922 * _default_ * thm4AirInfusedStoneSize ' range=':= _default_ * thm4AirInfusedStoneSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                         <!-- "Preferred" configuration complete. -->
 
@@ -687,16 +687,16 @@
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:1")'> <OreBlock block='Thaumcraft:blockCustomOre:1' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.727 * _default_ * thm4AirInfusedStoneSize ' range=':=  _default_ * thm4AirInfusedStoneSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.727 * _default_ * thm4AirInfusedStoneSize ' range=':=  _default_ * thm4AirInfusedStoneSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.529  * _default_ * thm4AirInfusedStoneFreq ' range=':=  _default_ * thm4AirInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 0.727 * _default_ * thm4AirInfusedStoneSize ' range=':= _default_ * thm4AirInfusedStoneSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.727 * _default_ * thm4AirInfusedStoneSize ' range=':= _default_ * thm4AirInfusedStoneSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.529  * _default_ * thm4AirInfusedStoneFreq ' range=':= _default_ * thm4AirInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='thm4AirInfusedStoneHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FEFEAB' drawBoundBox='false' boundBoxColor='0x60FEFEAB'>
                                 <Description>
                                     Single blocks, generously
@@ -733,16 +733,16 @@
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:1")'> <OreBlock block='Thaumcraft:blockCustomOre:1' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <BiomeType name='Plains'  />
-                            <Setting name='CloudRadius' avg=':= 0.727 * _default_ * thm4AirInfusedStoneSize ' range=':=  _default_ * thm4AirInfusedStoneSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.727 * _default_ * thm4AirInfusedStoneSize ' range=':=  _default_ * thm4AirInfusedStoneSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.529  * _default_ * thm4AirInfusedStoneFreq ' range=':=  _default_ * thm4AirInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 0.727 * _default_ * thm4AirInfusedStoneSize ' range=':= _default_ * thm4AirInfusedStoneSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.727 * _default_ * thm4AirInfusedStoneSize ' range=':= _default_ * thm4AirInfusedStoneSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.529  * _default_ * thm4AirInfusedStoneFreq ' range=':= _default_ * thm4AirInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='thm4AirInfusedStonePreferredHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FEFEAB' drawBoundBox='false' boundBoxColor='0x60FEFEAB'>
                                 <Description>
                                     Ore generation is doubled in
@@ -771,10 +771,10 @@
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:1")'> <OreBlock block='Thaumcraft:blockCustomOre:1' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 5 * thm4AirInfusedStoneSize ' range=':=  _default_ * thm4AirInfusedStoneSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1 * thm4AirInfusedStoneFreq ' range=':=  _default_ * thm4AirInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 5 * thm4AirInfusedStoneSize ' range=':= _default_ * thm4AirInfusedStoneSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1 * thm4AirInfusedStoneFreq ' range=':= _default_ * thm4AirInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -804,21 +804,21 @@
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:2")'> <OreBlock block='Thaumcraft:blockCustomOre:2' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.783 * _default_ * thm4FireInfusedStoneFreq ' range=':=  _default_ * thm4FireInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * thm4FireInfusedStoneSize ' range=':=  _default_ * thm4FireInfusedStoneSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.922 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * thm4FireInfusedStoneSize ' range=':=  _default_ * thm4FireInfusedStoneSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.922 * _default_ * thm4FireInfusedStoneSize ' range=':=  _default_ * thm4FireInfusedStoneSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.783 * _default_ * thm4FireInfusedStoneFreq ' range=':= _default_ * thm4FireInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * thm4FireInfusedStoneSize ' range=':= _default_ * thm4FireInfusedStoneSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.922 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * thm4FireInfusedStoneSize ' range=':= _default_ * thm4FireInfusedStoneSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.922 * _default_ * thm4FireInfusedStoneSize ' range=':= _default_ * thm4FireInfusedStoneSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
 
                         <!-- Beginning "Preferred" configuration. -->
@@ -830,21 +830,21 @@
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:2")'> <OreBlock block='Thaumcraft:blockCustomOre:2' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <BiomeType name='Desert'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.783 * _default_ * thm4FireInfusedStoneFreq ' range=':=  _default_ * thm4FireInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * thm4FireInfusedStoneSize ' range=':=  _default_ * thm4FireInfusedStoneSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.922 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * thm4FireInfusedStoneSize ' range=':=  _default_ * thm4FireInfusedStoneSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.922 * _default_ * thm4FireInfusedStoneSize ' range=':=  _default_ * thm4FireInfusedStoneSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.783 * _default_ * thm4FireInfusedStoneFreq ' range=':= _default_ * thm4FireInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * thm4FireInfusedStoneSize ' range=':= _default_ * thm4FireInfusedStoneSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.922 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * thm4FireInfusedStoneSize ' range=':= _default_ * thm4FireInfusedStoneSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.922 * _default_ * thm4FireInfusedStoneSize ' range=':= _default_ * thm4FireInfusedStoneSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                         <!-- "Preferred" configuration complete. -->
 
@@ -875,16 +875,16 @@
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:2")'> <OreBlock block='Thaumcraft:blockCustomOre:2' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.727 * _default_ * thm4FireInfusedStoneSize ' range=':=  _default_ * thm4FireInfusedStoneSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.727 * _default_ * thm4FireInfusedStoneSize ' range=':=  _default_ * thm4FireInfusedStoneSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.529  * _default_ * thm4FireInfusedStoneFreq ' range=':=  _default_ * thm4FireInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 0.727 * _default_ * thm4FireInfusedStoneSize ' range=':= _default_ * thm4FireInfusedStoneSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.727 * _default_ * thm4FireInfusedStoneSize ' range=':= _default_ * thm4FireInfusedStoneSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.529  * _default_ * thm4FireInfusedStoneFreq ' range=':= _default_ * thm4FireInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='thm4FireInfusedStoneHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FC5100' drawBoundBox='false' boundBoxColor='0x60FC5100'>
                                 <Description>
                                     Single blocks, generously
@@ -921,16 +921,16 @@
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:2")'> <OreBlock block='Thaumcraft:blockCustomOre:2' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <BiomeType name='Desert'  />
-                            <Setting name='CloudRadius' avg=':= 0.727 * _default_ * thm4FireInfusedStoneSize ' range=':=  _default_ * thm4FireInfusedStoneSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.727 * _default_ * thm4FireInfusedStoneSize ' range=':=  _default_ * thm4FireInfusedStoneSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.529  * _default_ * thm4FireInfusedStoneFreq ' range=':=  _default_ * thm4FireInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 0.727 * _default_ * thm4FireInfusedStoneSize ' range=':= _default_ * thm4FireInfusedStoneSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.727 * _default_ * thm4FireInfusedStoneSize ' range=':= _default_ * thm4FireInfusedStoneSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.529  * _default_ * thm4FireInfusedStoneFreq ' range=':= _default_ * thm4FireInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='thm4FireInfusedStonePreferredHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FC5100' drawBoundBox='false' boundBoxColor='0x60FC5100'>
                                 <Description>
                                     Ore generation is doubled in
@@ -959,10 +959,10 @@
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:2")'> <OreBlock block='Thaumcraft:blockCustomOre:2' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 5 * thm4FireInfusedStoneSize ' range=':=  _default_ * thm4FireInfusedStoneSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1 * thm4FireInfusedStoneFreq ' range=':=  _default_ * thm4FireInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 5 * thm4FireInfusedStoneSize ' range=':= _default_ * thm4FireInfusedStoneSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1 * thm4FireInfusedStoneFreq ' range=':= _default_ * thm4FireInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -993,21 +993,21 @@
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:3")'> <OreBlock block='Thaumcraft:blockCustomOre:3' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.783 * _default_ * thm4WaterInfusedStoneFreq ' range=':=  _default_ * thm4WaterInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * thm4WaterInfusedStoneSize ' range=':=  _default_ * thm4WaterInfusedStoneSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.922 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * thm4WaterInfusedStoneSize ' range=':=  _default_ * thm4WaterInfusedStoneSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.922 * _default_ * thm4WaterInfusedStoneSize ' range=':=  _default_ * thm4WaterInfusedStoneSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.783 * _default_ * thm4WaterInfusedStoneFreq ' range=':= _default_ * thm4WaterInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * thm4WaterInfusedStoneSize ' range=':= _default_ * thm4WaterInfusedStoneSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.922 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * thm4WaterInfusedStoneSize ' range=':= _default_ * thm4WaterInfusedStoneSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.922 * _default_ * thm4WaterInfusedStoneSize ' range=':= _default_ * thm4WaterInfusedStoneSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
 
                         <!-- Beginning "Preferred" configuration. -->
@@ -1020,21 +1020,21 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <BiomeType name='Water'  />
                             <BiomeType name='Swamp'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.783 * _default_ * thm4WaterInfusedStoneFreq ' range=':=  _default_ * thm4WaterInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * thm4WaterInfusedStoneSize ' range=':=  _default_ * thm4WaterInfusedStoneSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.922 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * thm4WaterInfusedStoneSize ' range=':=  _default_ * thm4WaterInfusedStoneSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.922 * _default_ * thm4WaterInfusedStoneSize ' range=':=  _default_ * thm4WaterInfusedStoneSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.783 * _default_ * thm4WaterInfusedStoneFreq ' range=':= _default_ * thm4WaterInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * thm4WaterInfusedStoneSize ' range=':= _default_ * thm4WaterInfusedStoneSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.922 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * thm4WaterInfusedStoneSize ' range=':= _default_ * thm4WaterInfusedStoneSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.922 * _default_ * thm4WaterInfusedStoneSize ' range=':= _default_ * thm4WaterInfusedStoneSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                         <!-- "Preferred" configuration complete. -->
 
@@ -1065,16 +1065,16 @@
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:3")'> <OreBlock block='Thaumcraft:blockCustomOre:3' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.727 * _default_ * thm4WaterInfusedStoneSize ' range=':=  _default_ * thm4WaterInfusedStoneSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.727 * _default_ * thm4WaterInfusedStoneSize ' range=':=  _default_ * thm4WaterInfusedStoneSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.529  * _default_ * thm4WaterInfusedStoneFreq ' range=':=  _default_ * thm4WaterInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 0.727 * _default_ * thm4WaterInfusedStoneSize ' range=':= _default_ * thm4WaterInfusedStoneSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.727 * _default_ * thm4WaterInfusedStoneSize ' range=':= _default_ * thm4WaterInfusedStoneSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.529  * _default_ * thm4WaterInfusedStoneFreq ' range=':= _default_ * thm4WaterInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='thm4WaterInfusedStoneHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x6000C0FA' drawBoundBox='false' boundBoxColor='0x6000C0FA'>
                                 <Description>
                                     Single blocks, generously
@@ -1112,16 +1112,16 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <BiomeType name='Water'  />
                             <BiomeType name='Swamp'  />
-                            <Setting name='CloudRadius' avg=':= 0.727 * _default_ * thm4WaterInfusedStoneSize ' range=':=  _default_ * thm4WaterInfusedStoneSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.727 * _default_ * thm4WaterInfusedStoneSize ' range=':=  _default_ * thm4WaterInfusedStoneSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.529  * _default_ * thm4WaterInfusedStoneFreq ' range=':=  _default_ * thm4WaterInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 0.727 * _default_ * thm4WaterInfusedStoneSize ' range=':= _default_ * thm4WaterInfusedStoneSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.727 * _default_ * thm4WaterInfusedStoneSize ' range=':= _default_ * thm4WaterInfusedStoneSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.529  * _default_ * thm4WaterInfusedStoneFreq ' range=':= _default_ * thm4WaterInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='thm4WaterInfusedStonePreferredHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x6000C0FA' drawBoundBox='false' boundBoxColor='0x6000C0FA'>
                                 <Description>
                                     Ore generation is doubled in
@@ -1150,10 +1150,10 @@
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:3")'> <OreBlock block='Thaumcraft:blockCustomOre:3' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 5 * thm4WaterInfusedStoneSize ' range=':=  _default_ * thm4WaterInfusedStoneSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1 * thm4WaterInfusedStoneFreq ' range=':=  _default_ * thm4WaterInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 5 * thm4WaterInfusedStoneSize ' range=':= _default_ * thm4WaterInfusedStoneSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1 * thm4WaterInfusedStoneFreq ' range=':= _default_ * thm4WaterInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -1184,21 +1184,21 @@
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:4")'> <OreBlock block='Thaumcraft:blockCustomOre:4' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.783 * _default_ * thm4EarthInfusedStoneFreq ' range=':=  _default_ * thm4EarthInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * thm4EarthInfusedStoneSize ' range=':=  _default_ * thm4EarthInfusedStoneSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.922 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * thm4EarthInfusedStoneSize ' range=':=  _default_ * thm4EarthInfusedStoneSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.922 * _default_ * thm4EarthInfusedStoneSize ' range=':=  _default_ * thm4EarthInfusedStoneSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.783 * _default_ * thm4EarthInfusedStoneFreq ' range=':= _default_ * thm4EarthInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * thm4EarthInfusedStoneSize ' range=':= _default_ * thm4EarthInfusedStoneSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.922 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * thm4EarthInfusedStoneSize ' range=':= _default_ * thm4EarthInfusedStoneSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.922 * _default_ * thm4EarthInfusedStoneSize ' range=':= _default_ * thm4EarthInfusedStoneSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
 
                         <!-- Beginning "Preferred" configuration. -->
@@ -1210,21 +1210,21 @@
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:4")'> <OreBlock block='Thaumcraft:blockCustomOre:4' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <BiomeType name='Forest'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.783 * _default_ * thm4EarthInfusedStoneFreq ' range=':=  _default_ * thm4EarthInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * thm4EarthInfusedStoneSize ' range=':=  _default_ * thm4EarthInfusedStoneSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.922 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * thm4EarthInfusedStoneSize ' range=':=  _default_ * thm4EarthInfusedStoneSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.922 * _default_ * thm4EarthInfusedStoneSize ' range=':=  _default_ * thm4EarthInfusedStoneSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.783 * _default_ * thm4EarthInfusedStoneFreq ' range=':= _default_ * thm4EarthInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * thm4EarthInfusedStoneSize ' range=':= _default_ * thm4EarthInfusedStoneSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.922 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * thm4EarthInfusedStoneSize ' range=':= _default_ * thm4EarthInfusedStoneSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.922 * _default_ * thm4EarthInfusedStoneSize ' range=':= _default_ * thm4EarthInfusedStoneSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                         <!-- "Preferred" configuration complete. -->
 
@@ -1255,16 +1255,16 @@
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:4")'> <OreBlock block='Thaumcraft:blockCustomOre:4' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.727 * _default_ * thm4EarthInfusedStoneSize ' range=':=  _default_ * thm4EarthInfusedStoneSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.727 * _default_ * thm4EarthInfusedStoneSize ' range=':=  _default_ * thm4EarthInfusedStoneSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.529  * _default_ * thm4EarthInfusedStoneFreq ' range=':=  _default_ * thm4EarthInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 0.727 * _default_ * thm4EarthInfusedStoneSize ' range=':= _default_ * thm4EarthInfusedStoneSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.727 * _default_ * thm4EarthInfusedStoneSize ' range=':= _default_ * thm4EarthInfusedStoneSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.529  * _default_ * thm4EarthInfusedStoneFreq ' range=':= _default_ * thm4EarthInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='thm4EarthInfusedStoneHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x6000D900' drawBoundBox='false' boundBoxColor='0x6000D900'>
                                 <Description>
                                     Single blocks, generously
@@ -1301,16 +1301,16 @@
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:4")'> <OreBlock block='Thaumcraft:blockCustomOre:4' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <BiomeType name='Forest'  />
-                            <Setting name='CloudRadius' avg=':= 0.727 * _default_ * thm4EarthInfusedStoneSize ' range=':=  _default_ * thm4EarthInfusedStoneSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.727 * _default_ * thm4EarthInfusedStoneSize ' range=':=  _default_ * thm4EarthInfusedStoneSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.529  * _default_ * thm4EarthInfusedStoneFreq ' range=':=  _default_ * thm4EarthInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 0.727 * _default_ * thm4EarthInfusedStoneSize ' range=':= _default_ * thm4EarthInfusedStoneSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.727 * _default_ * thm4EarthInfusedStoneSize ' range=':= _default_ * thm4EarthInfusedStoneSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.529  * _default_ * thm4EarthInfusedStoneFreq ' range=':= _default_ * thm4EarthInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='thm4EarthInfusedStonePreferredHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x6000D900' drawBoundBox='false' boundBoxColor='0x6000D900'>
                                 <Description>
                                     Ore generation is doubled in
@@ -1339,10 +1339,10 @@
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:4")'> <OreBlock block='Thaumcraft:blockCustomOre:4' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 5 * thm4EarthInfusedStoneSize ' range=':=  _default_ * thm4EarthInfusedStoneSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1 * thm4EarthInfusedStoneFreq ' range=':=  _default_ * thm4EarthInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 5 * thm4EarthInfusedStoneSize ' range=':= _default_ * thm4EarthInfusedStoneSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1 * thm4EarthInfusedStoneFreq ' range=':= _default_ * thm4EarthInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -1373,21 +1373,21 @@
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:5")'> <OreBlock block='Thaumcraft:blockCustomOre:5' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.783 * _default_ * thm4OrderInfusedStoneFreq ' range=':=  _default_ * thm4OrderInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * thm4OrderInfusedStoneSize ' range=':=  _default_ * thm4OrderInfusedStoneSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.922 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * thm4OrderInfusedStoneSize ' range=':=  _default_ * thm4OrderInfusedStoneSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.922 * _default_ * thm4OrderInfusedStoneSize ' range=':=  _default_ * thm4OrderInfusedStoneSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.783 * _default_ * thm4OrderInfusedStoneFreq ' range=':= _default_ * thm4OrderInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * thm4OrderInfusedStoneSize ' range=':= _default_ * thm4OrderInfusedStoneSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.922 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * thm4OrderInfusedStoneSize ' range=':= _default_ * thm4OrderInfusedStoneSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.922 * _default_ * thm4OrderInfusedStoneSize ' range=':= _default_ * thm4OrderInfusedStoneSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
 
                         <!-- Beginning "Preferred" configuration. -->
@@ -1401,21 +1401,21 @@
                             <BiomeType name='Mushroom'  />
                             <BiomeType name='Mountain'  />
                             <BiomeType name='Magical'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.783 * _default_ * thm4OrderInfusedStoneFreq ' range=':=  _default_ * thm4OrderInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * thm4OrderInfusedStoneSize ' range=':=  _default_ * thm4OrderInfusedStoneSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.922 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * thm4OrderInfusedStoneSize ' range=':=  _default_ * thm4OrderInfusedStoneSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.922 * _default_ * thm4OrderInfusedStoneSize ' range=':=  _default_ * thm4OrderInfusedStoneSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.783 * _default_ * thm4OrderInfusedStoneFreq ' range=':= _default_ * thm4OrderInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * thm4OrderInfusedStoneSize ' range=':= _default_ * thm4OrderInfusedStoneSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.922 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * thm4OrderInfusedStoneSize ' range=':= _default_ * thm4OrderInfusedStoneSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.922 * _default_ * thm4OrderInfusedStoneSize ' range=':= _default_ * thm4OrderInfusedStoneSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                         <!-- "Preferred" configuration complete. -->
 
@@ -1446,16 +1446,16 @@
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:5")'> <OreBlock block='Thaumcraft:blockCustomOre:5' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.727 * _default_ * thm4OrderInfusedStoneSize ' range=':=  _default_ * thm4OrderInfusedStoneSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.727 * _default_ * thm4OrderInfusedStoneSize ' range=':=  _default_ * thm4OrderInfusedStoneSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.529  * _default_ * thm4OrderInfusedStoneFreq ' range=':=  _default_ * thm4OrderInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 0.727 * _default_ * thm4OrderInfusedStoneSize ' range=':= _default_ * thm4OrderInfusedStoneSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.727 * _default_ * thm4OrderInfusedStoneSize ' range=':= _default_ * thm4OrderInfusedStoneSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.529  * _default_ * thm4OrderInfusedStoneFreq ' range=':= _default_ * thm4OrderInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='thm4OrderInfusedStoneHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60EBEBF9' drawBoundBox='false' boundBoxColor='0x60EBEBF9'>
                                 <Description>
                                     Single blocks, generously
@@ -1494,16 +1494,16 @@
                             <BiomeType name='Mushroom'  />
                             <BiomeType name='Mountain'  />
                             <BiomeType name='Magical'  />
-                            <Setting name='CloudRadius' avg=':= 0.727 * _default_ * thm4OrderInfusedStoneSize ' range=':=  _default_ * thm4OrderInfusedStoneSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.727 * _default_ * thm4OrderInfusedStoneSize ' range=':=  _default_ * thm4OrderInfusedStoneSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.529  * _default_ * thm4OrderInfusedStoneFreq ' range=':=  _default_ * thm4OrderInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 0.727 * _default_ * thm4OrderInfusedStoneSize ' range=':= _default_ * thm4OrderInfusedStoneSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.727 * _default_ * thm4OrderInfusedStoneSize ' range=':= _default_ * thm4OrderInfusedStoneSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.529  * _default_ * thm4OrderInfusedStoneFreq ' range=':= _default_ * thm4OrderInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='thm4OrderInfusedStonePreferredHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60EBEBF9' drawBoundBox='false' boundBoxColor='0x60EBEBF9'>
                                 <Description>
                                     Ore generation is doubled in
@@ -1532,10 +1532,10 @@
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:5")'> <OreBlock block='Thaumcraft:blockCustomOre:5' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 5 * thm4OrderInfusedStoneSize ' range=':=  _default_ * thm4OrderInfusedStoneSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1 * thm4OrderInfusedStoneFreq ' range=':=  _default_ * thm4OrderInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 5 * thm4OrderInfusedStoneSize ' range=':= _default_ * thm4OrderInfusedStoneSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1 * thm4OrderInfusedStoneFreq ' range=':= _default_ * thm4OrderInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -1566,21 +1566,21 @@
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:6")'> <OreBlock block='Thaumcraft:blockCustomOre:6' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.783 * _default_ * thm4EntropyInfusedStoneFreq ' range=':=  _default_ * thm4EntropyInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * thm4EntropyInfusedStoneSize ' range=':=  _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.922 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * thm4EntropyInfusedStoneSize ' range=':=  _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.922 * _default_ * thm4EntropyInfusedStoneSize ' range=':=  _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.783 * _default_ * thm4EntropyInfusedStoneFreq ' range=':= _default_ * thm4EntropyInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * thm4EntropyInfusedStoneSize ' range=':= _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.922 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * thm4EntropyInfusedStoneSize ' range=':= _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.922 * _default_ * thm4EntropyInfusedStoneSize ' range=':= _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
 
                         <!-- Beginning "Preferred" configuration. -->
@@ -1593,21 +1593,21 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <BiomeType name='Swamp'  />
                             <BiomeType name='Wasteland'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.783 * _default_ * thm4EntropyInfusedStoneFreq ' range=':=  _default_ * thm4EntropyInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * thm4EntropyInfusedStoneSize ' range=':=  _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.922 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * thm4EntropyInfusedStoneSize ' range=':=  _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.922 * _default_ * thm4EntropyInfusedStoneSize ' range=':=  _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.783 * _default_ * thm4EntropyInfusedStoneFreq ' range=':= _default_ * thm4EntropyInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * thm4EntropyInfusedStoneSize ' range=':= _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.922 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * thm4EntropyInfusedStoneSize ' range=':= _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.922 * _default_ * thm4EntropyInfusedStoneSize ' range=':= _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                         <!-- "Preferred" configuration complete. -->
 
@@ -1638,16 +1638,16 @@
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:6")'> <OreBlock block='Thaumcraft:blockCustomOre:6' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.727 * _default_ * thm4EntropyInfusedStoneSize ' range=':=  _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.727 * _default_ * thm4EntropyInfusedStoneSize ' range=':=  _default_ * thm4EntropyInfusedStoneSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.529  * _default_ * thm4EntropyInfusedStoneFreq ' range=':=  _default_ * thm4EntropyInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 0.727 * _default_ * thm4EntropyInfusedStoneSize ' range=':= _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.727 * _default_ * thm4EntropyInfusedStoneSize ' range=':= _default_ * thm4EntropyInfusedStoneSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.529  * _default_ * thm4EntropyInfusedStoneFreq ' range=':= _default_ * thm4EntropyInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='thm4EntropyInfusedStoneHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60260920' drawBoundBox='false' boundBoxColor='0x60260920'>
                                 <Description>
                                     Single blocks, generously
@@ -1685,16 +1685,16 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <BiomeType name='Swamp'  />
                             <BiomeType name='Wasteland'  />
-                            <Setting name='CloudRadius' avg=':= 0.727 * _default_ * thm4EntropyInfusedStoneSize ' range=':=  _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.727 * _default_ * thm4EntropyInfusedStoneSize ' range=':=  _default_ * thm4EntropyInfusedStoneSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.529  * _default_ * thm4EntropyInfusedStoneFreq ' range=':=  _default_ * thm4EntropyInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 0.727 * _default_ * thm4EntropyInfusedStoneSize ' range=':= _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.727 * _default_ * thm4EntropyInfusedStoneSize ' range=':= _default_ * thm4EntropyInfusedStoneSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.529  * _default_ * thm4EntropyInfusedStoneFreq ' range=':= _default_ * thm4EntropyInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='thm4EntropyInfusedStonePreferredHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60260920' drawBoundBox='false' boundBoxColor='0x60260920'>
                                 <Description>
                                     Ore generation is doubled in
@@ -1725,10 +1725,10 @@
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:6")'> <OreBlock block='Thaumcraft:blockCustomOre:6' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 5 * thm4EntropyInfusedStoneSize ' range=':=  _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1 * thm4EntropyInfusedStoneFreq ' range=':=  _default_ * thm4EntropyInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':=  61 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 5 * thm4EntropyInfusedStoneSize ' range=':= _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1 * thm4EntropyInfusedStoneFreq ' range=':= _default_ * thm4EntropyInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>

--- a/src/main/resources/config/modules/ThermalFoundation.xml
+++ b/src/main/resources/config/modules/ThermalFoundation.xml
@@ -288,21 +288,21 @@
                             <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore")'> <OreBlock block='ThermalFoundation:Ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.059 * _default_ * thfoCopperFreq ' range=':=  _default_ * thfoCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.019 * _default_ * thfoCopperSize ' range=':=  _default_ * thfoCopperSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.019 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * thfoCopperSize ' range=':=  _default_ * thfoCopperSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.019 * _default_ * thfoCopperSize ' range=':=  _default_ * thfoCopperSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.059 * _default_ * thfoCopperFreq ' range=':= _default_ * thfoCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.019 * _default_ * thfoCopperSize ' range=':= _default_ * thfoCopperSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 40 ' range=':= 20 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.019 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * thfoCopperSize ' range=':= _default_ * thfoCopperSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.019 * _default_ * thfoCopperSize ' range=':= _default_ * thfoCopperSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -330,16 +330,16 @@
                             <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore")'> <OreBlock block='ThermalFoundation:Ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.454 * _default_ * thfoCopperSize ' range=':=  _default_ * thfoCopperSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.454 * _default_ * thfoCopperSize ' range=':=  _default_ * thfoCopperSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 2.115  * _default_ * thfoCopperFreq ' range=':=  _default_ * thfoCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 1.454 * _default_ * thfoCopperSize ' range=':= _default_ * thfoCopperSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.454 * _default_ * thfoCopperSize ' range=':= _default_ * thfoCopperSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 2.115  * _default_ * thfoCopperFreq ' range=':= _default_ * thfoCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 40 ' range=':= 20 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='thfoCopperHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
                                 <Description>
                                     Single blocks, generously
@@ -382,10 +382,10 @@
                             <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore")'> <OreBlock block='ThermalFoundation:Ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 8 * thfoCopperSize ' range=':=  _default_ * thfoCopperSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 10 * thfoCopperFreq ' range=':=  _default_ * thfoCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 8 * thfoCopperSize ' range=':= _default_ * thfoCopperSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 10 * thfoCopperFreq ' range=':= _default_ * thfoCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 40 ' range=':= 20 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -407,21 +407,21 @@
                             <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:1")'> <OreBlock block='ThermalFoundation:Ore:1' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.948 * _default_ * thfoTinFreq ' range=':=  _default_ * thfoTinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.982 * _default_ * thfoTinSize ' range=':=  _default_ * thfoTinSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.982 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * thfoTinSize ' range=':=  _default_ * thfoTinSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.982 * _default_ * thfoTinSize ' range=':=  _default_ * thfoTinSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.948 * _default_ * thfoTinFreq ' range=':= _default_ * thfoTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.982 * _default_ * thfoTinSize ' range=':= _default_ * thfoTinSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 40 ' range=':= 20 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.982 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * thfoTinSize ' range=':= _default_ * thfoTinSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.982 * _default_ * thfoTinSize ' range=':= _default_ * thfoTinSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -449,16 +449,16 @@
                             <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:1")'> <OreBlock block='ThermalFoundation:Ore:1' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.375 * _default_ * thfoTinSize ' range=':=  _default_ * thfoTinSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.375 * _default_ * thfoTinSize ' range=':=  _default_ * thfoTinSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.892  * _default_ * thfoTinFreq ' range=':=  _default_ * thfoTinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 1.375 * _default_ * thfoTinSize ' range=':= _default_ * thfoTinSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.375 * _default_ * thfoTinSize ' range=':= _default_ * thfoTinSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.892  * _default_ * thfoTinFreq ' range=':= _default_ * thfoTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 40 ' range=':= 20 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='thfoTinHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60E8E8E8'>
                                 <Description>
                                     Single blocks, generously
@@ -501,10 +501,10 @@
                             <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:1")'> <OreBlock block='ThermalFoundation:Ore:1' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 8 * thfoTinSize ' range=':=  _default_ * thfoTinSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 8 * thfoTinFreq ' range=':=  _default_ * thfoTinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 8 * thfoTinSize ' range=':= _default_ * thfoTinSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 8 * thfoTinFreq ' range=':= _default_ * thfoTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 40 ' range=':= 20 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -526,21 +526,21 @@
                             <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:2")'> <OreBlock block='ThermalFoundation:Ore:2' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.821 * _default_ * thfoSilverFreq ' range=':=  _default_ * thfoSilverFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.936 * _default_ * thfoSilverSize ' range=':=  _default_ * thfoSilverSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.936 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * thfoSilverSize ' range=':=  _default_ * thfoSilverSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.936 * _default_ * thfoSilverSize ' range=':=  _default_ * thfoSilverSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.821 * _default_ * thfoSilverFreq ' range=':= _default_ * thfoSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.936 * _default_ * thfoSilverSize ' range=':= _default_ * thfoSilverSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 40 ' range=':= 20 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.936 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * thfoSilverSize ' range=':= _default_ * thfoSilverSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.936 * _default_ * thfoSilverSize ' range=':= _default_ * thfoSilverSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -568,16 +568,16 @@
                             <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:2")'> <OreBlock block='ThermalFoundation:Ore:2' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.280 * _default_ * thfoSilverSize ' range=':=  _default_ * thfoSilverSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.280 * _default_ * thfoSilverSize ' range=':=  _default_ * thfoSilverSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.638  * _default_ * thfoSilverFreq ' range=':=  _default_ * thfoSilverFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 1.280 * _default_ * thfoSilverSize ' range=':= _default_ * thfoSilverSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.280 * _default_ * thfoSilverSize ' range=':= _default_ * thfoSilverSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.638  * _default_ * thfoSilverFreq ' range=':= _default_ * thfoSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 40 ' range=':= 20 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='thfoSilverHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60E3F2F7' drawBoundBox='false' boundBoxColor='0x60E3F2F7'>
                                 <Description>
                                     Single blocks, generously
@@ -620,10 +620,10 @@
                             <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:2")'> <OreBlock block='ThermalFoundation:Ore:2' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 8 * thfoSilverSize ' range=':=  _default_ * thfoSilverSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 6 * thfoSilverFreq ' range=':=  _default_ * thfoSilverFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 8 * thfoSilverSize ' range=':= _default_ * thfoSilverSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 6 * thfoSilverFreq ' range=':= _default_ * thfoSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 40 ' range=':= 20 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -645,21 +645,21 @@
                             <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:3")'> <OreBlock block='ThermalFoundation:Ore:3' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.948 * _default_ * thfoLeadFreq ' range=':=  _default_ * thfoLeadFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.982 * _default_ * thfoLeadSize ' range=':=  _default_ * thfoLeadSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.982 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * thfoLeadSize ' range=':=  _default_ * thfoLeadSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.982 * _default_ * thfoLeadSize ' range=':=  _default_ * thfoLeadSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.948 * _default_ * thfoLeadFreq ' range=':= _default_ * thfoLeadFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.982 * _default_ * thfoLeadSize ' range=':= _default_ * thfoLeadSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 40 ' range=':= 20 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.982 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * thfoLeadSize ' range=':= _default_ * thfoLeadSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.982 * _default_ * thfoLeadSize ' range=':= _default_ * thfoLeadSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -687,16 +687,16 @@
                             <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:3")'> <OreBlock block='ThermalFoundation:Ore:3' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.375 * _default_ * thfoLeadSize ' range=':=  _default_ * thfoLeadSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.375 * _default_ * thfoLeadSize ' range=':=  _default_ * thfoLeadSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.892  * _default_ * thfoLeadFreq ' range=':=  _default_ * thfoLeadFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 1.375 * _default_ * thfoLeadSize ' range=':= _default_ * thfoLeadSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.375 * _default_ * thfoLeadSize ' range=':= _default_ * thfoLeadSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.892  * _default_ * thfoLeadFreq ' range=':= _default_ * thfoLeadFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 40 ' range=':= 20 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='thfoLeadHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60818EBE' drawBoundBox='false' boundBoxColor='0x60818EBE'>
                                 <Description>
                                     Single blocks, generously
@@ -739,10 +739,10 @@
                             <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:3")'> <OreBlock block='ThermalFoundation:Ore:3' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 8 * thfoLeadSize ' range=':=  _default_ * thfoLeadSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 8 * thfoLeadFreq ' range=':=  _default_ * thfoLeadFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 8 * thfoLeadSize ' range=':= _default_ * thfoLeadSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 8 * thfoLeadFreq ' range=':= _default_ * thfoLeadFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 40 ' range=':= 20 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -764,21 +764,21 @@
                             <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:4")'> <OreBlock block='ThermalFoundation:Ore:4' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.410 * _default_ * thfoFerrousFreq ' range=':=  _default_ * thfoFerrousFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.743 * _default_ * thfoFerrousSize ' range=':=  _default_ * thfoFerrousSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.743 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * thfoFerrousSize ' range=':=  _default_ * thfoFerrousSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.743 * _default_ * thfoFerrousSize ' range=':=  _default_ * thfoFerrousSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.410 * _default_ * thfoFerrousFreq ' range=':= _default_ * thfoFerrousFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.743 * _default_ * thfoFerrousSize ' range=':= _default_ * thfoFerrousSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 40 ' range=':= 20 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.743 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * thfoFerrousSize ' range=':= _default_ * thfoFerrousSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.743 * _default_ * thfoFerrousSize ' range=':= _default_ * thfoFerrousSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -806,16 +806,16 @@
                             <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:4")'> <OreBlock block='ThermalFoundation:Ore:4' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.905 * _default_ * thfoFerrousSize ' range=':=  _default_ * thfoFerrousSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.905 * _default_ * thfoFerrousSize ' range=':=  _default_ * thfoFerrousSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * thfoFerrousFreq ' range=':=  _default_ * thfoFerrousFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 0.905 * _default_ * thfoFerrousSize ' range=':= _default_ * thfoFerrousSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.905 * _default_ * thfoFerrousSize ' range=':= _default_ * thfoFerrousSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * thfoFerrousFreq ' range=':= _default_ * thfoFerrousFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 40 ' range=':= 20 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='thfoFerrousHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60BCBDAB' drawBoundBox='false' boundBoxColor='0x60BCBDAB'>
                                 <Description>
                                     Single blocks, generously
@@ -858,10 +858,10 @@
                             <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:4")'> <OreBlock block='ThermalFoundation:Ore:4' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4 * thfoFerrousSize ' range=':=  _default_ * thfoFerrousSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 3 * thfoFerrousFreq ' range=':=  _default_ * thfoFerrousFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 4 * thfoFerrousSize ' range=':= _default_ * thfoFerrousSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 3 * thfoFerrousFreq ' range=':= _default_ * thfoFerrousFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 40 ' range=':= 20 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -883,21 +883,21 @@
                             <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:5")'> <OreBlock block='ThermalFoundation:Ore:5' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.205 * _default_ * thfoShinyFreq ' range=':=  _default_ * thfoShinyFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.590 * _default_ * thfoShinySize ' range=':=  _default_ * thfoShinySize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.590 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * thfoShinySize ' range=':=  _default_ * thfoShinySize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.590 * _default_ * thfoShinySize ' range=':=  _default_ * thfoShinySize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.205 * _default_ * thfoShinyFreq ' range=':= _default_ * thfoShinyFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.590 * _default_ * thfoShinySize ' range=':= _default_ * thfoShinySize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 40 ' range=':= 20 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.590 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * thfoShinySize ' range=':= _default_ * thfoShinySize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.590 * _default_ * thfoShinySize ' range=':= _default_ * thfoShinySize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -925,16 +925,16 @@
                             <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:5")'> <OreBlock block='ThermalFoundation:Ore:5' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.640 * _default_ * thfoShinySize ' range=':=  _default_ * thfoShinySize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.640 * _default_ * thfoShinySize ' range=':=  _default_ * thfoShinySize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.410  * _default_ * thfoShinyFreq ' range=':=  _default_ * thfoShinyFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 0.640 * _default_ * thfoShinySize ' range=':= _default_ * thfoShinySize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.640 * _default_ * thfoShinySize ' range=':= _default_ * thfoShinySize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.410  * _default_ * thfoShinyFreq ' range=':= _default_ * thfoShinyFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 40 ' range=':= 20 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='thfoShinyHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x606FE5F3' drawBoundBox='false' boundBoxColor='0x606FE5F3'>
                                 <Description>
                                     Single blocks, generously
@@ -977,10 +977,10 @@
                             <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:5")'> <OreBlock block='ThermalFoundation:Ore:5' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3 * thfoShinySize ' range=':=  _default_ * thfoShinySize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1 * thfoShinyFreq ' range=':=  _default_ * thfoShinyFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 3 * thfoShinySize ' range=':= _default_ * thfoShinySize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1 * thfoShinyFreq ' range=':= _default_ * thfoShinyFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 40 ' range=':= 20 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>

--- a/src/main/resources/config/modules/TinkersConstruct.xml
+++ b/src/main/resources/config/modules/TinkersConstruct.xml
@@ -475,21 +475,21 @@
                             <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:3")'> <OreBlock block='TConstruct:SearedBrick:3' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.474 * _default_ * ticoCopperFreq ' range=':=  _default_ * ticoCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.780 * _default_ * ticoCopperSize ' range=':=  _default_ * ticoCopperSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.780 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * ticoCopperSize ' range=':=  _default_ * ticoCopperSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.780 * _default_ * ticoCopperSize ' range=':=  _default_ * ticoCopperSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.474 * _default_ * ticoCopperFreq ' range=':= _default_ * ticoCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.780 * _default_ * ticoCopperSize ' range=':= _default_ * ticoCopperSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 40 ' range=':= 20 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.780 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * ticoCopperSize ' range=':= _default_ * ticoCopperSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.780 * _default_ * ticoCopperSize ' range=':= _default_ * ticoCopperSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -517,16 +517,16 @@
                             <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:3")'> <OreBlock block='TConstruct:SearedBrick:3' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.973 * _default_ * ticoCopperSize ' range=':=  _default_ * ticoCopperSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.973 * _default_ * ticoCopperSize ' range=':=  _default_ * ticoCopperSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * ticoCopperFreq ' range=':=  _default_ * ticoCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 0.973 * _default_ * ticoCopperSize ' range=':= _default_ * ticoCopperSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.973 * _default_ * ticoCopperSize ' range=':= _default_ * ticoCopperSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * ticoCopperFreq ' range=':= _default_ * ticoCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 40 ' range=':= 20 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='ticoCopperHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
                                 <Description>
                                     Single blocks, generously
@@ -569,10 +569,10 @@
                             <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:3")'> <OreBlock block='TConstruct:SearedBrick:3' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 8 * ticoCopperSize ' range=':=  _default_ * ticoCopperSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2 * ticoCopperFreq ' range=':=  _default_ * ticoCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 8 * ticoCopperSize ' range=':= _default_ * ticoCopperSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2 * ticoCopperFreq ' range=':= _default_ * ticoCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 40 ' range=':= 20 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -594,21 +594,21 @@
                             <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:4")'> <OreBlock block='TConstruct:SearedBrick:4' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.474 * _default_ * ticoTinFreq ' range=':=  _default_ * ticoTinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.780 * _default_ * ticoTinSize ' range=':=  _default_ * ticoTinSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 23 ' range=':=  17 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.780 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * ticoTinSize ' range=':=  _default_ * ticoTinSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.780 * _default_ * ticoTinSize ' range=':=  _default_ * ticoTinSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.474 * _default_ * ticoTinFreq ' range=':= _default_ * ticoTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.780 * _default_ * ticoTinSize ' range=':= _default_ * ticoTinSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 23 ' range=':= 17 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.780 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * ticoTinSize ' range=':= _default_ * ticoTinSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.780 * _default_ * ticoTinSize ' range=':= _default_ * ticoTinSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -636,16 +636,16 @@
                             <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:4")'> <OreBlock block='TConstruct:SearedBrick:4' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.973 * _default_ * ticoTinSize ' range=':=  _default_ * ticoTinSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.973 * _default_ * ticoTinSize ' range=':=  _default_ * ticoTinSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * ticoTinFreq ' range=':=  _default_ * ticoTinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 23 ' range=':=  17 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 0.973 * _default_ * ticoTinSize ' range=':= _default_ * ticoTinSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.973 * _default_ * ticoTinSize ' range=':= _default_ * ticoTinSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * ticoTinFreq ' range=':= _default_ * ticoTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 23 ' range=':= 17 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='ticoTinHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60E8E8E8'>
                                 <Description>
                                     Single blocks, generously
@@ -688,10 +688,10 @@
                             <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:4")'> <OreBlock block='TConstruct:SearedBrick:4' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 8 * ticoTinSize ' range=':=  _default_ * ticoTinSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2 * ticoTinFreq ' range=':=  _default_ * ticoTinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 23 ' range=':=  17 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 8 * ticoTinSize ' range=':= _default_ * ticoTinSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2 * ticoTinFreq ' range=':= _default_ * ticoTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 23 ' range=':= 17 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -713,21 +713,21 @@
                             <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:5")'> <OreBlock block='TConstruct:SearedBrick:5' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.503 * _default_ * ticoAluminumFreq ' range=':=  _default_ * ticoAluminumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.795 * _default_ * ticoAluminumSize ' range=':=  _default_ * ticoAluminumSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 35 ' range=':=  29 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.795 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * ticoAluminumSize ' range=':=  _default_ * ticoAluminumSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.795 * _default_ * ticoAluminumSize ' range=':=  _default_ * ticoAluminumSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.503 * _default_ * ticoAluminumFreq ' range=':= _default_ * ticoAluminumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.795 * _default_ * ticoAluminumSize ' range=':= _default_ * ticoAluminumSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 35 ' range=':= 29 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.795 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * ticoAluminumSize ' range=':= _default_ * ticoAluminumSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.795 * _default_ * ticoAluminumSize ' range=':= _default_ * ticoAluminumSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -755,16 +755,16 @@
                             <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:5")'> <OreBlock block='TConstruct:SearedBrick:5' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.002 * _default_ * ticoAluminumSize ' range=':=  _default_ * ticoAluminumSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.002 * _default_ * ticoAluminumSize ' range=':=  _default_ * ticoAluminumSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.003  * _default_ * ticoAluminumFreq ' range=':=  _default_ * ticoAluminumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 35 ' range=':=  29 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 1.002 * _default_ * ticoAluminumSize ' range=':= _default_ * ticoAluminumSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.002 * _default_ * ticoAluminumSize ' range=':= _default_ * ticoAluminumSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.003  * _default_ * ticoAluminumFreq ' range=':= _default_ * ticoAluminumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 35 ' range=':= 29 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='ticoAluminumHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60EDEDED' drawBoundBox='false' boundBoxColor='0x60EDEDED'>
                                 <Description>
                                     Single blocks, generously
@@ -807,10 +807,10 @@
                             <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:5")'> <OreBlock block='TConstruct:SearedBrick:5' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 6 * ticoAluminumSize ' range=':=  _default_ * ticoAluminumSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 3 * ticoAluminumFreq ' range=':=  _default_ * ticoAluminumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 35 ' range=':=  29 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 6 * ticoAluminumSize ' range=':= _default_ * ticoAluminumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 3 * ticoAluminumFreq ' range=':= _default_ * ticoAluminumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 35 ' range=':= 29 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -832,21 +832,21 @@
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre")'> <OreBlock block='TConstruct:GravelOre' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.498 * _default_ * ticoIronGravelFreq ' range=':=  1 * _default_ * ticoIronGravelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.144 * _default_ * ticoIronGravelSize ' range=':=  1 * _default_ * ticoIronGravelSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 36 ' range=':=  31 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.144 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * ticoIronGravelSize ' range=':=  _default_ * ticoIronGravelSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.144 * _default_ * ticoIronGravelSize ' range=':=  1 * _default_ * ticoIronGravelSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.498 * _default_ * ticoIronGravelFreq ' range=':= 1 * _default_ * ticoIronGravelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.144 * _default_ * ticoIronGravelSize ' range=':= 1 * _default_ * ticoIronGravelSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 36 ' range=':= 31 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.144 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * ticoIronGravelSize ' range=':= _default_ * ticoIronGravelSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.144 * _default_ * ticoIronGravelSize ' range=':= 1 * _default_ * ticoIronGravelSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -874,16 +874,16 @@
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre")'> <OreBlock block='TConstruct:GravelOre' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.730 * _default_ * ticoIronGravelSize ' range=':=  _default_ * ticoIronGravelSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.730 * _default_ * ticoIronGravelSize ' range=':=  _default_ * ticoIronGravelSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 2.991  * _default_ * ticoIronGravelFreq ' range=':=  _default_ * ticoIronGravelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 36 ' range=':=  31 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 1.730 * _default_ * ticoIronGravelSize ' range=':= _default_ * ticoIronGravelSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.730 * _default_ * ticoIronGravelSize ' range=':= _default_ * ticoIronGravelSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 2.991  * _default_ * ticoIronGravelFreq ' range=':= _default_ * ticoIronGravelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 36 ' range=':= 31 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='ticoIronGravelHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60DDC2AF' drawBoundBox='false' boundBoxColor='0x60DDC2AF'>
                                 <Description>
                                     Single blocks, generously
@@ -926,10 +926,10 @@
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre")'> <OreBlock block='TConstruct:GravelOre' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 8 * ticoIronGravelSize ' range=':=  _default_ * ticoIronGravelSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 20 * ticoIronGravelFreq ' range=':=  _default_ * ticoIronGravelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 36 ' range=':=  31 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 8 * ticoIronGravelSize ' range=':= _default_ * ticoIronGravelSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 20 * ticoIronGravelFreq ' range=':= _default_ * ticoIronGravelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 36 ' range=':= 31 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -951,21 +951,21 @@
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:1")'> <OreBlock block='TConstruct:GravelOre:1' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.474 * _default_ * ticoGoldGravelFreq ' range=':=  1 * _default_ * ticoGoldGravelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.780 * _default_ * ticoGoldGravelSize ' range=':=  1 * _default_ * ticoGoldGravelSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 17 ' range=':=  12 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.780 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * ticoGoldGravelSize ' range=':=  _default_ * ticoGoldGravelSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.780 * _default_ * ticoGoldGravelSize ' range=':=  1 * _default_ * ticoGoldGravelSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.474 * _default_ * ticoGoldGravelFreq ' range=':= 1 * _default_ * ticoGoldGravelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.780 * _default_ * ticoGoldGravelSize ' range=':= 1 * _default_ * ticoGoldGravelSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 17 ' range=':= 12 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.780 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * ticoGoldGravelSize ' range=':= _default_ * ticoGoldGravelSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.780 * _default_ * ticoGoldGravelSize ' range=':= 1 * _default_ * ticoGoldGravelSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -993,16 +993,16 @@
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:1")'> <OreBlock block='TConstruct:GravelOre:1' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.973 * _default_ * ticoGoldGravelSize ' range=':=  _default_ * ticoGoldGravelSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.973 * _default_ * ticoGoldGravelSize ' range=':=  _default_ * ticoGoldGravelSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * ticoGoldGravelFreq ' range=':=  _default_ * ticoGoldGravelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 17 ' range=':=  12 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 0.973 * _default_ * ticoGoldGravelSize ' range=':= _default_ * ticoGoldGravelSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.973 * _default_ * ticoGoldGravelSize ' range=':= _default_ * ticoGoldGravelSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * ticoGoldGravelFreq ' range=':= _default_ * ticoGoldGravelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 17 ' range=':= 12 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='ticoGoldGravelHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60EAEF57' drawBoundBox='false' boundBoxColor='0x60EAEF57'>
                                 <Description>
                                     Single blocks, generously
@@ -1045,10 +1045,10 @@
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:1")'> <OreBlock block='TConstruct:GravelOre:1' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 8 * ticoGoldGravelSize ' range=':=  _default_ * ticoGoldGravelSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2 * ticoGoldGravelFreq ' range=':=  _default_ * ticoGoldGravelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 17 ' range=':=  12 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 8 * ticoGoldGravelSize ' range=':= _default_ * ticoGoldGravelSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2 * ticoGoldGravelFreq ' range=':= _default_ * ticoGoldGravelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 17 ' range=':= 12 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -1070,21 +1070,21 @@
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:2")'> <OreBlock block='TConstruct:GravelOre:2' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.474 * _default_ * ticoCopperGravelFreq ' range=':=  _default_ * ticoCopperGravelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.780 * _default_ * ticoCopperGravelSize ' range=':=  _default_ * ticoCopperGravelSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.780 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * ticoCopperGravelSize ' range=':=  _default_ * ticoCopperGravelSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.780 * _default_ * ticoCopperGravelSize ' range=':=  _default_ * ticoCopperGravelSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.474 * _default_ * ticoCopperGravelFreq ' range=':= _default_ * ticoCopperGravelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.780 * _default_ * ticoCopperGravelSize ' range=':= _default_ * ticoCopperGravelSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 40 ' range=':= 20 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.780 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * ticoCopperGravelSize ' range=':= _default_ * ticoCopperGravelSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.780 * _default_ * ticoCopperGravelSize ' range=':= _default_ * ticoCopperGravelSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -1113,16 +1113,16 @@
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:2")'> <OreBlock block='TConstruct:GravelOre:2' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.973 * _default_ * ticoCopperGravelSize ' range=':=  _default_ * ticoCopperGravelSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.973 * _default_ * ticoCopperGravelSize ' range=':=  _default_ * ticoCopperGravelSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * ticoCopperGravelFreq ' range=':=  _default_ * ticoCopperGravelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 0.973 * _default_ * ticoCopperGravelSize ' range=':= _default_ * ticoCopperGravelSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.973 * _default_ * ticoCopperGravelSize ' range=':= _default_ * ticoCopperGravelSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * ticoCopperGravelFreq ' range=':= _default_ * ticoCopperGravelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 40 ' range=':= 20 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='ticoCopperGravelHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
                                 <Description>
                                     Single blocks, generously
@@ -1165,10 +1165,10 @@
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:2")'> <OreBlock block='TConstruct:GravelOre:2' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 8 * ticoCopperGravelSize ' range=':=  _default_ * ticoCopperGravelSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2 * ticoCopperGravelFreq ' range=':=  _default_ * ticoCopperGravelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 40 ' range=':=  20 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 8 * ticoCopperGravelSize ' range=':= _default_ * ticoCopperGravelSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2 * ticoCopperGravelFreq ' range=':= _default_ * ticoCopperGravelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 40 ' range=':= 20 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -1190,21 +1190,21 @@
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:3")'> <OreBlock block='TConstruct:GravelOre:3' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.474 * _default_ * ticoTinGravelFreq ' range=':=  _default_ * ticoTinGravelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.780 * _default_ * ticoTinGravelSize ' range=':=  _default_ * ticoTinGravelSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 23 ' range=':=  17 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.780 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * ticoTinGravelSize ' range=':=  _default_ * ticoTinGravelSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.780 * _default_ * ticoTinGravelSize ' range=':=  _default_ * ticoTinGravelSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.474 * _default_ * ticoTinGravelFreq ' range=':= _default_ * ticoTinGravelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.780 * _default_ * ticoTinGravelSize ' range=':= _default_ * ticoTinGravelSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 23 ' range=':= 17 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.780 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * ticoTinGravelSize ' range=':= _default_ * ticoTinGravelSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.780 * _default_ * ticoTinGravelSize ' range=':= _default_ * ticoTinGravelSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -1232,16 +1232,16 @@
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:3")'> <OreBlock block='TConstruct:GravelOre:3' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.973 * _default_ * ticoTinGravelSize ' range=':=  _default_ * ticoTinGravelSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.973 * _default_ * ticoTinGravelSize ' range=':=  _default_ * ticoTinGravelSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * ticoTinGravelFreq ' range=':=  _default_ * ticoTinGravelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 23 ' range=':=  17 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 0.973 * _default_ * ticoTinGravelSize ' range=':= _default_ * ticoTinGravelSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.973 * _default_ * ticoTinGravelSize ' range=':= _default_ * ticoTinGravelSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * ticoTinGravelFreq ' range=':= _default_ * ticoTinGravelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 23 ' range=':= 17 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='ticoTinGravelHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60E8E8E8'>
                                 <Description>
                                     Single blocks, generously
@@ -1284,10 +1284,10 @@
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:3")'> <OreBlock block='TConstruct:GravelOre:3' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 8 * ticoTinGravelSize ' range=':=  _default_ * ticoTinGravelSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2 * ticoTinGravelFreq ' range=':=  _default_ * ticoTinGravelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 23 ' range=':=  17 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 8 * ticoTinGravelSize ' range=':= _default_ * ticoTinGravelSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2 * ticoTinGravelFreq ' range=':= _default_ * ticoTinGravelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 23 ' range=':= 17 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -1309,21 +1309,21 @@
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:4")'> <OreBlock block='TConstruct:GravelOre:4' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.503 * _default_ * ticoAluminumGravelFreq ' range=':=  _default_ * ticoAluminumGravelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.795 * _default_ * ticoAluminumGravelSize ' range=':=  _default_ * ticoAluminumGravelSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 35 ' range=':=  29 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.795 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * ticoAluminumGravelSize ' range=':=  _default_ * ticoAluminumGravelSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.795 * _default_ * ticoAluminumGravelSize ' range=':=  _default_ * ticoAluminumGravelSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.503 * _default_ * ticoAluminumGravelFreq ' range=':= _default_ * ticoAluminumGravelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.795 * _default_ * ticoAluminumGravelSize ' range=':= _default_ * ticoAluminumGravelSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 35 ' range=':= 29 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.795 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * ticoAluminumGravelSize ' range=':= _default_ * ticoAluminumGravelSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.795 * _default_ * ticoAluminumGravelSize ' range=':= _default_ * ticoAluminumGravelSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -1352,16 +1352,16 @@
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:4")'> <OreBlock block='TConstruct:GravelOre:4' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.002 * _default_ * ticoAluminumGravelSize ' range=':=  _default_ * ticoAluminumGravelSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.002 * _default_ * ticoAluminumGravelSize ' range=':=  _default_ * ticoAluminumGravelSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.003  * _default_ * ticoAluminumGravelFreq ' range=':=  _default_ * ticoAluminumGravelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 35 ' range=':=  29 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 1.002 * _default_ * ticoAluminumGravelSize ' range=':= _default_ * ticoAluminumGravelSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.002 * _default_ * ticoAluminumGravelSize ' range=':= _default_ * ticoAluminumGravelSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.003  * _default_ * ticoAluminumGravelFreq ' range=':= _default_ * ticoAluminumGravelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 35 ' range=':= 29 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='ticoAluminumGravelHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60EDEDED' drawBoundBox='false' boundBoxColor='0x60EDEDED'>
                                 <Description>
                                     Single blocks, generously
@@ -1404,10 +1404,10 @@
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:4")'> <OreBlock block='TConstruct:GravelOre:4' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 6 * ticoAluminumGravelSize ' range=':=  _default_ * ticoAluminumGravelSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 3 * ticoAluminumGravelFreq ' range=':=  _default_ * ticoAluminumGravelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 35 ' range=':=  29 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 6 * ticoAluminumGravelSize ' range=':= _default_ * ticoAluminumGravelSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 3 * ticoAluminumGravelFreq ' range=':= _default_ * ticoAluminumGravelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 35 ' range=':= 29 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -1477,21 +1477,21 @@
                             <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:1")'> <OreBlock block='TConstruct:SearedBrick:1' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.580 * _default_ * ticoCobaltFreq ' range=':=  _default_ * ticoCobaltFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.834 * _default_ * ticoCobaltSize ' range=':=  _default_ * ticoCobaltSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64 ' range=':=  64 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.834 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * ticoCobaltSize ' range=':=  _default_ * ticoCobaltSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.834 * _default_ * ticoCobaltSize ' range=':=  _default_ * ticoCobaltSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.580 * _default_ * ticoCobaltFreq ' range=':= _default_ * ticoCobaltFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.834 * _default_ * ticoCobaltSize ' range=':= _default_ * ticoCobaltSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 64 ' range=':= 64 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.834 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * ticoCobaltSize ' range=':= _default_ * ticoCobaltSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.834 * _default_ * ticoCobaltSize ' range=':= _default_ * ticoCobaltSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -1519,16 +1519,16 @@
                             <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:1")'> <OreBlock block='TConstruct:SearedBrick:1' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.076 * _default_ * ticoCobaltSize ' range=':=  _default_ * ticoCobaltSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.076 * _default_ * ticoCobaltSize ' range=':=  _default_ * ticoCobaltSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.159  * _default_ * ticoCobaltFreq ' range=':=  _default_ * ticoCobaltFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64 ' range=':=  64 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 1.076 * _default_ * ticoCobaltSize ' range=':= _default_ * ticoCobaltSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.076 * _default_ * ticoCobaltSize ' range=':= _default_ * ticoCobaltSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.159  * _default_ * ticoCobaltFreq ' range=':= _default_ * ticoCobaltFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64 ' range=':= 64 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='ticoCobaltHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x601D62B8' drawBoundBox='false' boundBoxColor='0x601D62B8'>
                                 <Description>
                                     Single blocks, generously
@@ -1571,10 +1571,10 @@
                             <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:1")'> <OreBlock block='TConstruct:SearedBrick:1' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3 * ticoCobaltSize ' range=':=  _default_ * ticoCobaltSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2 * ticoCobaltFreq ' range=':=  _default_ * ticoCobaltFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64 ' range=':=  64 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 3 * ticoCobaltSize ' range=':= _default_ * ticoCobaltSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2 * ticoCobaltFreq ' range=':= _default_ * ticoCobaltFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64 ' range=':= 64 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -1596,21 +1596,21 @@
                             <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:2")'> <OreBlock block='TConstruct:SearedBrick:2' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.580 * _default_ * ticoArditeFreq ' range=':=  _default_ * ticoArditeFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.834 * _default_ * ticoArditeSize ' range=':=  _default_ * ticoArditeSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64 ' range=':=  64 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.834 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * ticoArditeSize ' range=':=  _default_ * ticoArditeSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.834 * _default_ * ticoArditeSize ' range=':=  _default_ * ticoArditeSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.580 * _default_ * ticoArditeFreq ' range=':= _default_ * ticoArditeFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.834 * _default_ * ticoArditeSize ' range=':= _default_ * ticoArditeSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 64 ' range=':= 64 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.834 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * ticoArditeSize ' range=':= _default_ * ticoArditeSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.834 * _default_ * ticoArditeSize ' range=':= _default_ * ticoArditeSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -1638,16 +1638,16 @@
                             <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:2")'> <OreBlock block='TConstruct:SearedBrick:2' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.076 * _default_ * ticoArditeSize ' range=':=  _default_ * ticoArditeSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.076 * _default_ * ticoArditeSize ' range=':=  _default_ * ticoArditeSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.159  * _default_ * ticoArditeFreq ' range=':=  _default_ * ticoArditeFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64 ' range=':=  64 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 1.076 * _default_ * ticoArditeSize ' range=':= _default_ * ticoArditeSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.076 * _default_ * ticoArditeSize ' range=':= _default_ * ticoArditeSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.159  * _default_ * ticoArditeFreq ' range=':= _default_ * ticoArditeFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64 ' range=':= 64 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='ticoArditeHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60F48A00' drawBoundBox='false' boundBoxColor='0x60F48A00'>
                                 <Description>
                                     Single blocks, generously
@@ -1690,10 +1690,10 @@
                             <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:2")'> <OreBlock block='TConstruct:SearedBrick:2' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3 * ticoArditeSize ' range=':=  _default_ * ticoArditeSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2 * ticoArditeFreq ' range=':=  _default_ * ticoArditeFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64 ' range=':=  64 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 3 * ticoArditeSize ' range=':= _default_ * ticoArditeSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2 * ticoArditeFreq ' range=':= _default_ * ticoArditeFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64 ' range=':= 64 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
@@ -1716,21 +1716,21 @@
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:5")'> <OreBlock block='TConstruct:GravelOre:5' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.580 * _default_ * ticoNetherCobaltGravelFreq ' range=':=  _default_ * ticoNetherCobaltGravelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.834 * _default_ * ticoNetherCobaltGravelSize ' range=':=  _default_ * ticoNetherCobaltGravelSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64 ' range=':=  64 ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.834 * _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * ticoNetherCobaltGravelSize ' range=':=  _default_ * ticoNetherCobaltGravelSize ' type='normal' />
-                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.834 * _default_ * ticoNetherCobaltGravelSize ' range=':=  _default_ * ticoNetherCobaltGravelSize ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.580 * _default_ * ticoNetherCobaltGravelFreq ' range=':= _default_ * ticoNetherCobaltGravelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.834 * _default_ * ticoNetherCobaltGravelSize ' range=':= _default_ * ticoNetherCobaltGravelSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 64 ' range=':= 64 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.834 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * ticoNetherCobaltGravelSize ' range=':= _default_ * ticoNetherCobaltGravelSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.834 * _default_ * ticoNetherCobaltGravelSize ' range=':= _default_ * ticoNetherCobaltGravelSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
@@ -1759,16 +1759,16 @@
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:5")'> <OreBlock block='TConstruct:GravelOre:5' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.076 * _default_ * ticoNetherCobaltGravelSize ' range=':=  _default_ * ticoNetherCobaltGravelSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.076 * _default_ * ticoNetherCobaltGravelSize ' range=':=  _default_ * ticoNetherCobaltGravelSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.159  * _default_ * ticoNetherCobaltGravelFreq ' range=':=  _default_ * ticoNetherCobaltGravelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64 ' range=':=  64 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='CloudRadius' avg=':= 1.076 * _default_ * ticoNetherCobaltGravelSize ' range=':= _default_ * ticoNetherCobaltGravelSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.076 * _default_ * ticoNetherCobaltGravelSize ' range=':= _default_ * ticoNetherCobaltGravelSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.159  * _default_ * ticoNetherCobaltGravelFreq ' range=':= _default_ * ticoNetherCobaltGravelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64 ' range=':= 64 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Veins name='ticoNetherCobaltGravelHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x601D62B8' drawBoundBox='false' boundBoxColor='0x601D62B8'>
                                 <Description>
                                     Single blocks, generously
@@ -1812,10 +1812,10 @@
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:5")'> <OreBlock block='TConstruct:GravelOre:5' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3 * ticoNetherCobaltGravelSize ' range=':=  _default_ * ticoNetherCobaltGravelSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2 * ticoNetherCobaltGravelFreq ' range=':=  _default_ * ticoNetherCobaltGravelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64 ' range=':=  64 ' type='normal' scaleTo='base' />
-                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                            <Setting name='Size' avg=':= 3 * ticoNetherCobaltGravelSize ' range=':= _default_ * ticoNetherCobaltGravelSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2 * ticoNetherCobaltGravelFreq ' range=':= _default_ * ticoNetherCobaltGravelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64 ' range=':= 64 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>

--- a/src/main/resources/config/modules/VanillaMinecraft.xml
+++ b/src/main/resources/config/modules/VanillaMinecraft.xml
@@ -394,21 +394,21 @@
                     <Biome name='Ocean'  weight='-1' />
                     <Biome name='Desert'  weight='-1' />
                     <Biome name='Mountain'  weight='-1' />
-                    <Setting name='MotherlodeFrequency' avg=':= 0.5 * _default_ * vnlaClayFreq ' range=':=  0.5 * _default_ * vnlaClayFreq ' type='uniform' scaleTo='base' />
-                    <Setting name='MotherlodeSize' avg=':= 2 * _default_ * vnlaClaySize ' range=':=  2 * _default_ * vnlaClaySize ' type='normal' />
-                    <Setting name='MotherlodeHeight' avg=':= 60 ' range=':=  4 ' type='normal' scaleTo='base' />
-                    <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='BranchLength' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                    <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='SegmentLength' avg=':= _default_ * vnlaClaySize ' range=':=  _default_ * vnlaClaySize ' type='normal' />
-                    <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='SegmentRadius' avg=':= _default_ * vnlaClaySize ' range=':=  _default_ * vnlaClaySize ' type='normal' />
-                    <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    <Setting name='MotherlodeFrequency' avg=':= 0.5 * _default_ * vnlaClayFreq ' range=':= 0.5 * _default_ * vnlaClayFreq ' type='uniform' scaleTo='base' />
+                    <Setting name='MotherlodeSize' avg=':= 2 * _default_ * vnlaClaySize ' range=':= 2 * _default_ * vnlaClaySize ' type='normal' />
+                    <Setting name='MotherlodeHeight' avg=':= 60 ' range=':= 4 ' type='normal' scaleTo='base' />
+                    <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='BranchLength' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                    <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='SegmentLength' avg=':= _default_ * vnlaClaySize ' range=':= _default_ * vnlaClaySize ' type='normal' />
+                    <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='SegmentRadius' avg=':= _default_ * vnlaClaySize ' range=':= _default_ * vnlaClaySize ' type='normal' />
+                    <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                 </Veins>
 
                 <!-- Beginning "Preferred" configuration. -->
@@ -427,21 +427,21 @@
                     <Biome name='Ocean'  weight='-1' />
                     <Biome name='Desert'  weight='-1' />
                     <Biome name='Mountain'  weight='-1' />
-                    <Setting name='MotherlodeFrequency' avg=':= 0.5 * _default_ * vnlaClayFreq ' range=':=  0.5 * _default_ * vnlaClayFreq ' type='uniform' scaleTo='base' />
-                    <Setting name='MotherlodeSize' avg=':= 2 * _default_ * vnlaClaySize ' range=':=  2 * _default_ * vnlaClaySize ' type='normal' />
-                    <Setting name='MotherlodeHeight' avg=':= 60 ' range=':=  4 ' type='normal' scaleTo='base' />
-                    <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='BranchLength' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                    <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='SegmentLength' avg=':= _default_ * vnlaClaySize ' range=':=  _default_ * vnlaClaySize ' type='normal' />
-                    <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='SegmentRadius' avg=':= _default_ * vnlaClaySize ' range=':=  _default_ * vnlaClaySize ' type='normal' />
-                    <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    <Setting name='MotherlodeFrequency' avg=':= 0.5 * _default_ * vnlaClayFreq ' range=':= 0.5 * _default_ * vnlaClayFreq ' type='uniform' scaleTo='base' />
+                    <Setting name='MotherlodeSize' avg=':= 2 * _default_ * vnlaClaySize ' range=':= 2 * _default_ * vnlaClaySize ' type='normal' />
+                    <Setting name='MotherlodeHeight' avg=':= 60 ' range=':= 4 ' type='normal' scaleTo='base' />
+                    <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='BranchLength' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                    <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='SegmentLength' avg=':= _default_ * vnlaClaySize ' range=':= _default_ * vnlaClaySize ' type='normal' />
+                    <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='SegmentRadius' avg=':= _default_ * vnlaClaySize ' range=':= _default_ * vnlaClaySize ' type='normal' />
+                    <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                 </Veins>
                 <!-- "Preferred" configuration complete. -->
 
@@ -471,21 +471,21 @@
                     <IfCondition condition=':= ?blockExists("minecraft:coal_ore")'> <OreBlock block='minecraft:coal_ore' weight='1.0' /> </IfCondition>
                     <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                     <Biome name='.*'  />
-                    <Setting name='MotherlodeFrequency' avg=':= 6.262 * _default_ * vnlaCoalFreq ' range=':=  1 * _default_ * vnlaCoalFreq ' type='normal' scaleTo='base' />
-                    <Setting name='MotherlodeSize' avg=':= 1.843 * _default_ * vnlaCoalSize ' range=':=  1 * _default_ * vnlaCoalSize ' type='normal' />
-                    <Setting name='MotherlodeHeight' avg=':= 68 ' range=':=  63 ' type='uniform' scaleTo='base' />
-                    <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='BranchLength' avg=':= 1.843 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                    <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                    <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='SegmentLength' avg=':= _default_ * vnlaCoalSize ' range=':=  _default_ * vnlaCoalSize ' type='normal' />
-                    <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='SegmentRadius' avg=':= 1.843 * _default_ * vnlaCoalSize ' range=':=  1 * _default_ * vnlaCoalSize ' type='normal' />
-                    <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    <Setting name='MotherlodeFrequency' avg=':= 6.262 * _default_ * vnlaCoalFreq ' range=':= 1 * _default_ * vnlaCoalFreq ' type='normal' scaleTo='base' />
+                    <Setting name='MotherlodeSize' avg=':= 1.843 * _default_ * vnlaCoalSize ' range=':= 1 * _default_ * vnlaCoalSize ' type='normal' />
+                    <Setting name='MotherlodeHeight' avg=':= 68 ' range=':= 63 ' type='uniform' scaleTo='base' />
+                    <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='BranchLength' avg=':= 1.843 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                    <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                    <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='SegmentLength' avg=':= _default_ * vnlaCoalSize ' range=':= _default_ * vnlaCoalSize ' type='normal' />
+                    <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='SegmentRadius' avg=':= 1.843 * _default_ * vnlaCoalSize ' range=':= 1 * _default_ * vnlaCoalSize ' type='normal' />
+                    <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                 </Veins>
             </IfCondition>
         </ConfigSection>
@@ -511,16 +511,16 @@
                     <IfCondition condition=':= ?blockExists("minecraft:coal_ore")'> <OreBlock block='minecraft:coal_ore' weight='1.0' /> </IfCondition>
                     <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                     <Biome name='.*'  />
-                    <Setting name='CloudRadius' avg=':= 2.057 * _default_ * vnlaCoalSize ' range=':=  _default_ * vnlaCoalSize ' type='normal' />
-                    <Setting name='CloudThickness' avg=':= 2.057 * _default_ * vnlaCoalSize ' range=':=  _default_ * vnlaCoalSize ' type='normal' scaleTo='base' />
-                    <Setting name='DistributionFrequency' avg=':= 4.230  * _default_ * vnlaCoalFreq ' range=':=  _default_ * vnlaCoalFreq ' type='normal' scaleTo='base' />
-                    <Setting name='CloudHeight' avg=':= 68 ' range=':=  63 ' type='uniform' scaleTo='base' />
-                    <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                    <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    <Setting name='CloudRadius' avg=':= 2.057 * _default_ * vnlaCoalSize ' range=':= _default_ * vnlaCoalSize ' type='normal' />
+                    <Setting name='CloudThickness' avg=':= 2.057 * _default_ * vnlaCoalSize ' range=':= _default_ * vnlaCoalSize ' type='normal' scaleTo='base' />
+                    <Setting name='DistributionFrequency' avg=':= 4.230  * _default_ * vnlaCoalFreq ' range=':= _default_ * vnlaCoalFreq ' type='normal' scaleTo='base' />
+                    <Setting name='CloudHeight' avg=':= 68 ' range=':= 63 ' type='uniform' scaleTo='base' />
+                    <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                    <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Veins name='vnlaCoalHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x602A2A2A' drawBoundBox='false' boundBoxColor='0x602A2A2A'>
                         <Description>
                             Single blocks, generously scattered
@@ -560,10 +560,10 @@
                     <IfCondition condition=':= ?blockExists("minecraft:coal_ore")'> <OreBlock block='minecraft:coal_ore' weight='1.0' /> </IfCondition>
                     <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                     <Biome name='.*'  />
-                    <Setting name='Size' avg=':= 16 * vnlaCoalSize ' range=':=  _default_ * vnlaCoalSize ' type='normal' />
-                    <Setting name='Frequency' avg=':= 20 * vnlaCoalFreq ' range=':=  _default_ * vnlaCoalFreq ' type='normal' scaleTo='base' />
-                    <Setting name='Height' avg=':= 68 ' range=':=  63 ' type='uniform' scaleTo='base' />
-                    <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    <Setting name='Size' avg=':= 16 * vnlaCoalSize ' range=':= _default_ * vnlaCoalSize ' type='normal' />
+                    <Setting name='Frequency' avg=':= 20 * vnlaCoalFreq ' range=':= _default_ * vnlaCoalFreq ' type='normal' scaleTo='base' />
+                    <Setting name='Height' avg=':= 68 ' range=':= 63 ' type='uniform' scaleTo='base' />
+                    <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                 </StandardGen>
             </IfCondition>
         </ConfigSection>
@@ -589,16 +589,16 @@
                     <IfCondition condition=':= ?blockExists("minecraft:coal_ore")'> <OreBlock block='minecraft:coal_ore' weight='1.0' /> </IfCondition>
                     <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                     <Biome name='.*'  />
-                    <Setting name='CloudRadius' avg=':= 2.057 * _default_ * vnlaCoalSize ' range=':=  _default_ * vnlaCoalSize ' type='normal' />
-                    <Setting name='CloudThickness' avg=':= 2.057 * _default_ * vnlaCoalSize ' range=':=  _default_ * vnlaCoalSize ' type='normal' scaleTo='base' />
-                    <Setting name='DistributionFrequency' avg=':= 4.230  * _default_ * vnlaCoalFreq ' range=':=  _default_ * vnlaCoalFreq ' type='normal' scaleTo='base' />
-                    <Setting name='CloudHeight' avg=':= 68 ' range=':=  63 ' type='uniform' scaleTo='base' />
-                    <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                    <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    <Setting name='CloudRadius' avg=':= 2.057 * _default_ * vnlaCoalSize ' range=':= _default_ * vnlaCoalSize ' type='normal' />
+                    <Setting name='CloudThickness' avg=':= 2.057 * _default_ * vnlaCoalSize ' range=':= _default_ * vnlaCoalSize ' type='normal' scaleTo='base' />
+                    <Setting name='DistributionFrequency' avg=':= 4.230  * _default_ * vnlaCoalFreq ' range=':= _default_ * vnlaCoalFreq ' type='normal' scaleTo='base' />
+                    <Setting name='CloudHeight' avg=':= 68 ' range=':= 63 ' type='uniform' scaleTo='base' />
+                    <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                    <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Veins name='vnlaCoalHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x602A2A2A' drawBoundBox='false' boundBoxColor='0x602A2A2A'>
                         <Description>
                             Single blocks, generously scattered
@@ -642,21 +642,21 @@
                     <IfCondition condition=':= ?blockExists("minecraft:iron_ore")'> <OreBlock block='minecraft:iron_ore' weight='1.0' /> </IfCondition>
                     <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                     <Biome name='.*'  />
-                    <Setting name='MotherlodeFrequency' avg=':= 1.498 * _default_ * vnlaIronFreq ' range=':=  1 * _default_ * vnlaIronFreq ' type='normal' scaleTo='base' />
-                    <Setting name='MotherlodeSize' avg=':= 1.144 * _default_ * vnlaIronSize ' range=':=  1 * _default_ * vnlaIronSize ' type='normal' />
-                    <Setting name='MotherlodeHeight' avg=':= 36 ' range=':=  31 ' type='normal' scaleTo='base' />
-                    <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='BranchLength' avg=':= 1.144 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                    <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                    <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='SegmentLength' avg=':= _default_ * vnlaIronSize ' range=':=  _default_ * vnlaIronSize ' type='normal' />
-                    <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='SegmentRadius' avg=':= 1.144 * _default_ * vnlaIronSize ' range=':=  1 * _default_ * vnlaIronSize ' type='normal' />
-                    <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    <Setting name='MotherlodeFrequency' avg=':= 1.498 * _default_ * vnlaIronFreq ' range=':= 1 * _default_ * vnlaIronFreq ' type='normal' scaleTo='base' />
+                    <Setting name='MotherlodeSize' avg=':= 1.144 * _default_ * vnlaIronSize ' range=':= 1 * _default_ * vnlaIronSize ' type='normal' />
+                    <Setting name='MotherlodeHeight' avg=':= 36 ' range=':= 31 ' type='normal' scaleTo='base' />
+                    <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='BranchLength' avg=':= 1.144 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                    <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                    <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='SegmentLength' avg=':= _default_ * vnlaIronSize ' range=':= _default_ * vnlaIronSize ' type='normal' />
+                    <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='SegmentRadius' avg=':= 1.144 * _default_ * vnlaIronSize ' range=':= 1 * _default_ * vnlaIronSize ' type='normal' />
+                    <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                 </Veins>
             </IfCondition>
         </ConfigSection>
@@ -674,10 +674,10 @@
                     <IfCondition condition=':= ?blockExists("minecraft:iron_ore")'> <OreBlock block='minecraft:iron_ore' weight='1.0' /> </IfCondition>
                     <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                     <Biome name='.*'  />
-                    <Setting name='Size' avg=':= 8 * vnlaIronSize ' range=':=  _default_ * vnlaIronSize ' type='normal' />
-                    <Setting name='Frequency' avg=':= 20 * vnlaIronFreq ' range=':=  _default_ * vnlaIronFreq ' type='normal' scaleTo='base' />
-                    <Setting name='Height' avg=':= 36 ' range=':=  31 ' type='normal' scaleTo='base' />
-                    <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    <Setting name='Size' avg=':= 8 * vnlaIronSize ' range=':= _default_ * vnlaIronSize ' type='normal' />
+                    <Setting name='Frequency' avg=':= 20 * vnlaIronFreq ' range=':= _default_ * vnlaIronFreq ' type='normal' scaleTo='base' />
+                    <Setting name='Height' avg=':= 36 ' range=':= 31 ' type='normal' scaleTo='base' />
+                    <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                 </StandardGen>
             </IfCondition>
         </ConfigSection>
@@ -703,16 +703,16 @@
                     <IfCondition condition=':= ?blockExists("minecraft:iron_ore")'> <OreBlock block='minecraft:iron_ore' weight='1.0' /> </IfCondition>
                     <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                     <Biome name='.*'  />
-                    <Setting name='CloudRadius' avg=':= 1.730 * _default_ * vnlaIronSize ' range=':=  _default_ * vnlaIronSize ' type='normal' />
-                    <Setting name='CloudThickness' avg=':= 1.730 * _default_ * vnlaIronSize ' range=':=  _default_ * vnlaIronSize ' type='normal' scaleTo='base' />
-                    <Setting name='DistributionFrequency' avg=':= 2.991  * _default_ * vnlaIronFreq ' range=':=  _default_ * vnlaIronFreq ' type='normal' scaleTo='base' />
-                    <Setting name='CloudHeight' avg=':= 36 ' range=':=  31 ' type='normal' scaleTo='base' />
-                    <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                    <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    <Setting name='CloudRadius' avg=':= 1.730 * _default_ * vnlaIronSize ' range=':= _default_ * vnlaIronSize ' type='normal' />
+                    <Setting name='CloudThickness' avg=':= 1.730 * _default_ * vnlaIronSize ' range=':= _default_ * vnlaIronSize ' type='normal' scaleTo='base' />
+                    <Setting name='DistributionFrequency' avg=':= 2.991  * _default_ * vnlaIronFreq ' range=':= _default_ * vnlaIronFreq ' type='normal' scaleTo='base' />
+                    <Setting name='CloudHeight' avg=':= 36 ' range=':= 31 ' type='normal' scaleTo='base' />
+                    <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                    <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Veins name='vnlaIronHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60DDC2AF' drawBoundBox='false' boundBoxColor='0x60DDC2AF'>
                         <Description>
                             Single blocks, generously scattered
@@ -756,21 +756,21 @@
                     <IfCondition condition=':= ?blockExists("minecraft:gold_ore")'> <OreBlock block='minecraft:gold_ore' weight='1.0' /> </IfCondition>
                     <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                     <Biome name='.*'  />
-                    <Setting name='MotherlodeFrequency' avg=':= 0.474 * _default_ * vnlaGoldFreq ' range=':=  1 * _default_ * vnlaGoldFreq ' type='normal' scaleTo='base' />
-                    <Setting name='MotherlodeSize' avg=':= 0.780 * _default_ * vnlaGoldSize ' range=':=  1 * _default_ * vnlaGoldSize ' type='normal' />
-                    <Setting name='MotherlodeHeight' avg=':= 17 ' range=':=  12 ' type='normal' scaleTo='base' />
-                    <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='BranchLength' avg=':= 0.780 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                    <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                    <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='SegmentLength' avg=':= _default_ * vnlaGoldSize ' range=':=  _default_ * vnlaGoldSize ' type='normal' />
-                    <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='SegmentRadius' avg=':= 0.780 * _default_ * vnlaGoldSize ' range=':=  1 * _default_ * vnlaGoldSize ' type='normal' />
-                    <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    <Setting name='MotherlodeFrequency' avg=':= 0.474 * _default_ * vnlaGoldFreq ' range=':= 1 * _default_ * vnlaGoldFreq ' type='normal' scaleTo='base' />
+                    <Setting name='MotherlodeSize' avg=':= 0.780 * _default_ * vnlaGoldSize ' range=':= 1 * _default_ * vnlaGoldSize ' type='normal' />
+                    <Setting name='MotherlodeHeight' avg=':= 17 ' range=':= 12 ' type='normal' scaleTo='base' />
+                    <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='BranchLength' avg=':= 0.780 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                    <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                    <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='SegmentLength' avg=':= _default_ * vnlaGoldSize ' range=':= _default_ * vnlaGoldSize ' type='normal' />
+                    <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='SegmentRadius' avg=':= 0.780 * _default_ * vnlaGoldSize ' range=':= 1 * _default_ * vnlaGoldSize ' type='normal' />
+                    <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                 </Veins>
             </IfCondition>
         </ConfigSection>
@@ -788,10 +788,10 @@
                     <IfCondition condition=':= ?blockExists("minecraft:gold_ore")'> <OreBlock block='minecraft:gold_ore' weight='1.0' /> </IfCondition>
                     <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                     <Biome name='.*'  />
-                    <Setting name='Size' avg=':= 8 * vnlaGoldSize ' range=':=  _default_ * vnlaGoldSize ' type='normal' />
-                    <Setting name='Frequency' avg=':= 2 * vnlaGoldFreq ' range=':=  _default_ * vnlaGoldFreq ' type='normal' scaleTo='base' />
-                    <Setting name='Height' avg=':= 17 ' range=':=  12 ' type='normal' scaleTo='base' />
-                    <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    <Setting name='Size' avg=':= 8 * vnlaGoldSize ' range=':= _default_ * vnlaGoldSize ' type='normal' />
+                    <Setting name='Frequency' avg=':= 2 * vnlaGoldFreq ' range=':= _default_ * vnlaGoldFreq ' type='normal' scaleTo='base' />
+                    <Setting name='Height' avg=':= 17 ' range=':= 12 ' type='normal' scaleTo='base' />
+                    <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                 </StandardGen>
             </IfCondition>
         </ConfigSection>
@@ -817,16 +817,16 @@
                     <IfCondition condition=':= ?blockExists("minecraft:gold_ore")'> <OreBlock block='minecraft:gold_ore' weight='1.0' /> </IfCondition>
                     <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                     <Biome name='.*'  />
-                    <Setting name='CloudRadius' avg=':= 0.973 * _default_ * vnlaGoldSize ' range=':=  _default_ * vnlaGoldSize ' type='normal' />
-                    <Setting name='CloudThickness' avg=':= 0.973 * _default_ * vnlaGoldSize ' range=':=  _default_ * vnlaGoldSize ' type='normal' scaleTo='base' />
-                    <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * vnlaGoldFreq ' range=':=  _default_ * vnlaGoldFreq ' type='normal' scaleTo='base' />
-                    <Setting name='CloudHeight' avg=':= 17 ' range=':=  12 ' type='normal' scaleTo='base' />
-                    <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                    <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    <Setting name='CloudRadius' avg=':= 0.973 * _default_ * vnlaGoldSize ' range=':= _default_ * vnlaGoldSize ' type='normal' />
+                    <Setting name='CloudThickness' avg=':= 0.973 * _default_ * vnlaGoldSize ' range=':= _default_ * vnlaGoldSize ' type='normal' scaleTo='base' />
+                    <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * vnlaGoldFreq ' range=':= _default_ * vnlaGoldFreq ' type='normal' scaleTo='base' />
+                    <Setting name='CloudHeight' avg=':= 17 ' range=':= 12 ' type='normal' scaleTo='base' />
+                    <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                    <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Veins name='vnlaGoldHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60EAEF57' drawBoundBox='false' boundBoxColor='0x60EAEF57'>
                         <Description>
                             Single blocks, generously scattered
@@ -870,21 +870,21 @@
                     <IfCondition condition=':= ?blockExists("minecraft:redstone_ore")'> <OreBlock block='minecraft:redstone_ore' weight='1.0' /> </IfCondition>
                     <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                     <Biome name='.*'  />
-                    <Setting name='MotherlodeFrequency' avg=':= 1.642 * _default_ * vnlaRedstoneFreq ' range=':=  1 * _default_ * vnlaRedstoneFreq ' type='normal' scaleTo='base' />
-                    <Setting name='MotherlodeSize' avg=':= 1.180 * _default_ * vnlaRedstoneSize ' range=':=  1 * _default_ * vnlaRedstoneSize ' type='normal' />
-                    <Setting name='MotherlodeHeight' avg=':= 10 ' range=':=  5 ' type='normal' scaleTo='base' />
-                    <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='BranchInclination' avg=':= -_default_ ' range=':=  -_default_ ' type='normal' />
-                    <Setting name='BranchLength' avg=':= 1.180 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                    <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                    <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='SegmentLength' avg=':= _default_ * vnlaRedstoneSize ' range=':=  _default_ * vnlaRedstoneSize ' type='normal' />
-                    <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='SegmentRadius' avg=':= 1.180 * _default_ * vnlaRedstoneSize ' range=':=  1 * _default_ * vnlaRedstoneSize ' type='normal' />
-                    <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    <Setting name='MotherlodeFrequency' avg=':= 1.642 * _default_ * vnlaRedstoneFreq ' range=':= 1 * _default_ * vnlaRedstoneFreq ' type='normal' scaleTo='base' />
+                    <Setting name='MotherlodeSize' avg=':= 1.180 * _default_ * vnlaRedstoneSize ' range=':= 1 * _default_ * vnlaRedstoneSize ' type='normal' />
+                    <Setting name='MotherlodeHeight' avg=':= 10 ' range=':= 5 ' type='normal' scaleTo='base' />
+                    <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='BranchInclination' avg=':= -_default_ ' range=':= -_default_ ' type='normal' />
+                    <Setting name='BranchLength' avg=':= 1.180 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                    <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                    <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='SegmentLength' avg=':= _default_ * vnlaRedstoneSize ' range=':= _default_ * vnlaRedstoneSize ' type='normal' />
+                    <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='SegmentRadius' avg=':= 1.180 * _default_ * vnlaRedstoneSize ' range=':= 1 * _default_ * vnlaRedstoneSize ' type='normal' />
+                    <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                 </Veins>
 
                 <!-- Beginning "Preferred" configuration. -->
@@ -896,21 +896,21 @@
                     <IfCondition condition=':= ?blockExists("minecraft:redstone_ore")'> <OreBlock block='minecraft:redstone_ore' weight='1.0' /> </IfCondition>
                     <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                     <BiomeType name='Desert'  />
-                    <Setting name='MotherlodeFrequency' avg=':= 1.642 * _default_ * vnlaRedstoneFreq ' range=':=  1 * _default_ * vnlaRedstoneFreq ' type='normal' scaleTo='base' />
-                    <Setting name='MotherlodeSize' avg=':= 1.180 * _default_ * vnlaRedstoneSize ' range=':=  1 * _default_ * vnlaRedstoneSize ' type='normal' />
-                    <Setting name='MotherlodeHeight' avg=':= 10 ' range=':=  5 ' type='normal' scaleTo='base' />
-                    <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='BranchInclination' avg=':= -_default_ ' range=':=  -_default_ ' type='normal' />
-                    <Setting name='BranchLength' avg=':= 1.180 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                    <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                    <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='SegmentLength' avg=':= _default_ * vnlaRedstoneSize ' range=':=  _default_ * vnlaRedstoneSize ' type='normal' />
-                    <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='SegmentRadius' avg=':= 1.180 * _default_ * vnlaRedstoneSize ' range=':=  1 * _default_ * vnlaRedstoneSize ' type='normal' />
-                    <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    <Setting name='MotherlodeFrequency' avg=':= 1.642 * _default_ * vnlaRedstoneFreq ' range=':= 1 * _default_ * vnlaRedstoneFreq ' type='normal' scaleTo='base' />
+                    <Setting name='MotherlodeSize' avg=':= 1.180 * _default_ * vnlaRedstoneSize ' range=':= 1 * _default_ * vnlaRedstoneSize ' type='normal' />
+                    <Setting name='MotherlodeHeight' avg=':= 10 ' range=':= 5 ' type='normal' scaleTo='base' />
+                    <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='BranchInclination' avg=':= -_default_ ' range=':= -_default_ ' type='normal' />
+                    <Setting name='BranchLength' avg=':= 1.180 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                    <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                    <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='SegmentLength' avg=':= _default_ * vnlaRedstoneSize ' range=':= _default_ * vnlaRedstoneSize ' type='normal' />
+                    <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='SegmentRadius' avg=':= 1.180 * _default_ * vnlaRedstoneSize ' range=':= 1 * _default_ * vnlaRedstoneSize ' type='normal' />
+                    <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                 </Veins>
                 <!-- "Preferred" configuration complete. -->
 
@@ -930,10 +930,10 @@
                     <IfCondition condition=':= ?blockExists("minecraft:redstone_ore")'> <OreBlock block='minecraft:redstone_ore' weight='1.0' /> </IfCondition>
                     <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                     <Biome name='.*'  />
-                    <Setting name='Size' avg=':= 7 * vnlaRedstoneSize ' range=':=  _default_ * vnlaRedstoneSize ' type='normal' />
-                    <Setting name='Frequency' avg=':= 8 * vnlaRedstoneFreq ' range=':=  _default_ * vnlaRedstoneFreq ' type='normal' scaleTo='base' />
-                    <Setting name='Height' avg=':= 10 ' range=':=  5 ' type='normal' scaleTo='base' />
-                    <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    <Setting name='Size' avg=':= 7 * vnlaRedstoneSize ' range=':= _default_ * vnlaRedstoneSize ' type='normal' />
+                    <Setting name='Frequency' avg=':= 8 * vnlaRedstoneFreq ' range=':= _default_ * vnlaRedstoneFreq ' type='normal' scaleTo='base' />
+                    <Setting name='Height' avg=':= 10 ' range=':= 5 ' type='normal' scaleTo='base' />
+                    <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                 </StandardGen>
             </IfCondition>
         </ConfigSection>
@@ -959,16 +959,16 @@
                     <IfCondition condition=':= ?blockExists("minecraft:redstone_ore")'> <OreBlock block='minecraft:redstone_ore' weight='1.0' /> </IfCondition>
                     <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                     <Biome name='.*'  />
-                    <Setting name='CloudRadius' avg=':= 1.330 * _default_ * vnlaRedstoneSize ' range=':=  _default_ * vnlaRedstoneSize ' type='normal' />
-                    <Setting name='CloudThickness' avg=':= 1.330 * _default_ * vnlaRedstoneSize ' range=':=  _default_ * vnlaRedstoneSize ' type='normal' scaleTo='base' />
-                    <Setting name='DistributionFrequency' avg=':= 1.770  * _default_ * vnlaRedstoneFreq ' range=':=  _default_ * vnlaRedstoneFreq ' type='normal' scaleTo='base' />
-                    <Setting name='CloudHeight' avg=':= 10 ' range=':=  5 ' type='normal' scaleTo='base' />
-                    <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                    <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    <Setting name='CloudRadius' avg=':= 1.330 * _default_ * vnlaRedstoneSize ' range=':= _default_ * vnlaRedstoneSize ' type='normal' />
+                    <Setting name='CloudThickness' avg=':= 1.330 * _default_ * vnlaRedstoneSize ' range=':= _default_ * vnlaRedstoneSize ' type='normal' scaleTo='base' />
+                    <Setting name='DistributionFrequency' avg=':= 1.770  * _default_ * vnlaRedstoneFreq ' range=':= _default_ * vnlaRedstoneFreq ' type='normal' scaleTo='base' />
+                    <Setting name='CloudHeight' avg=':= 10 ' range=':= 5 ' type='normal' scaleTo='base' />
+                    <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                    <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Veins name='vnlaRedstoneHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60A80002' drawBoundBox='false' boundBoxColor='0x60A80002'>
                         <Description>
                             Single blocks, generously scattered
@@ -1002,16 +1002,16 @@
                     <IfCondition condition=':= ?blockExists("minecraft:redstone_ore")'> <OreBlock block='minecraft:redstone_ore' weight='1.0' /> </IfCondition>
                     <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                     <BiomeType name='Desert'  />
-                    <Setting name='CloudRadius' avg=':= 1.330 * _default_ * vnlaRedstoneSize ' range=':=  _default_ * vnlaRedstoneSize ' type='normal' />
-                    <Setting name='CloudThickness' avg=':= 1.330 * _default_ * vnlaRedstoneSize ' range=':=  _default_ * vnlaRedstoneSize ' type='normal' scaleTo='base' />
-                    <Setting name='DistributionFrequency' avg=':= 1.770  * _default_ * vnlaRedstoneFreq ' range=':=  _default_ * vnlaRedstoneFreq ' type='normal' scaleTo='base' />
-                    <Setting name='CloudHeight' avg=':= 10 ' range=':=  5 ' type='normal' scaleTo='base' />
-                    <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                    <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    <Setting name='CloudRadius' avg=':= 1.330 * _default_ * vnlaRedstoneSize ' range=':= _default_ * vnlaRedstoneSize ' type='normal' />
+                    <Setting name='CloudThickness' avg=':= 1.330 * _default_ * vnlaRedstoneSize ' range=':= _default_ * vnlaRedstoneSize ' type='normal' scaleTo='base' />
+                    <Setting name='DistributionFrequency' avg=':= 1.770  * _default_ * vnlaRedstoneFreq ' range=':= _default_ * vnlaRedstoneFreq ' type='normal' scaleTo='base' />
+                    <Setting name='CloudHeight' avg=':= 10 ' range=':= 5 ' type='normal' scaleTo='base' />
+                    <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                    <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Veins name='vnlaRedstonePreferredHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60A80002' drawBoundBox='false' boundBoxColor='0x60A80002'>
                         <Description>
                             Ore generation is doubled in  preferred
@@ -1044,21 +1044,21 @@
                     <IfCondition condition=':= ?blockExists("minecraft:diamond_ore")'> <OreBlock block='minecraft:diamond_ore' weight='1.0' /> </IfCondition>
                     <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                     <Biome name='.*'  />
-                    <Setting name='MotherlodeFrequency' avg=':= 0.365 * _default_ * vnlaDiamondFreq ' range=':=  1 * _default_ * vnlaDiamondFreq ' type='normal' scaleTo='base' />
-                    <Setting name='MotherlodeSize' avg=':= 0.715 * _default_ * vnlaDiamondSize ' range=':=  1 * _default_ * vnlaDiamondSize ' type='normal' />
-                    <Setting name='MotherlodeHeight' avg=':= 10 ' range=':=  5 ' type='normal' scaleTo='base' />
-                    <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='BranchLength' avg=':= 0.715 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                    <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                    <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='SegmentLength' avg=':= _default_ * vnlaDiamondSize ' range=':=  _default_ * vnlaDiamondSize ' type='normal' />
-                    <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='SegmentRadius' avg=':= 0.715 * _default_ * vnlaDiamondSize ' range=':=  1 * _default_ * vnlaDiamondSize ' type='normal' />
-                    <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    <Setting name='MotherlodeFrequency' avg=':= 0.365 * _default_ * vnlaDiamondFreq ' range=':= 1 * _default_ * vnlaDiamondFreq ' type='normal' scaleTo='base' />
+                    <Setting name='MotherlodeSize' avg=':= 0.715 * _default_ * vnlaDiamondSize ' range=':= 1 * _default_ * vnlaDiamondSize ' type='normal' />
+                    <Setting name='MotherlodeHeight' avg=':= 10 ' range=':= 5 ' type='normal' scaleTo='base' />
+                    <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='BranchLength' avg=':= 0.715 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                    <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                    <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='SegmentLength' avg=':= _default_ * vnlaDiamondSize ' range=':= _default_ * vnlaDiamondSize ' type='normal' />
+                    <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='SegmentRadius' avg=':= 0.715 * _default_ * vnlaDiamondSize ' range=':= 1 * _default_ * vnlaDiamondSize ' type='normal' />
+                    <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                 </Veins>
 
                 <!-- Configuring contained material. -->
@@ -1066,8 +1066,8 @@
                     <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
                     <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                     <IfCondition condition=':= ?blockExists("minecraft:diamond_ore")'> <Replaces block='minecraft:diamond_ore' weight='1.0' /> </IfCondition>
-                    <Setting name='MotherlodeSize' avg=':= 0.715 * _default_ * vnlaDiamondSize  * 0.5 ' range=':=  1 * _default_ * vnlaDiamondSize  * 0.5 ' type='normal' />
-                    <Setting name='SegmentRadius' avg=':= 0.715 * _default_ * vnlaDiamondSize  * 0.5 ' range=':=  1 * _default_ * vnlaDiamondSize  * 0.5 ' type='normal' />
+                    <Setting name='MotherlodeSize' avg=':= 0.715 * _default_ * vnlaDiamondSize  * 0.5 ' range=':= 1 * _default_ * vnlaDiamondSize  * 0.5 ' type='normal' />
+                    <Setting name='SegmentRadius' avg=':= 0.715 * _default_ * vnlaDiamondSize  * 0.5 ' range=':= 1 * _default_ * vnlaDiamondSize  * 0.5 ' type='normal' />
                     <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
                 </Veins>
             </IfCondition>
@@ -1086,10 +1086,10 @@
                     <IfCondition condition=':= ?blockExists("minecraft:diamond_ore")'> <OreBlock block='minecraft:diamond_ore' weight='1.0' /> </IfCondition>
                     <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                     <Biome name='.*'  />
-                    <Setting name='Size' avg=':= 7 * vnlaDiamondSize ' range=':=  _default_ * vnlaDiamondSize ' type='normal' />
-                    <Setting name='Frequency' avg=':= 1 * vnlaDiamondFreq ' range=':=  _default_ * vnlaDiamondFreq ' type='normal' scaleTo='base' />
-                    <Setting name='Height' avg=':= 10 ' range=':=  5 ' type='normal' scaleTo='base' />
-                    <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    <Setting name='Size' avg=':= 7 * vnlaDiamondSize ' range=':= _default_ * vnlaDiamondSize ' type='normal' />
+                    <Setting name='Frequency' avg=':= 1 * vnlaDiamondFreq ' range=':= _default_ * vnlaDiamondFreq ' type='normal' scaleTo='base' />
+                    <Setting name='Height' avg=':= 10 ' range=':= 5 ' type='normal' scaleTo='base' />
+                    <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                 </StandardGen>
             </IfCondition>
         </ConfigSection>
@@ -1115,16 +1115,16 @@
                     <IfCondition condition=':= ?blockExists("minecraft:diamond_ore")'> <OreBlock block='minecraft:diamond_ore' weight='1.0' /> </IfCondition>
                     <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                     <Biome name='.*'  />
-                    <Setting name='CloudRadius' avg=':= 0.791 * _default_ * vnlaDiamondSize ' range=':=  _default_ * vnlaDiamondSize ' type='normal' />
-                    <Setting name='CloudThickness' avg=':= 0.791 * _default_ * vnlaDiamondSize ' range=':=  _default_ * vnlaDiamondSize ' type='normal' scaleTo='base' />
-                    <Setting name='DistributionFrequency' avg=':= 0.626  * _default_ * vnlaDiamondFreq ' range=':=  _default_ * vnlaDiamondFreq ' type='normal' scaleTo='base' />
-                    <Setting name='CloudHeight' avg=':= 10 ' range=':=  5 ' type='normal' scaleTo='base' />
-                    <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                    <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    <Setting name='CloudRadius' avg=':= 0.791 * _default_ * vnlaDiamondSize ' range=':= _default_ * vnlaDiamondSize ' type='normal' />
+                    <Setting name='CloudThickness' avg=':= 0.791 * _default_ * vnlaDiamondSize ' range=':= _default_ * vnlaDiamondSize ' type='normal' scaleTo='base' />
+                    <Setting name='DistributionFrequency' avg=':= 0.626  * _default_ * vnlaDiamondFreq ' range=':= _default_ * vnlaDiamondFreq ' type='normal' scaleTo='base' />
+                    <Setting name='CloudHeight' avg=':= 10 ' range=':= 5 ' type='normal' scaleTo='base' />
+                    <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                    <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Veins name='vnlaDiamondHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x608BF4E3' drawBoundBox='false' boundBoxColor='0x608BF4E3'>
                         <Description>
                             Single blocks, generously scattered
@@ -1168,21 +1168,21 @@
                     <IfCondition condition=':= ?blockExists("minecraft:lapis_ore")'> <OreBlock block='minecraft:lapis_ore' weight='1.0' /> </IfCondition>
                     <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                     <Biome name='.*'  />
-                    <Setting name='MotherlodeFrequency' avg=':= 0.538 * _default_ * vnlaLapisLazuliFreq ' range=':=  1 * _default_ * vnlaLapisLazuliFreq ' type='normal' scaleTo='base' />
-                    <Setting name='MotherlodeSize' avg=':= 0.813 * _default_ * vnlaLapisLazuliSize ' range=':=  1 * _default_ * vnlaLapisLazuliSize ' type='normal' />
-                    <Setting name='MotherlodeHeight' avg=':= 19 ' range=':=  14 ' type='normal' scaleTo='base' />
-                    <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='BranchInclination' avg=':= -_default_ ' range=':=  -_default_ ' type='normal' />
-                    <Setting name='BranchLength' avg=':= 0.813 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                    <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                    <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='SegmentLength' avg=':= _default_ * vnlaLapisLazuliSize ' range=':=  _default_ * vnlaLapisLazuliSize ' type='normal' />
-                    <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='SegmentRadius' avg=':= 0.813 * _default_ * vnlaLapisLazuliSize ' range=':=  1 * _default_ * vnlaLapisLazuliSize ' type='normal' />
-                    <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    <Setting name='MotherlodeFrequency' avg=':= 0.538 * _default_ * vnlaLapisLazuliFreq ' range=':= 1 * _default_ * vnlaLapisLazuliFreq ' type='normal' scaleTo='base' />
+                    <Setting name='MotherlodeSize' avg=':= 0.813 * _default_ * vnlaLapisLazuliSize ' range=':= 1 * _default_ * vnlaLapisLazuliSize ' type='normal' />
+                    <Setting name='MotherlodeHeight' avg=':= 19 ' range=':= 14 ' type='normal' scaleTo='base' />
+                    <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='BranchInclination' avg=':= -_default_ ' range=':= -_default_ ' type='normal' />
+                    <Setting name='BranchLength' avg=':= 0.813 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                    <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                    <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='SegmentLength' avg=':= _default_ * vnlaLapisLazuliSize ' range=':= _default_ * vnlaLapisLazuliSize ' type='normal' />
+                    <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='SegmentRadius' avg=':= 0.813 * _default_ * vnlaLapisLazuliSize ' range=':= 1 * _default_ * vnlaLapisLazuliSize ' type='normal' />
+                    <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                 </Veins>
 
                 <!-- Beginning "Preferred" configuration. -->
@@ -1194,21 +1194,21 @@
                     <IfCondition condition=':= ?blockExists("minecraft:lapis_ore")'> <OreBlock block='minecraft:lapis_ore' weight='1.0' /> </IfCondition>
                     <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                     <BiomeType name='Ocean'  />
-                    <Setting name='MotherlodeFrequency' avg=':= 0.538 * _default_ * vnlaLapisLazuliFreq ' range=':=  1 * _default_ * vnlaLapisLazuliFreq ' type='normal' scaleTo='base' />
-                    <Setting name='MotherlodeSize' avg=':= 0.813 * _default_ * vnlaLapisLazuliSize ' range=':=  1 * _default_ * vnlaLapisLazuliSize ' type='normal' />
-                    <Setting name='MotherlodeHeight' avg=':= 19 ' range=':=  14 ' type='normal' scaleTo='base' />
-                    <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='BranchInclination' avg=':= -_default_ ' range=':=  -_default_ ' type='normal' />
-                    <Setting name='BranchLength' avg=':= 0.813 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                    <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                    <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='SegmentLength' avg=':= _default_ * vnlaLapisLazuliSize ' range=':=  _default_ * vnlaLapisLazuliSize ' type='normal' />
-                    <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='SegmentRadius' avg=':= 0.813 * _default_ * vnlaLapisLazuliSize ' range=':=  1 * _default_ * vnlaLapisLazuliSize ' type='normal' />
-                    <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    <Setting name='MotherlodeFrequency' avg=':= 0.538 * _default_ * vnlaLapisLazuliFreq ' range=':= 1 * _default_ * vnlaLapisLazuliFreq ' type='normal' scaleTo='base' />
+                    <Setting name='MotherlodeSize' avg=':= 0.813 * _default_ * vnlaLapisLazuliSize ' range=':= 1 * _default_ * vnlaLapisLazuliSize ' type='normal' />
+                    <Setting name='MotherlodeHeight' avg=':= 19 ' range=':= 14 ' type='normal' scaleTo='base' />
+                    <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='BranchInclination' avg=':= -_default_ ' range=':= -_default_ ' type='normal' />
+                    <Setting name='BranchLength' avg=':= 0.813 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                    <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                    <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='SegmentLength' avg=':= _default_ * vnlaLapisLazuliSize ' range=':= _default_ * vnlaLapisLazuliSize ' type='normal' />
+                    <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='SegmentRadius' avg=':= 0.813 * _default_ * vnlaLapisLazuliSize ' range=':= 1 * _default_ * vnlaLapisLazuliSize ' type='normal' />
+                    <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                 </Veins>
                 <!-- "Preferred" configuration complete. -->
 
@@ -1228,10 +1228,10 @@
                     <IfCondition condition=':= ?blockExists("minecraft:lapis_ore")'> <OreBlock block='minecraft:lapis_ore' weight='1.0' /> </IfCondition>
                     <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                     <Biome name='.*'  />
-                    <Setting name='Size' avg=':= 6 * vnlaLapisLazuliSize ' range=':=  _default_ * vnlaLapisLazuliSize ' type='normal' />
-                    <Setting name='Frequency' avg=':= 1 * vnlaLapisLazuliFreq ' range=':=  _default_ * vnlaLapisLazuliFreq ' type='normal' scaleTo='base' />
-                    <Setting name='Height' avg=':= 19 ' range=':=  14 ' type='normal' scaleTo='base' />
-                    <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    <Setting name='Size' avg=':= 6 * vnlaLapisLazuliSize ' range=':= _default_ * vnlaLapisLazuliSize ' type='normal' />
+                    <Setting name='Frequency' avg=':= 1 * vnlaLapisLazuliFreq ' range=':= _default_ * vnlaLapisLazuliFreq ' type='normal' scaleTo='base' />
+                    <Setting name='Height' avg=':= 19 ' range=':= 14 ' type='normal' scaleTo='base' />
+                    <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                 </StandardGen>
             </IfCondition>
         </ConfigSection>
@@ -1257,16 +1257,16 @@
                     <IfCondition condition=':= ?blockExists("minecraft:lapis_ore")'> <OreBlock block='minecraft:lapis_ore' weight='1.0' /> </IfCondition>
                     <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                     <Biome name='.*'  />
-                    <Setting name='CloudRadius' avg=':= 0.761 * _default_ * vnlaLapisLazuliSize ' range=':=  _default_ * vnlaLapisLazuliSize ' type='normal' />
-                    <Setting name='CloudThickness' avg=':= 0.761 * _default_ * vnlaLapisLazuliSize ' range=':=  _default_ * vnlaLapisLazuliSize ' type='normal' scaleTo='base' />
-                    <Setting name='DistributionFrequency' avg=':= 0.579  * _default_ * vnlaLapisLazuliFreq ' range=':=  _default_ * vnlaLapisLazuliFreq ' type='normal' scaleTo='base' />
-                    <Setting name='CloudHeight' avg=':= 19 ' range=':=  14 ' type='normal' scaleTo='base' />
-                    <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                    <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    <Setting name='CloudRadius' avg=':= 0.761 * _default_ * vnlaLapisLazuliSize ' range=':= _default_ * vnlaLapisLazuliSize ' type='normal' />
+                    <Setting name='CloudThickness' avg=':= 0.761 * _default_ * vnlaLapisLazuliSize ' range=':= _default_ * vnlaLapisLazuliSize ' type='normal' scaleTo='base' />
+                    <Setting name='DistributionFrequency' avg=':= 0.579  * _default_ * vnlaLapisLazuliFreq ' range=':= _default_ * vnlaLapisLazuliFreq ' type='normal' scaleTo='base' />
+                    <Setting name='CloudHeight' avg=':= 19 ' range=':= 14 ' type='normal' scaleTo='base' />
+                    <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                    <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Veins name='vnlaLapisLazuliHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x601442BA' drawBoundBox='false' boundBoxColor='0x601442BA'>
                         <Description>
                             Single blocks, generously scattered
@@ -1300,16 +1300,16 @@
                     <IfCondition condition=':= ?blockExists("minecraft:lapis_ore")'> <OreBlock block='minecraft:lapis_ore' weight='1.0' /> </IfCondition>
                     <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                     <BiomeType name='Ocean'  />
-                    <Setting name='CloudRadius' avg=':= 0.761 * _default_ * vnlaLapisLazuliSize ' range=':=  _default_ * vnlaLapisLazuliSize ' type='normal' />
-                    <Setting name='CloudThickness' avg=':= 0.761 * _default_ * vnlaLapisLazuliSize ' range=':=  _default_ * vnlaLapisLazuliSize ' type='normal' scaleTo='base' />
-                    <Setting name='DistributionFrequency' avg=':= 0.579  * _default_ * vnlaLapisLazuliFreq ' range=':=  _default_ * vnlaLapisLazuliFreq ' type='normal' scaleTo='base' />
-                    <Setting name='CloudHeight' avg=':= 19 ' range=':=  14 ' type='normal' scaleTo='base' />
-                    <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                    <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    <Setting name='CloudRadius' avg=':= 0.761 * _default_ * vnlaLapisLazuliSize ' range=':= _default_ * vnlaLapisLazuliSize ' type='normal' />
+                    <Setting name='CloudThickness' avg=':= 0.761 * _default_ * vnlaLapisLazuliSize ' range=':= _default_ * vnlaLapisLazuliSize ' type='normal' scaleTo='base' />
+                    <Setting name='DistributionFrequency' avg=':= 0.579  * _default_ * vnlaLapisLazuliFreq ' range=':= _default_ * vnlaLapisLazuliFreq ' type='normal' scaleTo='base' />
+                    <Setting name='CloudHeight' avg=':= 19 ' range=':= 14 ' type='normal' scaleTo='base' />
+                    <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                    <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Veins name='vnlaLapisLazuliPreferredHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x601442BA' drawBoundBox='false' boundBoxColor='0x601442BA'>
                         <Description>
                             Ore generation is doubled in  preferred
@@ -1342,21 +1342,21 @@
                     <IfCondition condition=':= ?blockExists("minecraft:emerald_ore")'> <OreBlock block='minecraft:emerald_ore' weight='1.0' /> </IfCondition>
                     <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                     <BiomeType name='Mountain'  />
-                    <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * vnlaEmeraldFreq ' range=':=  1 * _default_ * vnlaEmeraldFreq ' type='normal' scaleTo='base' />
-                    <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * vnlaEmeraldSize ' range=':=  1 * _default_ * vnlaEmeraldSize ' type='normal' />
-                    <Setting name='MotherlodeHeight' avg=':= 37 ' range=':=  14 ' type='normal' scaleTo='base' />
-                    <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                    <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                    <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='SegmentLength' avg=':= _default_ * vnlaEmeraldSize ' range=':=  _default_ * vnlaEmeraldSize ' type='normal' />
-                    <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * vnlaEmeraldSize ' range=':=  1 * _default_ * vnlaEmeraldSize ' type='normal' />
-                    <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * vnlaEmeraldFreq ' range=':= 1 * _default_ * vnlaEmeraldFreq ' type='normal' scaleTo='base' />
+                    <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * vnlaEmeraldSize ' range=':= 1 * _default_ * vnlaEmeraldSize ' type='normal' />
+                    <Setting name='MotherlodeHeight' avg=':= 37 ' range=':= 14 ' type='normal' scaleTo='base' />
+                    <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                    <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                    <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='SegmentLength' avg=':= _default_ * vnlaEmeraldSize ' range=':= _default_ * vnlaEmeraldSize ' type='normal' />
+                    <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * vnlaEmeraldSize ' range=':= 1 * _default_ * vnlaEmeraldSize ' type='normal' />
+                    <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                 </Veins>
 
                 <!-- Configuring contained material. -->
@@ -1364,8 +1364,8 @@
                     <IfCondition condition=':= ?blockExists("minecraft:monster_egg")'> <OreBlock block='minecraft:monster_egg' weight='1.0' /> </IfCondition>
                     <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                     <IfCondition condition=':= ?blockExists("minecraft:emerald_ore")'> <Replaces block='minecraft:emerald_ore' weight='1.0' /> </IfCondition>
-                    <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * vnlaEmeraldSize  * 0.5 ' range=':=  1 * _default_ * vnlaEmeraldSize  * 0.5 ' type='normal' />
-                    <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * vnlaEmeraldSize  * 0.5 ' range=':=  1 * _default_ * vnlaEmeraldSize  * 0.5 ' type='normal' />
+                    <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * vnlaEmeraldSize  * 0.5 ' range=':= 1 * _default_ * vnlaEmeraldSize  * 0.5 ' type='normal' />
+                    <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * vnlaEmeraldSize  * 0.5 ' range=':= 1 * _default_ * vnlaEmeraldSize  * 0.5 ' type='normal' />
                     <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
                 </Veins>
             </IfCondition>
@@ -1384,10 +1384,10 @@
                     <IfCondition condition=':= ?blockExists("minecraft:emerald_ore")'> <OreBlock block='minecraft:emerald_ore' weight='1.0' /> </IfCondition>
                     <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                     <BiomeType name='Mountain'  />
-                    <Setting name='Size' avg=':= 1 * vnlaEmeraldSize ' range=':=  _default_ * vnlaEmeraldSize ' type='normal' />
-                    <Setting name='Frequency' avg=':= 1 * vnlaEmeraldFreq ' range=':=  _default_ * vnlaEmeraldFreq ' type='normal' scaleTo='base' />
-                    <Setting name='Height' avg=':= 37 ' range=':=  14 ' type='normal' scaleTo='base' />
-                    <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    <Setting name='Size' avg=':= 1 * vnlaEmeraldSize ' range=':= _default_ * vnlaEmeraldSize ' type='normal' />
+                    <Setting name='Frequency' avg=':= 1 * vnlaEmeraldFreq ' range=':= _default_ * vnlaEmeraldFreq ' type='normal' scaleTo='base' />
+                    <Setting name='Height' avg=':= 37 ' range=':= 14 ' type='normal' scaleTo='base' />
+                    <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                 </StandardGen>
             </IfCondition>
         </ConfigSection>
@@ -1413,16 +1413,16 @@
                     <IfCondition condition=':= ?blockExists("minecraft:emerald_ore")'> <OreBlock block='minecraft:emerald_ore' weight='1.0' /> </IfCondition>
                     <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                     <BiomeType name='Mountain'  />
-                    <Setting name='CloudRadius' avg=':= 0.486 * _default_ * vnlaEmeraldSize ' range=':=  _default_ * vnlaEmeraldSize ' type='normal' />
-                    <Setting name='CloudThickness' avg=':= 0.486 * _default_ * vnlaEmeraldSize ' range=':=  _default_ * vnlaEmeraldSize ' type='normal' scaleTo='base' />
-                    <Setting name='DistributionFrequency' avg=':= 0.236  * _default_ * vnlaEmeraldFreq ' range=':=  _default_ * vnlaEmeraldFreq ' type='normal' scaleTo='base' />
-                    <Setting name='CloudHeight' avg=':= 37 ' range=':=  14 ' type='normal' scaleTo='base' />
-                    <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                    <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    <Setting name='CloudRadius' avg=':= 0.486 * _default_ * vnlaEmeraldSize ' range=':= _default_ * vnlaEmeraldSize ' type='normal' />
+                    <Setting name='CloudThickness' avg=':= 0.486 * _default_ * vnlaEmeraldSize ' range=':= _default_ * vnlaEmeraldSize ' type='normal' scaleTo='base' />
+                    <Setting name='DistributionFrequency' avg=':= 0.236  * _default_ * vnlaEmeraldFreq ' range=':= _default_ * vnlaEmeraldFreq ' type='normal' scaleTo='base' />
+                    <Setting name='CloudHeight' avg=':= 37 ' range=':= 14 ' type='normal' scaleTo='base' />
+                    <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                    <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Veins name='vnlaEmeraldHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x606CE391' drawBoundBox='false' boundBoxColor='0x606CE391'>
                         <Description>
                             Single blocks, generously scattered
@@ -1497,21 +1497,21 @@
                     <IfCondition condition=':= ?blockExists("minecraft:quartz_ore")'> <OreBlock block='minecraft:quartz_ore' weight='1.0' /> </IfCondition>
                     <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
                     <Biome name='.*'  />
-                    <Setting name='MotherlodeFrequency' avg=':= 5.049 * _default_ * vnlaNetherQuartzFreq ' range=':=  1 * _default_ * vnlaNetherQuartzFreq ' type='normal' scaleTo='base' />
-                    <Setting name='MotherlodeSize' avg=':= 1.716 * _default_ * vnlaNetherQuartzSize ' range=':=  1 * _default_ * vnlaNetherQuartzSize ' type='normal' />
-                    <Setting name='MotherlodeHeight' avg=':= 68 ' range=':=  52 ' type='uniform' scaleTo='base' />
-                    <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='BranchFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='BranchInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='BranchLength' avg=':= 1.716 * _default_ ' range=':=  1 * _default_ ' type='normal' />
-                    <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                    <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='SegmentLength' avg=':= _default_ * vnlaNetherQuartzSize ' range=':=  _default_ * vnlaNetherQuartzSize ' type='normal' />
-                    <Setting name='SegmentAngle' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='SegmentRadius' avg=':= 1.716 * _default_ * vnlaNetherQuartzSize ' range=':=  1 * _default_ * vnlaNetherQuartzSize ' type='normal' />
-                    <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    <Setting name='MotherlodeFrequency' avg=':= 5.049 * _default_ * vnlaNetherQuartzFreq ' range=':= 1 * _default_ * vnlaNetherQuartzFreq ' type='normal' scaleTo='base' />
+                    <Setting name='MotherlodeSize' avg=':= 1.716 * _default_ * vnlaNetherQuartzSize ' range=':= 1 * _default_ * vnlaNetherQuartzSize ' type='normal' />
+                    <Setting name='MotherlodeHeight' avg=':= 68 ' range=':= 52 ' type='uniform' scaleTo='base' />
+                    <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='BranchLength' avg=':= 1.716 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                    <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                    <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='SegmentLength' avg=':= _default_ * vnlaNetherQuartzSize ' range=':= _default_ * vnlaNetherQuartzSize ' type='normal' />
+                    <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='SegmentRadius' avg=':= 1.716 * _default_ * vnlaNetherQuartzSize ' range=':= 1 * _default_ * vnlaNetherQuartzSize ' type='normal' />
+                    <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                 </Veins>
             </IfCondition>
         </ConfigSection>
@@ -1529,10 +1529,10 @@
                     <IfCondition condition=':= ?blockExists("minecraft:quartz_ore")'> <OreBlock block='minecraft:quartz_ore' weight='1.0' /> </IfCondition>
                     <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
                     <Biome name='.*'  />
-                    <Setting name='Size' avg=':= 13 * vnlaNetherQuartzSize ' range=':=  _default_ * vnlaNetherQuartzSize ' type='normal' />
-                    <Setting name='Frequency' avg=':= 16 * vnlaNetherQuartzFreq ' range=':=  _default_ * vnlaNetherQuartzFreq ' type='normal' scaleTo='base' />
-                    <Setting name='Height' avg=':= 68 ' range=':=  52 ' type='uniform' scaleTo='base' />
-                    <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    <Setting name='Size' avg=':= 13 * vnlaNetherQuartzSize ' range=':= _default_ * vnlaNetherQuartzSize ' type='normal' />
+                    <Setting name='Frequency' avg=':= 16 * vnlaNetherQuartzFreq ' range=':= _default_ * vnlaNetherQuartzFreq ' type='normal' scaleTo='base' />
+                    <Setting name='Height' avg=':= 68 ' range=':= 52 ' type='uniform' scaleTo='base' />
+                    <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                 </StandardGen>
             </IfCondition>
         </ConfigSection>
@@ -1558,16 +1558,16 @@
                     <IfCondition condition=':= ?blockExists("minecraft:quartz_ore")'> <OreBlock block='minecraft:quartz_ore' weight='1.0' /> </IfCondition>
                     <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
                     <Biome name='.*'  />
-                    <Setting name='CloudRadius' avg=':= 1.847 * _default_ * vnlaNetherQuartzSize ' range=':=  _default_ * vnlaNetherQuartzSize ' type='normal' />
-                    <Setting name='CloudThickness' avg=':= 1.847 * _default_ * vnlaNetherQuartzSize ' range=':=  _default_ * vnlaNetherQuartzSize ' type='normal' scaleTo='base' />
-                    <Setting name='DistributionFrequency' avg=':= 3.411  * _default_ * vnlaNetherQuartzFreq ' range=':=  _default_ * vnlaNetherQuartzFreq ' type='normal' scaleTo='base' />
-                    <Setting name='CloudHeight' avg=':= 68 ' range=':=  52 ' type='uniform' scaleTo='base' />
-                    <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='CloudInclination' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='OreDensity' avg=':= _default_ ' range=':=  _default_ ' type='normal' scaleTo='base' />
-                    <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
-                    <Setting name='OreRadiusMult' avg=':= _default_ ' range=':=  _default_ ' type='normal' />
+                    <Setting name='CloudRadius' avg=':= 1.847 * _default_ * vnlaNetherQuartzSize ' range=':= _default_ * vnlaNetherQuartzSize ' type='normal' />
+                    <Setting name='CloudThickness' avg=':= 1.847 * _default_ * vnlaNetherQuartzSize ' range=':= _default_ * vnlaNetherQuartzSize ' type='normal' scaleTo='base' />
+                    <Setting name='DistributionFrequency' avg=':= 3.411  * _default_ * vnlaNetherQuartzFreq ' range=':= _default_ * vnlaNetherQuartzFreq ' type='normal' scaleTo='base' />
+                    <Setting name='CloudHeight' avg=':= 68 ' range=':= 52 ' type='uniform' scaleTo='base' />
+                    <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                    <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                    <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Veins name='vnlaNetherQuartzHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60DBCCBF' drawBoundBox='false' boundBoxColor='0x60DBCCBF'>
                         <Description>
                             Single blocks, generously scattered


### PR DESCRIPTION
The following changes:
* Geodes would break down if scaled too large; this is the result of the way the inner-ore and bubble deposits were scaling with the shell stone (they were scaling faster).  FIXED.
* Geodes had way too much ores.  Nerfed a little; now there's an average of 1-3 ores per geode (with a preference for Lapis)
* The random number seeds were apparently shared between all ores in some of the new distributions.  New static seed numbers were assigned.
* Originally, all spaces were stripped from options.  This resulted in problems with two-word biome names (like 'Deep Ocean').  The spaces stopped being stripped, but it was quickly discovered that those same strings now had an extra leding space (like ' Deep Ocean'), for the same result.  This time, the leading spaces were stripped without affecting the rest of the string; as a result, two-word biome names, as well as calculations (_default_ * 6) are no longer broken.