### PR TITLE
Square-Cube Compliance

### DIFF
--- a/src/main/resources/config/modules/AppliedEnergistics.xml
+++ b/src/main/resources/config/modules/AppliedEnergistics.xml
@@ -123,18 +123,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.712 * _default_ * apenCertusQuartzFreq ' range=':= 1 * _default_ * apenCertusQuartzFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.394 * _default_ * apenCertusQuartzSize ' range=':= 1 * _default_ * apenCertusQuartzSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * _default_ * apenCertusQuartzSize ' range=':= 1 * _default_ * apenCertusQuartzSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 43 ' range=':= 26 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.394 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.647 * _default_ ' range=':= 1 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * apenCertusQuartzSize ' range=':= _default_ * apenCertusQuartzSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.394 * _default_ * apenCertusQuartzSize ' range=':= 1 * _default_ * apenCertusQuartzSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.283 * _default_ * apenCertusQuartzSize ' range=':= 1 * _default_ * apenCertusQuartzSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>

--- a/src/main/resources/config/modules/ArsMagica2.xml
+++ b/src/main/resources/config/modules/ArsMagica2.xml
@@ -187,18 +187,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.213 * _default_ * arsmVinteumFreq ' range=':= _default_ * arsmVinteumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.066 * _default_ * arsmVinteumSize ' range=':= _default_ * arsmVinteumSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * _default_ * arsmVinteumSize ' range=':= _default_ * arsmVinteumSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 22 ' range=':= 17 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.066 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.101 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * arsmVinteumSize ' range=':= _default_ * arsmVinteumSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.066 * _default_ * arsmVinteumSize ' range=':= _default_ * arsmVinteumSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.049 * _default_ * arsmVinteumSize ' range=':= _default_ * arsmVinteumSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -313,18 +313,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.485 * _default_ * arsmChimeriteFreq ' range=':= _default_ * arsmChimeriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.141 * _default_ * arsmChimeriteSize ' range=':= _default_ * arsmChimeriteSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * _default_ * arsmChimeriteSize ' range=':= _default_ * arsmChimeriteSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 40 ' range=':= 20 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.141 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.219 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * arsmChimeriteSize ' range=':= _default_ * arsmChimeriteSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.141 * _default_ * arsmChimeriteSize ' range=':= _default_ * arsmChimeriteSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.104 * _default_ * arsmChimeriteSize ' range=':= _default_ * arsmChimeriteSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -439,18 +439,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.485 * _default_ * arsmBlueTopazFreq ' range=':= _default_ * arsmBlueTopazFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.141 * _default_ * arsmBlueTopazSize ' range=':= _default_ * arsmBlueTopazSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * _default_ * arsmBlueTopazSize ' range=':= _default_ * arsmBlueTopazSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 20 ' range=':= 108 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.141 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.219 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * arsmBlueTopazSize ' range=':= _default_ * arsmBlueTopazSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.141 * _default_ * arsmBlueTopazSize ' range=':= _default_ * arsmBlueTopazSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.104 * _default_ * arsmBlueTopazSize ' range=':= _default_ * arsmBlueTopazSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>

--- a/src/main/resources/config/modules/BiomesOPlenty.xml
+++ b/src/main/resources/config/modules/BiomesOPlenty.xml
@@ -355,18 +355,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <BiomeType name='Desert'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * boplRubyFreq ' range=':= _default_ * boplRubyFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplRubySize ' range=':= _default_ * boplRubySize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * _default_ * boplRubySize ' range=':= _default_ * boplRubySize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.371 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * boplRubySize ' range=':= _default_ * boplRubySize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplRubySize ' range=':= _default_ * boplRubySize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.609 * _default_ * boplRubySize ' range=':= _default_ * boplRubySize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -376,8 +376,8 @@
                             <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:2")'> <Replaces block='BiomesOPlenty:gemOre:2' weight='1.0' /> </IfCondition>
-                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplRubySize  * 0.5 ' range=':= _default_ * boplRubySize  * 0.5 ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplRubySize  * 0.5 ' range=':= _default_ * boplRubySize  * 0.5 ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * _default_ * boplRubySize  * 0.5 ' range=':= _default_ * boplRubySize  * 0.5 ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.609 * _default_ * boplRubySize  * 0.5 ' range=':= _default_ * boplRubySize  * 0.5 ' type='normal' />
                             <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
                         </Veins>
                     </IfCondition>
@@ -484,18 +484,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <BiomeType name='Plains'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * boplPeridotFreq ' range=':= _default_ * boplPeridotFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplPeridotSize ' range=':= _default_ * boplPeridotSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * _default_ * boplPeridotSize ' range=':= _default_ * boplPeridotSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.371 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * boplPeridotSize ' range=':= _default_ * boplPeridotSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplPeridotSize ' range=':= _default_ * boplPeridotSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.609 * _default_ * boplPeridotSize ' range=':= _default_ * boplPeridotSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -505,8 +505,8 @@
                             <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:4")'> <Replaces block='BiomesOPlenty:gemOre:4' weight='1.0' /> </IfCondition>
-                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplPeridotSize  * 0.5 ' range=':= _default_ * boplPeridotSize  * 0.5 ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplPeridotSize  * 0.5 ' range=':= _default_ * boplPeridotSize  * 0.5 ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * _default_ * boplPeridotSize  * 0.5 ' range=':= _default_ * boplPeridotSize  * 0.5 ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.609 * _default_ * boplPeridotSize  * 0.5 ' range=':= _default_ * boplPeridotSize  * 0.5 ' type='normal' />
                             <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
                         </Veins>
                     </IfCondition>
@@ -613,18 +613,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <BiomeType name='Jungle'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * boplTopazFreq ' range=':= _default_ * boplTopazFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplTopazSize ' range=':= _default_ * boplTopazSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * _default_ * boplTopazSize ' range=':= _default_ * boplTopazSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.371 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * boplTopazSize ' range=':= _default_ * boplTopazSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplTopazSize ' range=':= _default_ * boplTopazSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.609 * _default_ * boplTopazSize ' range=':= _default_ * boplTopazSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -634,8 +634,8 @@
                             <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:6")'> <Replaces block='BiomesOPlenty:gemOre:6' weight='1.0' /> </IfCondition>
-                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplTopazSize  * 0.5 ' range=':= _default_ * boplTopazSize  * 0.5 ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplTopazSize  * 0.5 ' range=':= _default_ * boplTopazSize  * 0.5 ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * _default_ * boplTopazSize  * 0.5 ' range=':= _default_ * boplTopazSize  * 0.5 ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.609 * _default_ * boplTopazSize  * 0.5 ' range=':= _default_ * boplTopazSize  * 0.5 ' type='normal' />
                             <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
                         </Veins>
                     </IfCondition>
@@ -744,18 +744,18 @@
                             <Biome name='Alps'  weight='-1' />
                             <Biome name='Alps Forest'  weight='-1' />
                             <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * boplTanzaniteFreq ' range=':= _default_ * boplTanzaniteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplTanzaniteSize ' range=':= _default_ * boplTanzaniteSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * _default_ * boplTanzaniteSize ' range=':= _default_ * boplTanzaniteSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.371 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * boplTanzaniteSize ' range=':= _default_ * boplTanzaniteSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplTanzaniteSize ' range=':= _default_ * boplTanzaniteSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.609 * _default_ * boplTanzaniteSize ' range=':= _default_ * boplTanzaniteSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -765,8 +765,8 @@
                             <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:8")'> <Replaces block='BiomesOPlenty:gemOre:8' weight='1.0' /> </IfCondition>
-                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplTanzaniteSize  * 0.5 ' range=':= _default_ * boplTanzaniteSize  * 0.5 ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplTanzaniteSize  * 0.5 ' range=':= _default_ * boplTanzaniteSize  * 0.5 ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * _default_ * boplTanzaniteSize  * 0.5 ' range=':= _default_ * boplTanzaniteSize  * 0.5 ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.609 * _default_ * boplTanzaniteSize  * 0.5 ' range=':= _default_ * boplTanzaniteSize  * 0.5 ' type='normal' />
                             <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
                         </Veins>
                     </IfCondition>
@@ -877,18 +877,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <BiomeType name='Swamp'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * boplMalachiteFreq ' range=':= _default_ * boplMalachiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplMalachiteSize ' range=':= _default_ * boplMalachiteSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * _default_ * boplMalachiteSize ' range=':= _default_ * boplMalachiteSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.371 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * boplMalachiteSize ' range=':= _default_ * boplMalachiteSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplMalachiteSize ' range=':= _default_ * boplMalachiteSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.609 * _default_ * boplMalachiteSize ' range=':= _default_ * boplMalachiteSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -898,8 +898,8 @@
                             <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:10")'> <Replaces block='BiomesOPlenty:gemOre:10' weight='1.0' /> </IfCondition>
-                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplMalachiteSize  * 0.5 ' range=':= _default_ * boplMalachiteSize  * 0.5 ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplMalachiteSize  * 0.5 ' range=':= _default_ * boplMalachiteSize  * 0.5 ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * _default_ * boplMalachiteSize  * 0.5 ' range=':= _default_ * boplMalachiteSize  * 0.5 ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.609 * _default_ * boplMalachiteSize  * 0.5 ' range=':= _default_ * boplMalachiteSize  * 0.5 ' type='normal' />
                             <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
                         </Veins>
                     </IfCondition>
@@ -1012,18 +1012,18 @@
                             <Biome name='Sacred Springs'  />
                             <Biome name='Tropics'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * boplSapphireFreq ' range=':= _default_ * boplSapphireFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplSapphireSize ' range=':= _default_ * boplSapphireSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * _default_ * boplSapphireSize ' range=':= _default_ * boplSapphireSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.371 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * boplSapphireSize ' range=':= _default_ * boplSapphireSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplSapphireSize ' range=':= _default_ * boplSapphireSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.609 * _default_ * boplSapphireSize ' range=':= _default_ * boplSapphireSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1033,8 +1033,8 @@
                             <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:12")'> <Replaces block='BiomesOPlenty:gemOre:12' weight='1.0' /> </IfCondition>
-                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplSapphireSize  * 0.5 ' range=':= _default_ * boplSapphireSize  * 0.5 ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplSapphireSize  * 0.5 ' range=':= _default_ * boplSapphireSize  * 0.5 ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * _default_ * boplSapphireSize  * 0.5 ' range=':= _default_ * boplSapphireSize  * 0.5 ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.609 * _default_ * boplSapphireSize  * 0.5 ' range=':= _default_ * boplSapphireSize  * 0.5 ' type='normal' />
                             <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
                         </Veins>
                     </IfCondition>
@@ -1156,18 +1156,18 @@
                             <Biome name='Shield'  />
                             <Biome name='Thicket'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * boplAmberFreq ' range=':= _default_ * boplAmberFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplAmberSize ' range=':= _default_ * boplAmberSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * _default_ * boplAmberSize ' range=':= _default_ * boplAmberSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.371 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * boplAmberSize ' range=':= _default_ * boplAmberSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplAmberSize ' range=':= _default_ * boplAmberSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.609 * _default_ * boplAmberSize ' range=':= _default_ * boplAmberSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1177,8 +1177,8 @@
                             <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:14")'> <Replaces block='BiomesOPlenty:gemOre:14' weight='1.0' /> </IfCondition>
-                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplAmberSize  * 0.5 ' range=':= _default_ * boplAmberSize  * 0.5 ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplAmberSize  * 0.5 ' range=':= _default_ * boplAmberSize  * 0.5 ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * _default_ * boplAmberSize  * 0.5 ' range=':= _default_ * boplAmberSize  * 0.5 ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.609 * _default_ * boplAmberSize  * 0.5 ' range=':= _default_ * boplAmberSize  * 0.5 ' type='normal' />
                             <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
                         </Veins>
                     </IfCondition>
@@ -1324,18 +1324,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * boplEnderAmathystFreq ' range=':= _default_ * boplEnderAmathystFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplEnderAmathystSize ' range=':= _default_ * boplEnderAmathystSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * _default_ * boplEnderAmathystSize ' range=':= _default_ * boplEnderAmathystSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.371 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * boplEnderAmathystSize ' range=':= _default_ * boplEnderAmathystSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplEnderAmathystSize ' range=':= _default_ * boplEnderAmathystSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.609 * _default_ * boplEnderAmathystSize ' range=':= _default_ * boplEnderAmathystSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1345,8 +1345,8 @@
                             <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre")'> <Replaces block='BiomesOPlenty:gemOre' weight='1.0' /> </IfCondition>
-                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * boplEnderAmathystSize  * 0.5 ' range=':= _default_ * boplEnderAmathystSize  * 0.5 ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * boplEnderAmathystSize  * 0.5 ' range=':= _default_ * boplEnderAmathystSize  * 0.5 ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * _default_ * boplEnderAmathystSize  * 0.5 ' range=':= _default_ * boplEnderAmathystSize  * 0.5 ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.609 * _default_ * boplEnderAmathystSize  * 0.5 ' range=':= _default_ * boplEnderAmathystSize  * 0.5 ' type='normal' />
                             <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
                         </Veins>
                     </IfCondition>

--- a/src/main/resources/config/modules/Chisel2.xml
+++ b/src/main/resources/config/modules/Chisel2.xml
@@ -227,18 +227,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.340 * _default_ * chslAndesiteFreq ' range=':= 1 * _default_ * chslAndesiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.102 * _default_ * chslAndesiteSize ' range=':= 1 * _default_ * chslAndesiteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 43 ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.050 * _default_ * chslAndesiteSize ' range=':= 1 * _default_ * chslAndesiteSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.102 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.158 * _default_ ' range=':= 1 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * chslAndesiteSize ' range=':= _default_ * chslAndesiteSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.102 * _default_ * chslAndesiteSize ' range=':= 1 * _default_ * chslAndesiteSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.076 * _default_ * chslAndesiteSize ' range=':= 1 * _default_ * chslAndesiteSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -271,7 +271,7 @@
                             <Setting name='CloudRadius' avg=':= 1.636 * _default_ * chslAndesiteSize ' range=':= _default_ * chslAndesiteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.636 * _default_ * chslAndesiteSize ' range=':= _default_ * chslAndesiteSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 2.676  * _default_ * chslAndesiteFreq ' range=':= _default_ * chslAndesiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 43 ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -325,18 +325,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.340 * _default_ * chslDioriteFreq ' range=':= 1 * _default_ * chslDioriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.102 * _default_ * chslDioriteSize ' range=':= 1 * _default_ * chslDioriteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 61 ' range=':= 67 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.050 * _default_ * chslDioriteSize ' range=':= 1 * _default_ * chslDioriteSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.102 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.158 * _default_ ' range=':= 1 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * chslDioriteSize ' range=':= _default_ * chslDioriteSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.102 * _default_ * chslDioriteSize ' range=':= 1 * _default_ * chslDioriteSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.076 * _default_ * chslDioriteSize ' range=':= 1 * _default_ * chslDioriteSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -369,7 +369,7 @@
                             <Setting name='CloudRadius' avg=':= 1.636 * _default_ * chslDioriteSize ' range=':= _default_ * chslDioriteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.636 * _default_ * chslDioriteSize ' range=':= _default_ * chslDioriteSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 2.676  * _default_ * chslDioriteFreq ' range=':= _default_ * chslDioriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 61 ' range=':= 67 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -423,18 +423,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.340 * _default_ * chslGraniteFreq ' range=':= 1 * _default_ * chslGraniteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.102 * _default_ * chslGraniteSize ' range=':= 1 * _default_ * chslGraniteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 61 ' range=':= 67 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.050 * _default_ * chslGraniteSize ' range=':= 1 * _default_ * chslGraniteSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.102 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.158 * _default_ ' range=':= 1 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * chslGraniteSize ' range=':= _default_ * chslGraniteSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.102 * _default_ * chslGraniteSize ' range=':= 1 * _default_ * chslGraniteSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.076 * _default_ * chslGraniteSize ' range=':= 1 * _default_ * chslGraniteSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -467,7 +467,7 @@
                             <Setting name='CloudRadius' avg=':= 1.636 * _default_ * chslGraniteSize ' range=':= _default_ * chslGraniteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.636 * _default_ * chslGraniteSize ' range=':= _default_ * chslGraniteSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 2.676  * _default_ * chslGraniteFreq ' range=':= _default_ * chslGraniteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 61 ' range=':= 67 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -521,18 +521,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.571 * _default_ * chslLimestoneFreq ' range=':= 1 * _default_ * chslLimestoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.163 * _default_ * chslLimestoneSize ' range=':= 1 * _default_ * chslLimestoneSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 61 ' range=':= 67 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.078 * _default_ * chslLimestoneSize ' range=':= 1 * _default_ * chslLimestoneSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.163 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.254 * _default_ ' range=':= 1 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * chslLimestoneSize ' range=':= _default_ * chslLimestoneSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.163 * _default_ * chslLimestoneSize ' range=':= 1 * _default_ * chslLimestoneSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.120 * _default_ * chslLimestoneSize ' range=':= 1 * _default_ * chslLimestoneSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -565,7 +565,7 @@
                             <Setting name='CloudRadius' avg=':= 1.771 * _default_ * chslLimestoneSize ' range=':= _default_ * chslLimestoneSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.771 * _default_ * chslLimestoneSize ' range=':= _default_ * chslLimestoneSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 3.137  * _default_ * chslLimestoneFreq ' range=':= _default_ * chslLimestoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 61 ' range=':= 67 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -619,18 +619,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.470 * _default_ * chslMarbleFreq ' range=':= 1 * _default_ * chslMarbleFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.137 * _default_ * chslMarbleSize ' range=':= 1 * _default_ * chslMarbleSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 61 ' range=':= 67 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.066 * _default_ * chslMarbleSize ' range=':= 1 * _default_ * chslMarbleSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.137 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.212 * _default_ ' range=':= 1 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * chslMarbleSize ' range=':= _default_ * chslMarbleSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.137 * _default_ * chslMarbleSize ' range=':= 1 * _default_ * chslMarbleSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.101 * _default_ * chslMarbleSize ' range=':= 1 * _default_ * chslMarbleSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -663,7 +663,7 @@
                             <Setting name='CloudRadius' avg=':= 1.713 * _default_ * chslMarbleSize ' range=':= _default_ * chslMarbleSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.713 * _default_ * chslMarbleSize ' range=':= _default_ * chslMarbleSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 2.935  * _default_ * chslMarbleFreq ' range=':= _default_ * chslMarbleFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 61 ' range=':= 67 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />

--- a/src/main/resources/config/modules/DenseOres.xml
+++ b/src/main/resources/config/modules/DenseOres.xml
@@ -368,18 +368,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.498 * _default_ * dnsoIronFreq ' range=':= 1 * _default_ * dnsoIronFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.144 * _default_ * dnsoIronSize ' range=':= 1 * _default_ * dnsoIronSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 1.070 * _default_ * dnsoIronSize ' range=':= 1 * _default_ * dnsoIronSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 36 ' range=':= 31 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.144 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.224 * _default_ ' range=':= 1 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * dnsoIronSize ' range=':= _default_ * dnsoIronSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.144 * _default_ * dnsoIronSize ' range=':= 1 * _default_ * dnsoIronSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.106 * _default_ * dnsoIronSize ' range=':= 1 * _default_ * dnsoIronSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -491,18 +491,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.474 * _default_ * dnsoGoldFreq ' range=':= 1 * _default_ * dnsoGoldFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.780 * _default_ * dnsoGoldSize ' range=':= 1 * _default_ * dnsoGoldSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.883 * _default_ * dnsoGoldSize ' range=':= 1 * _default_ * dnsoGoldSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 17 ' range=':= 12 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.780 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.688 * _default_ ' range=':= 1 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * dnsoGoldSize ' range=':= _default_ * dnsoGoldSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.780 * _default_ * dnsoGoldSize ' range=':= 1 * _default_ * dnsoGoldSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.830 * _default_ * dnsoGoldSize ' range=':= 1 * _default_ * dnsoGoldSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -614,18 +614,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.538 * _default_ * dnsoLapisFreq ' range=':= 1 * _default_ * dnsoLapisFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.813 * _default_ * dnsoLapisSize ' range=':= 1 * _default_ * dnsoLapisSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * _default_ * dnsoLapisSize ' range=':= 1 * _default_ * dnsoLapisSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 19 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= -_default_ ' range=':= -_default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.813 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.733 * _default_ ' range=':= 1 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * dnsoLapisSize ' range=':= _default_ * dnsoLapisSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.813 * _default_ * dnsoLapisSize ' range=':= 1 * _default_ * dnsoLapisSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.856 * _default_ * dnsoLapisSize ' range=':= 1 * _default_ * dnsoLapisSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -641,18 +641,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <BiomeType name='Ocean'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.538 * _default_ * dnsoLapisFreq ' range=':= 1 * _default_ * dnsoLapisFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.813 * _default_ * dnsoLapisSize ' range=':= 1 * _default_ * dnsoLapisSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * _default_ * dnsoLapisSize ' range=':= 1 * _default_ * dnsoLapisSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 19 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= -_default_ ' range=':= -_default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.813 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.733 * _default_ ' range=':= 1 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * dnsoLapisSize ' range=':= _default_ * dnsoLapisSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.813 * _default_ * dnsoLapisSize ' range=':= 1 * _default_ * dnsoLapisSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.856 * _default_ * dnsoLapisSize ' range=':= 1 * _default_ * dnsoLapisSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -800,18 +800,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.365 * _default_ * dnsoDiamondFreq ' range=':= 1 * _default_ * dnsoDiamondFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.715 * _default_ * dnsoDiamondSize ' range=':= 1 * _default_ * dnsoDiamondSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * _default_ * dnsoDiamondSize ' range=':= 1 * _default_ * dnsoDiamondSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 10 ' range=':= 5 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.715 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.604 * _default_ ' range=':= 1 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * dnsoDiamondSize ' range=':= _default_ * dnsoDiamondSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.715 * _default_ * dnsoDiamondSize ' range=':= 1 * _default_ * dnsoDiamondSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.777 * _default_ * dnsoDiamondSize ' range=':= 1 * _default_ * dnsoDiamondSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -822,8 +822,8 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:diamond_ore")'> <Replaces block='minecraft:diamond_ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("denseores:block0:3")'> <Replaces block='denseores:block0:3' weight='1.0' /> </IfCondition>
-                            <Setting name='MotherlodeSize' avg=':= 0.715 * _default_ * dnsoDiamondSize  * 0.5 ' range=':= 1 * _default_ * dnsoDiamondSize  * 0.5 ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.715 * _default_ * dnsoDiamondSize  * 0.5 ' range=':= 1 * _default_ * dnsoDiamondSize  * 0.5 ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * _default_ * dnsoDiamondSize  * 0.5 ' range=':= 1 * _default_ * dnsoDiamondSize  * 0.5 ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.777 * _default_ * dnsoDiamondSize  * 0.5 ' range=':= 1 * _default_ * dnsoDiamondSize  * 0.5 ' type='normal' />
                             <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
                         </Veins>
                     </IfCondition>
@@ -934,18 +934,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <BiomeType name='Mountain'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * dnsoEmeraldFreq ' range=':= 1 * _default_ * dnsoEmeraldFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * dnsoEmeraldSize ' range=':= 1 * _default_ * dnsoEmeraldSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * _default_ * dnsoEmeraldSize ' range=':= 1 * _default_ * dnsoEmeraldSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 37 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.371 * _default_ ' range=':= 1 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * dnsoEmeraldSize ' range=':= _default_ * dnsoEmeraldSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * dnsoEmeraldSize ' range=':= 1 * _default_ * dnsoEmeraldSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.609 * _default_ * dnsoEmeraldSize ' range=':= 1 * _default_ * dnsoEmeraldSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -956,8 +956,8 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:emerald_ore")'> <Replaces block='minecraft:emerald_ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("denseores:block0:4")'> <Replaces block='denseores:block0:4' weight='1.0' /> </IfCondition>
-                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * dnsoEmeraldSize  * 0.5 ' range=':= 1 * _default_ * dnsoEmeraldSize  * 0.5 ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * dnsoEmeraldSize  * 0.5 ' range=':= 1 * _default_ * dnsoEmeraldSize  * 0.5 ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * _default_ * dnsoEmeraldSize  * 0.5 ' range=':= 1 * _default_ * dnsoEmeraldSize  * 0.5 ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.609 * _default_ * dnsoEmeraldSize  * 0.5 ' range=':= 1 * _default_ * dnsoEmeraldSize  * 0.5 ' type='normal' />
                             <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
                         </Veins>
                     </IfCondition>
@@ -1068,18 +1068,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.642 * _default_ * dnsoRedstoneFreq ' range=':= 1 * _default_ * dnsoRedstoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.180 * _default_ * dnsoRedstoneSize ' range=':= 1 * _default_ * dnsoRedstoneSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * _default_ * dnsoRedstoneSize ' range=':= 1 * _default_ * dnsoRedstoneSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 10 ' range=':= 5 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= -_default_ ' range=':= -_default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.180 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.282 * _default_ ' range=':= 1 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * dnsoRedstoneSize ' range=':= _default_ * dnsoRedstoneSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.180 * _default_ * dnsoRedstoneSize ' range=':= 1 * _default_ * dnsoRedstoneSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.132 * _default_ * dnsoRedstoneSize ' range=':= 1 * _default_ * dnsoRedstoneSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1095,18 +1095,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <BiomeType name='Desert'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.642 * _default_ * dnsoRedstoneFreq ' range=':= 1 * _default_ * dnsoRedstoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.180 * _default_ * dnsoRedstoneSize ' range=':= 1 * _default_ * dnsoRedstoneSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * _default_ * dnsoRedstoneSize ' range=':= 1 * _default_ * dnsoRedstoneSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 10 ' range=':= 5 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= -_default_ ' range=':= -_default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.180 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.282 * _default_ ' range=':= 1 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * dnsoRedstoneSize ' range=':= _default_ * dnsoRedstoneSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.180 * _default_ * dnsoRedstoneSize ' range=':= 1 * _default_ * dnsoRedstoneSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.132 * _default_ * dnsoRedstoneSize ' range=':= 1 * _default_ * dnsoRedstoneSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1261,18 +1261,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 6.262 * _default_ * dnsoCoalFreq ' range=':= 1 * _default_ * dnsoCoalFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.843 * _default_ * dnsoCoalSize ' range=':= 1 * _default_ * dnsoCoalSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * _default_ * dnsoCoalSize ' range=':= 1 * _default_ * dnsoCoalSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 68 ' range=':= 63 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.843 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 2.502 * _default_ ' range=':= 1 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * dnsoCoalSize ' range=':= _default_ * dnsoCoalSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.843 * _default_ * dnsoCoalSize ' range=':= 1 * _default_ * dnsoCoalSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.582 * _default_ * dnsoCoalSize ' range=':= 1 * _default_ * dnsoCoalSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1481,18 +1481,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 5.049 * _default_ * dnsoNetherQuartzFreq ' range=':= 1 * _default_ * dnsoNetherQuartzFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.716 * _default_ * dnsoNetherQuartzSize ' range=':= 1 * _default_ * dnsoNetherQuartzSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * _default_ * dnsoNetherQuartzSize ' range=':= 1 * _default_ * dnsoNetherQuartzSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 68 ' range=':= 52 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.716 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 2.247 * _default_ ' range=':= 1 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * dnsoNetherQuartzSize ' range=':= _default_ * dnsoNetherQuartzSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.716 * _default_ * dnsoNetherQuartzSize ' range=':= 1 * _default_ * dnsoNetherQuartzSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.499 * _default_ * dnsoNetherQuartzSize ' range=':= 1 * _default_ * dnsoNetherQuartzSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>

--- a/src/main/resources/config/modules/ElectriCraft.xml
+++ b/src/main/resources/config/modules/ElectriCraft.xml
@@ -288,18 +288,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.821 * _default_ * elcrCopperFreq ' range=':= 1 * _default_ * elcrCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.936 * _default_ * elcrCopperSize ' range=':= 1 * _default_ * elcrCopperSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.968 * _default_ * elcrCopperSize ' range=':= 1 * _default_ * elcrCopperSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 48 ' range=':= 16 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.936 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.906 * _default_ ' range=':= 1 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * elcrCopperSize ' range=':= _default_ * elcrCopperSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.936 * _default_ * elcrCopperSize ' range=':= 1 * _default_ * elcrCopperSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.952 * _default_ * elcrCopperSize ' range=':= 1 * _default_ * elcrCopperSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -407,18 +407,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.948 * _default_ * elcrTinFreq ' range=':= 1 * _default_ * elcrTinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.982 * _default_ * elcrTinSize ' range=':= 1 * _default_ * elcrTinSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.991 * _default_ * elcrTinSize ' range=':= 1 * _default_ * elcrTinSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 60 ' range=':= 12 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.982 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.973 * _default_ ' range=':= 1 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * elcrTinSize ' range=':= _default_ * elcrTinSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.982 * _default_ * elcrTinSize ' range=':= 1 * _default_ * elcrTinSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.987 * _default_ * elcrTinSize ' range=':= 1 * _default_ * elcrTinSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -526,18 +526,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.580 * _default_ * elcrSilverFreq ' range=':= 1 * _default_ * elcrSilverFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.834 * _default_ * elcrSilverSize ' range=':= 1 * _default_ * elcrSilverSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.913 * _default_ * elcrSilverSize ' range=':= 1 * _default_ * elcrSilverSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.834 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.762 * _default_ ' range=':= 1 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * elcrSilverSize ' range=':= _default_ * elcrSilverSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.834 * _default_ * elcrSilverSize ' range=':= 1 * _default_ * elcrSilverSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.873 * _default_ * elcrSilverSize ' range=':= 1 * _default_ * elcrSilverSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -645,18 +645,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.821 * _default_ * elcrNickelFreq ' range=':= 1 * _default_ * elcrNickelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.936 * _default_ * elcrNickelSize ' range=':= 1 * _default_ * elcrNickelSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.968 * _default_ * elcrNickelSize ' range=':= 1 * _default_ * elcrNickelSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 32 ' range=':= 16 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.936 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.906 * _default_ ' range=':= 1 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * elcrNickelSize ' range=':= _default_ * elcrNickelSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.936 * _default_ * elcrNickelSize ' range=':= 1 * _default_ * elcrNickelSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.952 * _default_ * elcrNickelSize ' range=':= 1 * _default_ * elcrNickelSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -764,18 +764,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.059 * _default_ * elcrAluminumFreq ' range=':= 1 * _default_ * elcrAluminumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.019 * _default_ * elcrAluminumSize ' range=':= 1 * _default_ * elcrAluminumSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 1.010 * _default_ * elcrAluminumSize ' range=':= 1 * _default_ * elcrAluminumSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 94 ' range=':= 34 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.019 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.029 * _default_ ' range=':= 1 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * elcrAluminumSize ' range=':= _default_ * elcrAluminumSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.019 * _default_ * elcrAluminumSize ' range=':= 1 * _default_ * elcrAluminumSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.015 * _default_ * elcrAluminumSize ' range=':= 1 * _default_ * elcrAluminumSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -883,18 +883,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.335 * _default_ * elcrPlatinumFreq ' range=':= 1 * _default_ * elcrPlatinumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.695 * _default_ * elcrPlatinumSize ' range=':= 1 * _default_ * elcrPlatinumSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.833 * _default_ * elcrPlatinumSize ' range=':= 1 * _default_ * elcrPlatinumSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 11 ' range=':= 5 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.695 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.579 * _default_ ' range=':= 1 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * elcrPlatinumSize ' range=':= _default_ * elcrPlatinumSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.695 * _default_ * elcrPlatinumSize ' range=':= 1 * _default_ * elcrPlatinumSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.761 * _default_ * elcrPlatinumSize ' range=':= 1 * _default_ * elcrPlatinumSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>

--- a/src/main/resources/config/modules/Factorization.xml
+++ b/src/main/resources/config/modules/Factorization.xml
@@ -145,18 +145,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.543 * _default_ * fctrSilverFreq ' range=':= _default_ * fctrSilverFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.816 * _default_ * fctrSilverSize ' range=':= _default_ * fctrSilverSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.903 * _default_ * fctrSilverSize ' range=':= _default_ * fctrSilverSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 25 ' range=':= 10 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.816 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.737 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * fctrSilverSize ' range=':= _default_ * fctrSilverSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.816 * _default_ * fctrSilverSize ' range=':= _default_ * fctrSilverSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.858 * _default_ * fctrSilverSize ' range=':= _default_ * fctrSilverSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -273,18 +273,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.350 * _default_ * fctrDarkIronFreq ' range=':= _default_ * fctrDarkIronFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.705 * _default_ * fctrDarkIronSize ' range=':= _default_ * fctrDarkIronSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * _default_ * fctrDarkIronSize ' range=':= _default_ * fctrDarkIronSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 3 ' range=':= 2 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.705 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.592 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * fctrDarkIronSize ' range=':= _default_ * fctrDarkIronSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.705 * _default_ * fctrDarkIronSize ' range=':= _default_ * fctrDarkIronSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.769 * _default_ * fctrDarkIronSize ' range=':= _default_ * fctrDarkIronSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>

--- a/src/main/resources/config/modules/Forestry.xml
+++ b/src/main/resources/config/modules/Forestry.xml
@@ -187,18 +187,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.100 * _default_ * frstApatiteFreq ' range=':= _default_ * frstApatiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.281 * _default_ * frstApatiteSize ' range=':= _default_ * frstApatiteSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * frstApatiteSize ' range=':= _default_ * frstApatiteSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 120 ' range=':= 64 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.281 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.449 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * frstApatiteSize ' range=':= _default_ * frstApatiteSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.281 * _default_ * frstApatiteSize ' range=':= _default_ * frstApatiteSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.204 * _default_ * frstApatiteSize ' range=':= _default_ * frstApatiteSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -306,18 +306,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.297 * _default_ * frstCopperFreq ' range=':= _default_ * frstCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.091 * _default_ * frstCopperSize ' range=':= _default_ * frstCopperSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 1.044 * _default_ * frstCopperSize ' range=':= _default_ * frstCopperSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 106 ' range=':= 74 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.091 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.139 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * frstCopperSize ' range=':= _default_ * frstCopperSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.091 * _default_ * frstCopperSize ' range=':= _default_ * frstCopperSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.067 * _default_ * frstCopperSize ' range=':= _default_ * frstCopperSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -425,18 +425,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.231 * _default_ * frstTinFreq ' range=':= _default_ * frstTinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.072 * _default_ * frstTinSize ' range=':= _default_ * frstTinSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 1.035 * _default_ * frstTinSize ' range=':= _default_ * frstTinSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 98 ' range=':= 82 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.072 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.109 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * frstTinSize ' range=':= _default_ * frstTinSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.072 * _default_ * frstTinSize ' range=':= _default_ * frstTinSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.053 * _default_ * frstTinSize ' range=':= _default_ * frstTinSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>

--- a/src/main/resources/config/modules/FossilsandArchaeology.xml
+++ b/src/main/resources/config/modules/FossilsandArchaeology.xml
@@ -153,18 +153,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 6.104 * _default_ * fsarFossilsFreq ' range=':= _default_ * fsarFossilsFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.828 * _default_ * fsarFossilsSize ' range=':= _default_ * fsarFossilsSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * fsarFossilsSize ' range=':= _default_ * fsarFossilsSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 53 ' range=':= 47 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.828 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 2.471 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * fsarFossilsSize ' range=':= _default_ * fsarFossilsSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.828 * _default_ * fsarFossilsSize ' range=':= _default_ * fsarFossilsSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.572 * _default_ * fsarFossilsSize ' range=':= _default_ * fsarFossilsSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -180,18 +180,18 @@
                             <BiomeType name='Swamp'  />
                             <BiomeType name='desert'  />
                             <Setting name='MotherlodeFrequency' avg=':= 6.104 * _default_ * fsarFossilsFreq ' range=':= _default_ * fsarFossilsFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.828 * _default_ * fsarFossilsSize ' range=':= _default_ * fsarFossilsSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * fsarFossilsSize ' range=':= _default_ * fsarFossilsSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 53 ' range=':= 47 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.828 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 2.471 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * fsarFossilsSize ' range=':= _default_ * fsarFossilsSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.828 * _default_ * fsarFossilsSize ' range=':= _default_ * fsarFossilsSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.572 * _default_ * fsarFossilsSize ' range=':= _default_ * fsarFossilsSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -342,18 +342,18 @@
                             <Biome name='.*'  />
                             <BiomeType name='Frozen'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.980 * _default_ * fsarPermafrostFreq ' range=':= _default_ * fsarPermafrostFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.256 * _default_ * fsarPermafrostSize ' range=':= _default_ * fsarPermafrostSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * _default_ * fsarPermafrostSize ' range=':= _default_ * fsarPermafrostSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 18 ' range=':= 12.5 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.256 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.407 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * fsarPermafrostSize ' range=':= _default_ * fsarPermafrostSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.256 * _default_ * fsarPermafrostSize ' range=':= _default_ * fsarPermafrostSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.186 * _default_ * fsarPermafrostSize ' range=':= _default_ * fsarPermafrostSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>

--- a/src/main/resources/config/modules/GeoStrata.xml
+++ b/src/main/resources/config/modules/GeoStrata.xml
@@ -672,18 +672,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 3.282 * _default_ * gstaShaleFreq ' range=':= _default_ * gstaShaleFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.486 * _default_ * gstaShaleSize ' range=':= _default_ * gstaShaleSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 1.219 * _default_ * gstaShaleSize ' range=':= _default_ * gstaShaleSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 56 ' range=':= 8 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.486 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.812 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * gstaShaleSize ' range=':= _default_ * gstaShaleSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.486 * _default_ * gstaShaleSize ' range=':= _default_ * gstaShaleSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.346 * _default_ * gstaShaleSize ' range=':= _default_ * gstaShaleSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -791,18 +791,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 3.282 * _default_ * gstaSandstoneFreq ' range=':= _default_ * gstaSandstoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.486 * _default_ * gstaSandstoneSize ' range=':= _default_ * gstaSandstoneSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 1.219 * _default_ * gstaSandstoneSize ' range=':= _default_ * gstaSandstoneSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 88 ' range=':= 40 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.486 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.812 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * gstaSandstoneSize ' range=':= _default_ * gstaSandstoneSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.486 * _default_ * gstaSandstoneSize ' range=':= _default_ * gstaSandstoneSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.346 * _default_ * gstaSandstoneSize ' range=':= _default_ * gstaSandstoneSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -885,7 +885,7 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 32 * gstaSandstoneSize ' range=':= _default_ * gstaSandstoneSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= _default_ * gstaSandstoneFreq ' range=':= _default_ * gstaSandstoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Frequency' avg=':= 24 * gstaSandstoneFreq ' range=':= _default_ * gstaSandstoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 88 ' range=':= 40 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -910,18 +910,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 3.282 * _default_ * gstaLimestoneFreq ' range=':= _default_ * gstaLimestoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.486 * _default_ * gstaLimestoneSize ' range=':= _default_ * gstaLimestoneSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 1.219 * _default_ * gstaLimestoneSize ' range=':= _default_ * gstaLimestoneSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 88 ' range=':= 40 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.486 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.812 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * gstaLimestoneSize ' range=':= _default_ * gstaLimestoneSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.486 * _default_ * gstaLimestoneSize ' range=':= _default_ * gstaLimestoneSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.346 * _default_ * gstaLimestoneSize ' range=':= _default_ * gstaLimestoneSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1004,7 +1004,7 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 32 * gstaLimestoneSize ' range=':= _default_ * gstaLimestoneSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= _default_ * gstaLimestoneFreq ' range=':= _default_ * gstaLimestoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Frequency' avg=':= 24 * gstaLimestoneFreq ' range=':= _default_ * gstaLimestoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 88 ' range=':= 40 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -1029,18 +1029,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.543 * _default_ * gstaPumiceFreq ' range=':= _default_ * gstaPumiceFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.365 * _default_ * gstaPumiceSize ' range=':= _default_ * gstaPumiceSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 1.168 * _default_ * gstaPumiceSize ' range=':= _default_ * gstaPumiceSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 11 ' range=':= 5 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.365 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.595 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * gstaPumiceSize ' range=':= _default_ * gstaPumiceSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.365 * _default_ * gstaPumiceSize ' range=':= _default_ * gstaPumiceSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.263 * _default_ * gstaPumiceSize ' range=':= _default_ * gstaPumiceSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1148,18 +1148,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.161 * _default_ * gstaOpalFreq ' range=':= _default_ * gstaOpalFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.051 * _default_ * gstaOpalSize ' range=':= _default_ * gstaOpalSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 1.025 * _default_ * gstaOpalSize ' range=':= _default_ * gstaOpalSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.051 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.077 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * gstaOpalSize ' range=':= _default_ * gstaOpalSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.051 * _default_ * gstaOpalSize ' range=':= _default_ * gstaOpalSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.038 * _default_ * gstaOpalSize ' range=':= _default_ * gstaOpalSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1267,18 +1267,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 3.282 * _default_ * gstaSlateFreq ' range=':= _default_ * gstaSlateFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.486 * _default_ * gstaSlateSize ' range=':= _default_ * gstaSlateSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 1.219 * _default_ * gstaSlateSize ' range=':= _default_ * gstaSlateSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 40 ' range=':= 8 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.486 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.812 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * gstaSlateSize ' range=':= _default_ * gstaSlateSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.486 * _default_ * gstaSlateSize ' range=':= _default_ * gstaSlateSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.346 * _default_ * gstaSlateSize ' range=':= _default_ * gstaSlateSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1386,18 +1386,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.936 * _default_ * gstaGneissFreq ' range=':= _default_ * gstaGneissFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.432 * _default_ * gstaGneissSize ' range=':= _default_ * gstaGneissSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 1.197 * _default_ * gstaGneissSize ' range=':= _default_ * gstaGneissSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 24 ' range=':= 8 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.432 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.713 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * gstaGneissSize ' range=':= _default_ * gstaGneissSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.432 * _default_ * gstaGneissSize ' range=':= _default_ * gstaGneissSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.309 * _default_ * gstaGneissSize ' range=':= _default_ * gstaGneissSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1505,18 +1505,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.543 * _default_ * gstaPeridotiteFreq ' range=':= _default_ * gstaPeridotiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.365 * _default_ * gstaPeridotiteSize ' range=':= _default_ * gstaPeridotiteSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 1.168 * _default_ * gstaPeridotiteSize ' range=':= _default_ * gstaPeridotiteSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 15 ' range=':= 9 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.365 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.595 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * gstaPeridotiteSize ' range=':= _default_ * gstaPeridotiteSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.365 * _default_ * gstaPeridotiteSize ' range=':= _default_ * gstaPeridotiteSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.263 * _default_ * gstaPeridotiteSize ' range=':= _default_ * gstaPeridotiteSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1624,18 +1624,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.746 * _default_ * gstaGranuliteFreq ' range=':= _default_ * gstaGranuliteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.4 * _default_ * gstaGranuliteSize ' range=':= _default_ * gstaGranuliteSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 1.183 * _default_ * gstaGranuliteSize ' range=':= _default_ * gstaGranuliteSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 24 ' range=':= 8 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.4 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.657 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * gstaGranuliteSize ' range=':= _default_ * gstaGranuliteSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.4 * _default_ * gstaGranuliteSize ' range=':= _default_ * gstaGranuliteSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.287 * _default_ * gstaGranuliteSize ' range=':= _default_ * gstaGranuliteSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1743,18 +1743,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.543 * _default_ * gstaMigmatiteFreq ' range=':= _default_ * gstaMigmatiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.365 * _default_ * gstaMigmatiteSize ' range=':= _default_ * gstaMigmatiteSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 1.168 * _default_ * gstaMigmatiteSize ' range=':= _default_ * gstaMigmatiteSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 11 ' range=':= 5 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.365 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.595 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * gstaMigmatiteSize ' range=':= _default_ * gstaMigmatiteSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.365 * _default_ * gstaMigmatiteSize ' range=':= _default_ * gstaMigmatiteSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.263 * _default_ * gstaMigmatiteSize ' range=':= _default_ * gstaMigmatiteSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1862,18 +1862,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.936 * _default_ * gstaSchistFreq ' range=':= _default_ * gstaSchistFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.432 * _default_ * gstaSchistSize ' range=':= _default_ * gstaSchistSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 1.197 * _default_ * gstaSchistSize ' range=':= _default_ * gstaSchistSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 32 ' range=':= 16 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.432 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.713 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * gstaSchistSize ' range=':= _default_ * gstaSchistSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.432 * _default_ * gstaSchistSize ' range=':= _default_ * gstaSchistSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.309 * _default_ * gstaSchistSize ' range=':= _default_ * gstaSchistSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1981,18 +1981,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 3.282 * _default_ * gstaBasaltFreq ' range=':= _default_ * gstaBasaltFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.486 * _default_ * gstaBasaltSize ' range=':= _default_ * gstaBasaltSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 1.219 * _default_ * gstaBasaltSize ' range=':= _default_ * gstaBasaltSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 88 ' range=':= 40 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.486 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.812 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * gstaBasaltSize ' range=':= _default_ * gstaBasaltSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.486 * _default_ * gstaBasaltSize ' range=':= _default_ * gstaBasaltSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.346 * _default_ * gstaBasaltSize ' range=':= _default_ * gstaBasaltSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -2100,18 +2100,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 3.282 * _default_ * gstaOnyxFreq ' range=':= _default_ * gstaOnyxFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.486 * _default_ * gstaOnyxSize ' range=':= _default_ * gstaOnyxSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 1.219 * _default_ * gstaOnyxSize ' range=':= _default_ * gstaOnyxSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 15 ' range=':= 9 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.486 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.812 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * gstaOnyxSize ' range=':= _default_ * gstaOnyxSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.486 * _default_ * gstaOnyxSize ' range=':= _default_ * gstaOnyxSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.346 * _default_ * gstaOnyxSize ' range=':= _default_ * gstaOnyxSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -2219,18 +2219,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.321 * _default_ * gstaQuartzFreq ' range=':= _default_ * gstaQuartzFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.324 * _default_ * gstaQuartzSize ' range=':= _default_ * gstaQuartzSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 1.151 * _default_ * gstaQuartzSize ' range=':= _default_ * gstaQuartzSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 35 ' range=':= 29 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.324 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.523 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * gstaQuartzSize ' range=':= _default_ * gstaQuartzSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.324 * _default_ * gstaQuartzSize ' range=':= _default_ * gstaQuartzSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.234 * _default_ * gstaQuartzSize ' range=':= _default_ * gstaQuartzSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -2338,18 +2338,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 3.282 * _default_ * gstaMarbleFreq ' range=':= _default_ * gstaMarbleFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.486 * _default_ * gstaMarbleSize ' range=':= _default_ * gstaMarbleSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 1.219 * _default_ * gstaMarbleSize ' range=':= _default_ * gstaMarbleSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 40 ' range=':= 24 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.486 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.812 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * gstaMarbleSize ' range=':= _default_ * gstaMarbleSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.486 * _default_ * gstaMarbleSize ' range=':= _default_ * gstaMarbleSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.346 * _default_ * gstaMarbleSize ' range=':= _default_ * gstaMarbleSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -2457,18 +2457,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 3.282 * _default_ * gstaGraniteFreq ' range=':= _default_ * gstaGraniteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.486 * _default_ * gstaGraniteSize ' range=':= _default_ * gstaGraniteSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 1.219 * _default_ * gstaGraniteSize ' range=':= _default_ * gstaGraniteSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 32 ' range=':= 16 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.486 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.812 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * gstaGraniteSize ' range=':= _default_ * gstaGraniteSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.486 * _default_ * gstaGraniteSize ' range=':= _default_ * gstaGraniteSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.346 * _default_ * gstaGraniteSize ' range=':= _default_ * gstaGraniteSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -2576,18 +2576,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.936 * _default_ * gstaHornfelFreq ' range=':= _default_ * gstaHornfelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.432 * _default_ * gstaHornfelSize ' range=':= _default_ * gstaHornfelSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 1.197 * _default_ * gstaHornfelSize ' range=':= _default_ * gstaHornfelSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 35 ' range=':= 29 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.432 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.713 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * gstaHornfelSize ' range=':= _default_ * gstaHornfelSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.432 * _default_ * gstaHornfelSize ' range=':= _default_ * gstaHornfelSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.309 * _default_ * gstaHornfelSize ' range=':= _default_ * gstaHornfelSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>

--- a/src/main/resources/config/modules/Mekanism.xml
+++ b/src/main/resources/config/modules/Mekanism.xml
@@ -180,18 +180,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.161 * _default_ * mknsOsmiumFreq ' range=':= _default_ * mknsOsmiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.051 * _default_ * mknsOsmiumSize ' range=':= _default_ * mknsOsmiumSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 1.025 * _default_ * mknsOsmiumSize ' range=':= _default_ * mknsOsmiumSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 33 ' range=':= 27 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.051 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.077 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mknsOsmiumSize ' range=':= _default_ * mknsOsmiumSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.051 * _default_ * mknsOsmiumSize ' range=':= _default_ * mknsOsmiumSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.038 * _default_ * mknsOsmiumSize ' range=':= _default_ * mknsOsmiumSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -299,18 +299,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.340 * _default_ * mknsCopperFreq ' range=':= _default_ * mknsCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.102 * _default_ * mknsCopperSize ' range=':= _default_ * mknsCopperSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 1.050 * _default_ * mknsCopperSize ' range=':= _default_ * mknsCopperSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 33 ' range=':= 27 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.102 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.158 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mknsCopperSize ' range=':= _default_ * mknsCopperSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.102 * _default_ * mknsCopperSize ' range=':= _default_ * mknsCopperSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.076 * _default_ * mknsCopperSize ' range=':= _default_ * mknsCopperSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -418,18 +418,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.254 * _default_ * mknsTinFreq ' range=':= _default_ * mknsTinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.078 * _default_ * mknsTinSize ' range=':= _default_ * mknsTinSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 1.038 * _default_ * mknsTinSize ' range=':= _default_ * mknsTinSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 33 ' range=':= 27 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.078 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.120 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mknsTinSize ' range=':= _default_ * mknsTinSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.078 * _default_ * mknsTinSize ' range=':= _default_ * mknsTinSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.058 * _default_ * mknsTinSize ' range=':= _default_ * mknsTinSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>

--- a/src/main/resources/config/modules/Metallurgy4.xml
+++ b/src/main/resources/config/modules/Metallurgy4.xml
@@ -1303,18 +1303,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.400 * _default_ * mtlgSulfurFreq ' range=':= _default_ * mtlgSulfurFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.119 * _default_ * mtlgSulfurSize ' range=':= _default_ * mtlgSulfurSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * _default_ * mtlgSulfurSize ' range=':= _default_ * mtlgSulfurSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.119 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.183 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mtlgSulfurSize ' range=':= _default_ * mtlgSulfurSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.119 * _default_ * mtlgSulfurSize ' range=':= _default_ * mtlgSulfurSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.088 * _default_ * mtlgSulfurSize ' range=':= _default_ * mtlgSulfurSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1429,18 +1429,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.400 * _default_ * mtlgPhosphoriteFreq ' range=':= _default_ * mtlgPhosphoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.119 * _default_ * mtlgPhosphoriteSize ' range=':= _default_ * mtlgPhosphoriteSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * _default_ * mtlgPhosphoriteSize ' range=':= _default_ * mtlgPhosphoriteSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.119 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.183 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mtlgPhosphoriteSize ' range=':= _default_ * mtlgPhosphoriteSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.119 * _default_ * mtlgPhosphoriteSize ' range=':= _default_ * mtlgPhosphoriteSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.088 * _default_ * mtlgPhosphoriteSize ' range=':= _default_ * mtlgPhosphoriteSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1555,18 +1555,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.400 * _default_ * mtlgSaltpeterFreq ' range=':= _default_ * mtlgSaltpeterFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.119 * _default_ * mtlgSaltpeterSize ' range=':= _default_ * mtlgSaltpeterSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * _default_ * mtlgSaltpeterSize ' range=':= _default_ * mtlgSaltpeterSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.119 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.183 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mtlgSaltpeterSize ' range=':= _default_ * mtlgSaltpeterSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.119 * _default_ * mtlgSaltpeterSize ' range=':= _default_ * mtlgSaltpeterSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.088 * _default_ * mtlgSaltpeterSize ' range=':= _default_ * mtlgSaltpeterSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1681,18 +1681,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.400 * _default_ * mtlgMagnesiumFreq ' range=':= _default_ * mtlgMagnesiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.119 * _default_ * mtlgMagnesiumSize ' range=':= _default_ * mtlgMagnesiumSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * _default_ * mtlgMagnesiumSize ' range=':= _default_ * mtlgMagnesiumSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.119 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.183 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mtlgMagnesiumSize ' range=':= _default_ * mtlgMagnesiumSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.119 * _default_ * mtlgMagnesiumSize ' range=':= _default_ * mtlgMagnesiumSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.088 * _default_ * mtlgMagnesiumSize ' range=':= _default_ * mtlgMagnesiumSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1807,18 +1807,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.400 * _default_ * mtlgBitumenFreq ' range=':= _default_ * mtlgBitumenFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.119 * _default_ * mtlgBitumenSize ' range=':= _default_ * mtlgBitumenSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * _default_ * mtlgBitumenSize ' range=':= _default_ * mtlgBitumenSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.119 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.183 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mtlgBitumenSize ' range=':= _default_ * mtlgBitumenSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.119 * _default_ * mtlgBitumenSize ' range=':= _default_ * mtlgBitumenSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.088 * _default_ * mtlgBitumenSize ' range=':= _default_ * mtlgBitumenSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1933,18 +1933,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.400 * _default_ * mtlgPotashFreq ' range=':= _default_ * mtlgPotashFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.119 * _default_ * mtlgPotashSize ' range=':= _default_ * mtlgPotashSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * _default_ * mtlgPotashSize ' range=':= _default_ * mtlgPotashSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.119 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.183 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mtlgPotashSize ' range=':= _default_ * mtlgPotashSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.119 * _default_ * mtlgPotashSize ' range=':= _default_ * mtlgPotashSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.088 * _default_ * mtlgPotashSize ' range=':= _default_ * mtlgPotashSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -2052,18 +2052,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.005 * _default_ * mtlgCopperFreq ' range=':= _default_ * mtlgCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.002 * _default_ * mtlgCopperSize ' range=':= _default_ * mtlgCopperSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 1.001 * _default_ * mtlgCopperSize ' range=':= _default_ * mtlgCopperSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.002 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.003 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mtlgCopperSize ' range=':= _default_ * mtlgCopperSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.002 * _default_ * mtlgCopperSize ' range=':= _default_ * mtlgCopperSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.001 * _default_ * mtlgCopperSize ' range=':= _default_ * mtlgCopperSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -2171,18 +2171,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.991 * _default_ * mtlgTinFreq ' range=':= _default_ * mtlgTinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.997 * _default_ * mtlgTinSize ' range=':= _default_ * mtlgTinSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.998 * _default_ * mtlgTinSize ' range=':= _default_ * mtlgTinSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.997 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.995 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mtlgTinSize ' range=':= _default_ * mtlgTinSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.997 * _default_ * mtlgTinSize ' range=':= _default_ * mtlgTinSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.998 * _default_ * mtlgTinSize ' range=':= _default_ * mtlgTinSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -2290,18 +2290,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.530 * _default_ * mtlgManganeseFreq ' range=':= _default_ * mtlgManganeseFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.809 * _default_ * mtlgManganeseSize ' range=':= _default_ * mtlgManganeseSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.900 * _default_ * mtlgManganeseSize ' range=':= _default_ * mtlgManganeseSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.809 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.728 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mtlgManganeseSize ' range=':= _default_ * mtlgManganeseSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.809 * _default_ * mtlgManganeseSize ' range=':= _default_ * mtlgManganeseSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.853 * _default_ * mtlgManganeseSize ' range=':= _default_ * mtlgManganeseSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -2409,18 +2409,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.649 * _default_ * mtlgZincFreq ' range=':= _default_ * mtlgZincFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.866 * _default_ * mtlgZincSize ' range=':= _default_ * mtlgZincSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.930 * _default_ * mtlgZincSize ' range=':= _default_ * mtlgZincSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.866 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.805 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mtlgZincSize ' range=':= _default_ * mtlgZincSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.866 * _default_ * mtlgZincSize ' range=':= _default_ * mtlgZincSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.897 * _default_ * mtlgZincSize ' range=':= _default_ * mtlgZincSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -2528,18 +2528,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.649 * _default_ * mtlgSilverFreq ' range=':= _default_ * mtlgSilverFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.866 * _default_ * mtlgSilverSize ' range=':= _default_ * mtlgSilverSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.930 * _default_ * mtlgSilverSize ' range=':= _default_ * mtlgSilverSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.866 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.805 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mtlgSilverSize ' range=':= _default_ * mtlgSilverSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.866 * _default_ * mtlgSilverSize ' range=':= _default_ * mtlgSilverSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.897 * _default_ * mtlgSilverSize ' range=':= _default_ * mtlgSilverSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -2647,18 +2647,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.355 * _default_ * mtlgPlatinumFreq ' range=':= _default_ * mtlgPlatinumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.708 * _default_ * mtlgPlatinumSize ' range=':= _default_ * mtlgPlatinumSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.842 * _default_ * mtlgPlatinumSize ' range=':= _default_ * mtlgPlatinumSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.708 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.596 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mtlgPlatinumSize ' range=':= _default_ * mtlgPlatinumSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.708 * _default_ * mtlgPlatinumSize ' range=':= _default_ * mtlgPlatinumSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.772 * _default_ * mtlgPlatinumSize ' range=':= _default_ * mtlgPlatinumSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -2766,18 +2766,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.649 * _default_ * mtlgPromethiumFreq ' range=':= _default_ * mtlgPromethiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.866 * _default_ * mtlgPromethiumSize ' range=':= _default_ * mtlgPromethiumSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.930 * _default_ * mtlgPromethiumSize ' range=':= _default_ * mtlgPromethiumSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.866 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.805 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mtlgPromethiumSize ' range=':= _default_ * mtlgPromethiumSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.866 * _default_ * mtlgPromethiumSize ' range=':= _default_ * mtlgPromethiumSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.897 * _default_ * mtlgPromethiumSize ' range=':= _default_ * mtlgPromethiumSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -2885,18 +2885,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.530 * _default_ * mtlgDeepIronFreq ' range=':= _default_ * mtlgDeepIronFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.809 * _default_ * mtlgDeepIronSize ' range=':= _default_ * mtlgDeepIronSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.900 * _default_ * mtlgDeepIronSize ' range=':= _default_ * mtlgDeepIronSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.809 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.728 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mtlgDeepIronSize ' range=':= _default_ * mtlgDeepIronSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.809 * _default_ * mtlgDeepIronSize ' range=':= _default_ * mtlgDeepIronSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.853 * _default_ * mtlgDeepIronSize ' range=':= _default_ * mtlgDeepIronSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -3004,18 +3004,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.530 * _default_ * mtlgInfuscoliumFreq ' range=':= _default_ * mtlgInfuscoliumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.809 * _default_ * mtlgInfuscoliumSize ' range=':= _default_ * mtlgInfuscoliumSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.900 * _default_ * mtlgInfuscoliumSize ' range=':= _default_ * mtlgInfuscoliumSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.809 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.728 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mtlgInfuscoliumSize ' range=':= _default_ * mtlgInfuscoliumSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.809 * _default_ * mtlgInfuscoliumSize ' range=':= _default_ * mtlgInfuscoliumSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.853 * _default_ * mtlgInfuscoliumSize ' range=':= _default_ * mtlgInfuscoliumSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -3123,18 +3123,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.410 * _default_ * mtlgOureclaseFreq ' range=':= _default_ * mtlgOureclaseFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.743 * _default_ * mtlgOureclaseSize ' range=':= _default_ * mtlgOureclaseSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.862 * _default_ * mtlgOureclaseSize ' range=':= _default_ * mtlgOureclaseSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.743 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.641 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mtlgOureclaseSize ' range=':= _default_ * mtlgOureclaseSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.743 * _default_ * mtlgOureclaseSize ' range=':= _default_ * mtlgOureclaseSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.800 * _default_ * mtlgOureclaseSize ' range=':= _default_ * mtlgOureclaseSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -3242,18 +3242,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.410 * _default_ * mtlgAstralSilverFreq ' range=':= _default_ * mtlgAstralSilverFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.743 * _default_ * mtlgAstralSilverSize ' range=':= _default_ * mtlgAstralSilverSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.862 * _default_ * mtlgAstralSilverSize ' range=':= _default_ * mtlgAstralSilverSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.743 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.641 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mtlgAstralSilverSize ' range=':= _default_ * mtlgAstralSilverSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.743 * _default_ * mtlgAstralSilverSize ' range=':= _default_ * mtlgAstralSilverSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.800 * _default_ * mtlgAstralSilverSize ' range=':= _default_ * mtlgAstralSilverSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -3362,18 +3362,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.355 * _default_ * mtlgCarmotFreq ' range=':= _default_ * mtlgCarmotFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.708 * _default_ * mtlgCarmotSize ' range=':= _default_ * mtlgCarmotSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.842 * _default_ * mtlgCarmotSize ' range=':= _default_ * mtlgCarmotSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.708 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.596 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mtlgCarmotSize ' range=':= _default_ * mtlgCarmotSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.708 * _default_ * mtlgCarmotSize ' range=':= _default_ * mtlgCarmotSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.772 * _default_ * mtlgCarmotSize ' range=':= _default_ * mtlgCarmotSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -3481,18 +3481,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.355 * _default_ * mtlgMithrilFreq ' range=':= _default_ * mtlgMithrilFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.708 * _default_ * mtlgMithrilSize ' range=':= _default_ * mtlgMithrilSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.842 * _default_ * mtlgMithrilSize ' range=':= _default_ * mtlgMithrilSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.708 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.596 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mtlgMithrilSize ' range=':= _default_ * mtlgMithrilSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.708 * _default_ * mtlgMithrilSize ' range=':= _default_ * mtlgMithrilSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.772 * _default_ * mtlgMithrilSize ' range=':= _default_ * mtlgMithrilSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -3600,18 +3600,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.290 * _default_ * mtlgRubraciumFreq ' range=':= _default_ * mtlgRubraciumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.662 * _default_ * mtlgRubraciumSize ' range=':= _default_ * mtlgRubraciumSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.814 * _default_ * mtlgRubraciumSize ' range=':= _default_ * mtlgRubraciumSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.662 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.539 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mtlgRubraciumSize ' range=':= _default_ * mtlgRubraciumSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.662 * _default_ * mtlgRubraciumSize ' range=':= _default_ * mtlgRubraciumSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.734 * _default_ * mtlgRubraciumSize ' range=':= _default_ * mtlgRubraciumSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -3719,18 +3719,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.335 * _default_ * mtlgOrichalcumFreq ' range=':= _default_ * mtlgOrichalcumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.695 * _default_ * mtlgOrichalcumSize ' range=':= _default_ * mtlgOrichalcumSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.833 * _default_ * mtlgOrichalcumSize ' range=':= _default_ * mtlgOrichalcumSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.695 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.579 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mtlgOrichalcumSize ' range=':= _default_ * mtlgOrichalcumSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.695 * _default_ * mtlgOrichalcumSize ' range=':= _default_ * mtlgOrichalcumSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.761 * _default_ * mtlgOrichalcumSize ' range=':= _default_ * mtlgOrichalcumSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -3838,18 +3838,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.290 * _default_ * mtlgAdamantineFreq ' range=':= _default_ * mtlgAdamantineFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.662 * _default_ * mtlgAdamantineSize ' range=':= _default_ * mtlgAdamantineSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.814 * _default_ * mtlgAdamantineSize ' range=':= _default_ * mtlgAdamantineSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.662 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.539 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mtlgAdamantineSize ' range=':= _default_ * mtlgAdamantineSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.662 * _default_ * mtlgAdamantineSize ' range=':= _default_ * mtlgAdamantineSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.734 * _default_ * mtlgAdamantineSize ' range=':= _default_ * mtlgAdamantineSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -3957,18 +3957,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.290 * _default_ * mtlgAtlarusFreq ' range=':= _default_ * mtlgAtlarusFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.662 * _default_ * mtlgAtlarusSize ' range=':= _default_ * mtlgAtlarusSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.814 * _default_ * mtlgAtlarusSize ' range=':= _default_ * mtlgAtlarusSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.662 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.539 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mtlgAtlarusSize ' range=':= _default_ * mtlgAtlarusSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.662 * _default_ * mtlgAtlarusSize ' range=':= _default_ * mtlgAtlarusSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.734 * _default_ * mtlgAtlarusSize ' range=':= _default_ * mtlgAtlarusSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -4108,18 +4108,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.870 * _default_ * mtlgIgnatiusFreq ' range=':= _default_ * mtlgIgnatiusFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.955 * _default_ * mtlgIgnatiusSize ' range=':= _default_ * mtlgIgnatiusSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.977 * _default_ * mtlgIgnatiusSize ' range=':= _default_ * mtlgIgnatiusSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.955 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.933 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mtlgIgnatiusSize ' range=':= _default_ * mtlgIgnatiusSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.955 * _default_ * mtlgIgnatiusSize ' range=':= _default_ * mtlgIgnatiusSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.966 * _default_ * mtlgIgnatiusSize ' range=':= _default_ * mtlgIgnatiusSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -4227,18 +4227,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.768 * _default_ * mtlgShadowIronFreq ' range=':= _default_ * mtlgShadowIronFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.916 * _default_ * mtlgShadowIronSize ' range=':= _default_ * mtlgShadowIronSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.957 * _default_ * mtlgShadowIronSize ' range=':= _default_ * mtlgShadowIronSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.916 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.876 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mtlgShadowIronSize ' range=':= _default_ * mtlgShadowIronSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.916 * _default_ * mtlgShadowIronSize ' range=':= _default_ * mtlgShadowIronSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.936 * _default_ * mtlgShadowIronSize ' range=':= _default_ * mtlgShadowIronSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -4346,18 +4346,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.711 * _default_ * mtlgLemuriteFreq ' range=':= _default_ * mtlgLemuriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.892 * _default_ * mtlgLemuriteSize ' range=':= _default_ * mtlgLemuriteSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.945 * _default_ * mtlgLemuriteSize ' range=':= _default_ * mtlgLemuriteSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.892 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.843 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mtlgLemuriteSize ' range=':= _default_ * mtlgLemuriteSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.892 * _default_ * mtlgLemuriteSize ' range=':= _default_ * mtlgLemuriteSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.918 * _default_ * mtlgLemuriteSize ' range=':= _default_ * mtlgLemuriteSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -4465,18 +4465,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.649 * _default_ * mtlgMidasiumFreq ' range=':= _default_ * mtlgMidasiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.866 * _default_ * mtlgMidasiumSize ' range=':= _default_ * mtlgMidasiumSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.930 * _default_ * mtlgMidasiumSize ' range=':= _default_ * mtlgMidasiumSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.866 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.805 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mtlgMidasiumSize ' range=':= _default_ * mtlgMidasiumSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.866 * _default_ * mtlgMidasiumSize ' range=':= _default_ * mtlgMidasiumSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.897 * _default_ * mtlgMidasiumSize ' range=':= _default_ * mtlgMidasiumSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -4584,18 +4584,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.627 * _default_ * mtlgVyroxeresFreq ' range=':= _default_ * mtlgVyroxeresFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.856 * _default_ * mtlgVyroxeresSize ' range=':= _default_ * mtlgVyroxeresSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.925 * _default_ * mtlgVyroxeresSize ' range=':= _default_ * mtlgVyroxeresSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.856 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.792 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mtlgVyroxeresSize ' range=':= _default_ * mtlgVyroxeresSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.856 * _default_ * mtlgVyroxeresSize ' range=':= _default_ * mtlgVyroxeresSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.890 * _default_ * mtlgVyroxeresSize ' range=':= _default_ * mtlgVyroxeresSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -4703,18 +4703,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.474 * _default_ * mtlgCeruclaseFreq ' range=':= _default_ * mtlgCeruclaseFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.780 * _default_ * mtlgCeruclaseSize ' range=':= _default_ * mtlgCeruclaseSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.883 * _default_ * mtlgCeruclaseSize ' range=':= _default_ * mtlgCeruclaseSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.780 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.688 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mtlgCeruclaseSize ' range=':= _default_ * mtlgCeruclaseSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.780 * _default_ * mtlgCeruclaseSize ' range=':= _default_ * mtlgCeruclaseSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.830 * _default_ * mtlgCeruclaseSize ' range=':= _default_ * mtlgCeruclaseSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -4822,18 +4822,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.410 * _default_ * mtlgAlduoriteFreq ' range=':= _default_ * mtlgAlduoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.743 * _default_ * mtlgAlduoriteSize ' range=':= _default_ * mtlgAlduoriteSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.862 * _default_ * mtlgAlduoriteSize ' range=':= _default_ * mtlgAlduoriteSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.743 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.641 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mtlgAlduoriteSize ' range=':= _default_ * mtlgAlduoriteSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.743 * _default_ * mtlgAlduoriteSize ' range=':= _default_ * mtlgAlduoriteSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.800 * _default_ * mtlgAlduoriteSize ' range=':= _default_ * mtlgAlduoriteSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -4941,18 +4941,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.410 * _default_ * mtlgKalendriteFreq ' range=':= _default_ * mtlgKalendriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.743 * _default_ * mtlgKalendriteSize ' range=':= _default_ * mtlgKalendriteSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.862 * _default_ * mtlgKalendriteSize ' range=':= _default_ * mtlgKalendriteSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.743 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.641 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mtlgKalendriteSize ' range=':= _default_ * mtlgKalendriteSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.743 * _default_ * mtlgKalendriteSize ' range=':= _default_ * mtlgKalendriteSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.800 * _default_ * mtlgKalendriteSize ' range=':= _default_ * mtlgKalendriteSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -5060,18 +5060,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.290 * _default_ * mtlgVulcaniteFreq ' range=':= _default_ * mtlgVulcaniteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.662 * _default_ * mtlgVulcaniteSize ' range=':= _default_ * mtlgVulcaniteSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.814 * _default_ * mtlgVulcaniteSize ' range=':= _default_ * mtlgVulcaniteSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.662 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.539 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mtlgVulcaniteSize ' range=':= _default_ * mtlgVulcaniteSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.662 * _default_ * mtlgVulcaniteSize ' range=':= _default_ * mtlgVulcaniteSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.734 * _default_ * mtlgVulcaniteSize ' range=':= _default_ * mtlgVulcaniteSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -5179,18 +5179,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.290 * _default_ * mtlgSanguiniteFreq ' range=':= _default_ * mtlgSanguiniteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.662 * _default_ * mtlgSanguiniteSize ' range=':= _default_ * mtlgSanguiniteSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.814 * _default_ * mtlgSanguiniteSize ' range=':= _default_ * mtlgSanguiniteSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.662 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.539 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mtlgSanguiniteSize ' range=':= _default_ * mtlgSanguiniteSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.662 * _default_ * mtlgSanguiniteSize ' range=':= _default_ * mtlgSanguiniteSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.734 * _default_ * mtlgSanguiniteSize ' range=':= _default_ * mtlgSanguiniteSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -5330,18 +5330,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.580 * _default_ * mtlgEximiteFreq ' range=':= _default_ * mtlgEximiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.834 * _default_ * mtlgEximiteSize ' range=':= _default_ * mtlgEximiteSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.913 * _default_ * mtlgEximiteSize ' range=':= _default_ * mtlgEximiteSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.834 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.762 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mtlgEximiteSize ' range=':= _default_ * mtlgEximiteSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.834 * _default_ * mtlgEximiteSize ' range=':= _default_ * mtlgEximiteSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.873 * _default_ * mtlgEximiteSize ' range=':= _default_ * mtlgEximiteSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -5449,18 +5449,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.355 * _default_ * mtlgMeutoiteFreq ' range=':= _default_ * mtlgMeutoiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.708 * _default_ * mtlgMeutoiteSize ' range=':= _default_ * mtlgMeutoiteSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.842 * _default_ * mtlgMeutoiteSize ' range=':= _default_ * mtlgMeutoiteSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.708 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.596 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mtlgMeutoiteSize ' range=':= _default_ * mtlgMeutoiteSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.708 * _default_ * mtlgMeutoiteSize ' range=':= _default_ * mtlgMeutoiteSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.772 * _default_ * mtlgMeutoiteSize ' range=':= _default_ * mtlgMeutoiteSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -5542,8 +5542,8 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:ender.ore")'> <OreBlock block='Metallurgy:ender.ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4 * mtlgMeutoiteSize ' range=':= _default_ * mtlgMeutoiteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 6 * mtlgMeutoiteFreq ' range=':= _default_ * mtlgMeutoiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 3 * mtlgMeutoiteSize ' range=':= _default_ * mtlgMeutoiteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 3 * mtlgMeutoiteFreq ' range=':= _default_ * mtlgMeutoiteFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>

--- a/src/main/resources/config/modules/MineChem.xml
+++ b/src/main/resources/config/modules/MineChem.xml
@@ -112,18 +112,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.335 * _default_ * mchmUraniumFreq ' range=':= _default_ * mchmUraniumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.695 * _default_ * mchmUraniumSize ' range=':= _default_ * mchmUraniumSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.833 * _default_ * mchmUraniumSize ' range=':= _default_ * mchmUraniumSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 17.5 ' range=':= 12.5 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.695 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.579 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mchmUraniumSize ' range=':= _default_ * mchmUraniumSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.695 * _default_ * mchmUraniumSize ' range=':= _default_ * mchmUraniumSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.761 * _default_ * mchmUraniumSize ' range=':= _default_ * mchmUraniumSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>

--- a/src/main/resources/config/modules/MinecraftComesAlive.xml
+++ b/src/main/resources/config/modules/MinecraftComesAlive.xml
@@ -114,18 +114,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.649 * _default_ * mccaRoseGoldFreq ' range=':= _default_ * mccaRoseGoldFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.866 * _default_ * mccaRoseGoldSize ' range=':= _default_ * mccaRoseGoldSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.930 * _default_ * mccaRoseGoldSize ' range=':= _default_ * mccaRoseGoldSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 26 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.866 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.805 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mccaRoseGoldSize ' range=':= _default_ * mccaRoseGoldSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.866 * _default_ * mccaRoseGoldSize ' range=':= _default_ * mccaRoseGoldSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.897 * _default_ * mccaRoseGoldSize ' range=':= _default_ * mccaRoseGoldSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>

--- a/src/main/resources/config/modules/NetherOres.xml
+++ b/src/main/resources/config/modules/NetherOres.xml
@@ -1207,18 +1207,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 3.961 * _default_ * nthoCoalFreq ' range=':= _default_ * nthoCoalFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.582 * _default_ * nthoCoalSize ' range=':= _default_ * nthoCoalSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * nthoCoalSize ' range=':= _default_ * nthoCoalSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.582 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.990 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * nthoCoalSize ' range=':= _default_ * nthoCoalSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.582 * _default_ * nthoCoalSize ' range=':= _default_ * nthoCoalSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.411 * _default_ * nthoCoalSize ' range=':= _default_ * nthoCoalSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1326,18 +1326,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.478 * _default_ * nthoDiamondFreq ' range=':= _default_ * nthoDiamondFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.782 * _default_ * nthoDiamondSize ' range=':= _default_ * nthoDiamondSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * nthoDiamondSize ' range=':= _default_ * nthoDiamondSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.782 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.691 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * nthoDiamondSize ' range=':= _default_ * nthoDiamondSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.782 * _default_ * nthoDiamondSize ' range=':= _default_ * nthoDiamondSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.831 * _default_ * nthoDiamondSize ' range=':= _default_ * nthoDiamondSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1347,8 +1347,8 @@
                             <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:1")'> <Replaces block='NetherOres:tile.netherores.ore.0:1' weight='1.0' /> </IfCondition>
-                            <Setting name='MotherlodeSize' avg=':= 0.782 * _default_ * nthoDiamondSize  * 0.5 ' range=':= _default_ * nthoDiamondSize  * 0.5 ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.782 * _default_ * nthoDiamondSize  * 0.5 ' range=':= _default_ * nthoDiamondSize  * 0.5 ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * nthoDiamondSize  * 0.5 ' range=':= _default_ * nthoDiamondSize  * 0.5 ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.831 * _default_ * nthoDiamondSize  * 0.5 ' range=':= _default_ * nthoDiamondSize  * 0.5 ' type='normal' />
                             <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
                         </Veins>
                     </IfCondition>
@@ -1455,18 +1455,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.821 * _default_ * nthoGoldFreq ' range=':= _default_ * nthoGoldFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.936 * _default_ * nthoGoldSize ' range=':= _default_ * nthoGoldSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.968 * _default_ * nthoGoldSize ' range=':= _default_ * nthoGoldSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.936 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.906 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * nthoGoldSize ' range=':= _default_ * nthoGoldSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.936 * _default_ * nthoGoldSize ' range=':= _default_ * nthoGoldSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.952 * _default_ * nthoGoldSize ' range=':= _default_ * nthoGoldSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1574,18 +1574,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.948 * _default_ * nthoIronFreq ' range=':= _default_ * nthoIronFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.982 * _default_ * nthoIronSize ' range=':= _default_ * nthoIronSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.991 * _default_ * nthoIronSize ' range=':= _default_ * nthoIronSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.982 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.973 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * nthoIronSize ' range=':= _default_ * nthoIronSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.982 * _default_ * nthoIronSize ' range=':= _default_ * nthoIronSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.987 * _default_ * nthoIronSize ' range=':= _default_ * nthoIronSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1693,18 +1693,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.317 * _default_ * nthoLapisLazuliFreq ' range=':= _default_ * nthoLapisLazuliFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.096 * _default_ * nthoLapisLazuliSize ' range=':= _default_ * nthoLapisLazuliSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * nthoLapisLazuliSize ' range=':= _default_ * nthoLapisLazuliSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.096 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.148 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * nthoLapisLazuliSize ' range=':= _default_ * nthoLapisLazuliSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.096 * _default_ * nthoLapisLazuliSize ' range=':= _default_ * nthoLapisLazuliSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.071 * _default_ * nthoLapisLazuliSize ' range=':= _default_ * nthoLapisLazuliSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1813,18 +1813,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.521 * _default_ * nthoRedstoneFreq ' range=':= _default_ * nthoRedstoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.150 * _default_ * nthoRedstoneSize ' range=':= _default_ * nthoRedstoneSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * nthoRedstoneSize ' range=':= _default_ * nthoRedstoneSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.150 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.233 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * nthoRedstoneSize ' range=':= _default_ * nthoRedstoneSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.150 * _default_ * nthoRedstoneSize ' range=':= _default_ * nthoRedstoneSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.110 * _default_ * nthoRedstoneSize ' range=':= _default_ * nthoRedstoneSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1932,18 +1932,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.948 * _default_ * nthoCopperFreq ' range=':= _default_ * nthoCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.982 * _default_ * nthoCopperSize ' range=':= _default_ * nthoCopperSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.991 * _default_ * nthoCopperSize ' range=':= _default_ * nthoCopperSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.982 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.973 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * nthoCopperSize ' range=':= _default_ * nthoCopperSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.982 * _default_ * nthoCopperSize ' range=':= _default_ * nthoCopperSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.987 * _default_ * nthoCopperSize ' range=':= _default_ * nthoCopperSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -2051,18 +2051,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.948 * _default_ * nthoTinFreq ' range=':= _default_ * nthoTinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.982 * _default_ * nthoTinSize ' range=':= _default_ * nthoTinSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.991 * _default_ * nthoTinSize ' range=':= _default_ * nthoTinSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.982 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.973 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * nthoTinSize ' range=':= _default_ * nthoTinSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.982 * _default_ * nthoTinSize ' range=':= _default_ * nthoTinSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.987 * _default_ * nthoTinSize ' range=':= _default_ * nthoTinSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -2299,18 +2299,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.580 * _default_ * nthoSilverFreq ' range=':= _default_ * nthoSilverFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.834 * _default_ * nthoSilverSize ' range=':= _default_ * nthoSilverSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * nthoSilverSize ' range=':= _default_ * nthoSilverSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.834 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.581 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * nthoSilverSize ' range=':= _default_ * nthoSilverSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.834 * _default_ * nthoSilverSize ' range=':= _default_ * nthoSilverSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.762 * _default_ * nthoSilverSize ' range=':= _default_ * nthoSilverSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -2418,18 +2418,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.711 * _default_ * nthoLeadFreq ' range=':= _default_ * nthoLeadFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.892 * _default_ * nthoLeadSize ' range=':= _default_ * nthoLeadSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.913 * _default_ * nthoLeadSize ' range=':= _default_ * nthoLeadSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.892 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.762 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * nthoLeadSize ' range=':= _default_ * nthoLeadSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.892 * _default_ * nthoLeadSize ' range=':= _default_ * nthoLeadSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.873 * _default_ * nthoLeadSize ' range=':= _default_ * nthoLeadSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -2544,18 +2544,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.857 * _default_ * nthoUraniumFreq ' range=':= _default_ * nthoUraniumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.950 * _default_ * nthoUraniumSize ' range=':= _default_ * nthoUraniumSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * nthoUraniumSize ' range=':= _default_ * nthoUraniumSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.950 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.926 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * nthoUraniumSize ' range=':= _default_ * nthoUraniumSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.950 * _default_ * nthoUraniumSize ' range=':= _default_ * nthoUraniumSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.962 * _default_ * nthoUraniumSize ' range=':= _default_ * nthoUraniumSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -2663,18 +2663,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.242 * _default_ * nthoNikoliteFreq ' range=':= _default_ * nthoNikoliteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.075 * _default_ * nthoNikoliteSize ' range=':= _default_ * nthoNikoliteSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * nthoNikoliteSize ' range=':= _default_ * nthoNikoliteSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.075 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.114 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * nthoNikoliteSize ' range=':= _default_ * nthoNikoliteSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.075 * _default_ * nthoNikoliteSize ' range=':= _default_ * nthoNikoliteSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.056 * _default_ * nthoNikoliteSize ' range=':= _default_ * nthoNikoliteSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -2782,18 +2782,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.585 * _default_ * nthoRubyFreq ' range=':= _default_ * nthoRubyFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.836 * _default_ * nthoRubySize ' range=':= _default_ * nthoRubySize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * nthoRubySize ' range=':= _default_ * nthoRubySize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.836 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.765 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * nthoRubySize ' range=':= _default_ * nthoRubySize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.836 * _default_ * nthoRubySize ' range=':= _default_ * nthoRubySize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.875 * _default_ * nthoRubySize ' range=':= _default_ * nthoRubySize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -2803,8 +2803,8 @@
                             <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:13")'> <Replaces block='NetherOres:tile.netherores.ore.0:13' weight='1.0' /> </IfCondition>
-                            <Setting name='MotherlodeSize' avg=':= 0.836 * _default_ * nthoRubySize  * 0.5 ' range=':= _default_ * nthoRubySize  * 0.5 ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.836 * _default_ * nthoRubySize  * 0.5 ' range=':= _default_ * nthoRubySize  * 0.5 ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * nthoRubySize  * 0.5 ' range=':= _default_ * nthoRubySize  * 0.5 ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.875 * _default_ * nthoRubySize  * 0.5 ' range=':= _default_ * nthoRubySize  * 0.5 ' type='normal' />
                             <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
                         </Veins>
                     </IfCondition>
@@ -2911,18 +2911,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.585 * _default_ * nthoPeridotFreq ' range=':= _default_ * nthoPeridotFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.836 * _default_ * nthoPeridotSize ' range=':= _default_ * nthoPeridotSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * nthoPeridotSize ' range=':= _default_ * nthoPeridotSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.836 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.765 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * nthoPeridotSize ' range=':= _default_ * nthoPeridotSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.836 * _default_ * nthoPeridotSize ' range=':= _default_ * nthoPeridotSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.875 * _default_ * nthoPeridotSize ' range=':= _default_ * nthoPeridotSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -2932,8 +2932,8 @@
                             <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:14")'> <Replaces block='NetherOres:tile.netherores.ore.0:14' weight='1.0' /> </IfCondition>
-                            <Setting name='MotherlodeSize' avg=':= 0.836 * _default_ * nthoPeridotSize  * 0.5 ' range=':= _default_ * nthoPeridotSize  * 0.5 ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.836 * _default_ * nthoPeridotSize  * 0.5 ' range=':= _default_ * nthoPeridotSize  * 0.5 ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * nthoPeridotSize  * 0.5 ' range=':= _default_ * nthoPeridotSize  * 0.5 ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.875 * _default_ * nthoPeridotSize  * 0.5 ' range=':= _default_ * nthoPeridotSize  * 0.5 ' type='normal' />
                             <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
                         </Veins>
                     </IfCondition>
@@ -3040,18 +3040,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.585 * _default_ * nthoSapphireFreq ' range=':= _default_ * nthoSapphireFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.836 * _default_ * nthoSapphireSize ' range=':= _default_ * nthoSapphireSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * nthoSapphireSize ' range=':= _default_ * nthoSapphireSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.836 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.765 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * nthoSapphireSize ' range=':= _default_ * nthoSapphireSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.836 * _default_ * nthoSapphireSize ' range=':= _default_ * nthoSapphireSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.875 * _default_ * nthoSapphireSize ' range=':= _default_ * nthoSapphireSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -3061,8 +3061,8 @@
                             <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:15")'> <Replaces block='NetherOres:tile.netherores.ore.0:15' weight='1.0' /> </IfCondition>
-                            <Setting name='MotherlodeSize' avg=':= 0.836 * _default_ * nthoSapphireSize  * 0.5 ' range=':= _default_ * nthoSapphireSize  * 0.5 ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.836 * _default_ * nthoSapphireSize  * 0.5 ' range=':= _default_ * nthoSapphireSize  * 0.5 ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * nthoSapphireSize  * 0.5 ' range=':= _default_ * nthoSapphireSize  * 0.5 ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.875 * _default_ * nthoSapphireSize  * 0.5 ' range=':= _default_ * nthoSapphireSize  * 0.5 ' type='normal' />
                             <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
                         </Veins>
                     </IfCondition>
@@ -3169,18 +3169,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.205 * _default_ * nthoPlatinumFreq ' range=':= _default_ * nthoPlatinumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.590 * _default_ * nthoPlatinumSize ' range=':= _default_ * nthoPlatinumSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.768 * _default_ * nthoPlatinumSize ' range=':= _default_ * nthoPlatinumSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.590 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.453 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * nthoPlatinumSize ' range=':= _default_ * nthoPlatinumSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.590 * _default_ * nthoPlatinumSize ' range=':= _default_ * nthoPlatinumSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.673 * _default_ * nthoPlatinumSize ' range=':= _default_ * nthoPlatinumSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -3288,18 +3288,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.580 * _default_ * nthoNickelFreq ' range=':= _default_ * nthoNickelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.834 * _default_ * nthoNickelSize ' range=':= _default_ * nthoNickelSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.913 * _default_ * nthoNickelSize ' range=':= _default_ * nthoNickelSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.834 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.762 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * nthoNickelSize ' range=':= _default_ * nthoNickelSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.834 * _default_ * nthoNickelSize ' range=':= _default_ * nthoNickelSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.873 * _default_ * nthoNickelSize ' range=':= _default_ * nthoNickelSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -3407,18 +3407,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.410 * _default_ * nthoSteelFreq ' range=':= _default_ * nthoSteelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.743 * _default_ * nthoSteelSize ' range=':= _default_ * nthoSteelSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.862 * _default_ * nthoSteelSize ' range=':= _default_ * nthoSteelSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.743 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.641 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * nthoSteelSize ' range=':= _default_ * nthoSteelSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.743 * _default_ * nthoSteelSize ' range=':= _default_ * nthoSteelSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.800 * _default_ * nthoSteelSize ' range=':= _default_ * nthoSteelSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -3528,18 +3528,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.270 * _default_ * nthoIridiumFreq ' range=':= _default_ * nthoIridiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.647 * _default_ * nthoIridiumSize ' range=':= _default_ * nthoIridiumSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.804 * _default_ * nthoIridiumSize ' range=':= _default_ * nthoIridiumSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.647 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0 ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * nthoIridiumSize ' range=':= _default_ * nthoIridiumSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.647 * _default_ * nthoIridiumSize ' range=':= _default_ * nthoIridiumSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0 * nthoIridiumSize ' range=':= _default_ * nthoIridiumSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -3647,18 +3647,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.886 * _default_ * nthoOsmiumFreq ' range=':= _default_ * nthoOsmiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.961 * _default_ * nthoOsmiumSize ' range=':= _default_ * nthoOsmiumSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.980 * _default_ * nthoOsmiumSize ' range=':= _default_ * nthoOsmiumSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.961 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.941 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * nthoOsmiumSize ' range=':= _default_ * nthoOsmiumSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.961 * _default_ * nthoOsmiumSize ' range=':= _default_ * nthoOsmiumSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.970 * _default_ * nthoOsmiumSize ' range=':= _default_ * nthoOsmiumSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -3766,18 +3766,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.655 * _default_ * nthoSulfurFreq ' range=':= _default_ * nthoSulfurFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.183 * _default_ * nthoSulfurSize ' range=':= _default_ * nthoSulfurSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * nthoSulfurSize ' range=':= _default_ * nthoSulfurSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.183 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.287 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * nthoSulfurSize ' range=':= _default_ * nthoSulfurSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.183 * _default_ * nthoSulfurSize ' range=':= _default_ * nthoSulfurSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.134 * _default_ * nthoSulfurSize ' range=':= _default_ * nthoSulfurSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -3787,8 +3787,8 @@
                             <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:5")'> <Replaces block='NetherOres:tile.netherores.ore.1:5' weight='1.0' /> </IfCondition>
-                            <Setting name='MotherlodeSize' avg=':= 1.183 * _default_ * nthoSulfurSize  * 0.5 ' range=':= _default_ * nthoSulfurSize  * 0.5 ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.183 * _default_ * nthoSulfurSize  * 0.5 ' range=':= _default_ * nthoSulfurSize  * 0.5 ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * nthoSulfurSize  * 0.5 ' range=':= _default_ * nthoSulfurSize  * 0.5 ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.134 * _default_ * nthoSulfurSize  * 0.5 ' range=':= _default_ * nthoSulfurSize  * 0.5 ' type='normal' />
                             <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
                         </Veins>
                     </IfCondition>
@@ -3895,18 +3895,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.290 * _default_ * nthoTitaniumFreq ' range=':= _default_ * nthoTitaniumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.662 * _default_ * nthoTitaniumSize ' range=':= _default_ * nthoTitaniumSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.814 * _default_ * nthoTitaniumSize ' range=':= _default_ * nthoTitaniumSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.662 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.539 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * nthoTitaniumSize ' range=':= _default_ * nthoTitaniumSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.662 * _default_ * nthoTitaniumSize ' range=':= _default_ * nthoTitaniumSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.734 * _default_ * nthoTitaniumSize ' range=':= _default_ * nthoTitaniumSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -4014,18 +4014,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.711 * _default_ * nthoMithrilFreq ' range=':= _default_ * nthoMithrilFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.892 * _default_ * nthoMithrilSize ' range=':= _default_ * nthoMithrilSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.945 * _default_ * nthoMithrilSize ' range=':= _default_ * nthoMithrilSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.892 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.843 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * nthoMithrilSize ' range=':= _default_ * nthoMithrilSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.892 * _default_ * nthoMithrilSize ' range=':= _default_ * nthoMithrilSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.918 * _default_ * nthoMithrilSize ' range=':= _default_ * nthoMithrilSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -4133,18 +4133,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.530 * _default_ * nthoAdamantiumFreq ' range=':= _default_ * nthoAdamantiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.809 * _default_ * nthoAdamantiumSize ' range=':= _default_ * nthoAdamantiumSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.900 * _default_ * nthoAdamantiumSize ' range=':= _default_ * nthoAdamantiumSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.809 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.728 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * nthoAdamantiumSize ' range=':= _default_ * nthoAdamantiumSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.809 * _default_ * nthoAdamantiumSize ' range=':= _default_ * nthoAdamantiumSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.853 * _default_ * nthoAdamantiumSize ' range=':= _default_ * nthoAdamantiumSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -4252,18 +4252,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.410 * _default_ * nthoRutileFreq ' range=':= _default_ * nthoRutileFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.743 * _default_ * nthoRutileSize ' range=':= _default_ * nthoRutileSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.862 * _default_ * nthoRutileSize ' range=':= _default_ * nthoRutileSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.743 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.641 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * nthoRutileSize ' range=':= _default_ * nthoRutileSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.743 * _default_ * nthoRutileSize ' range=':= _default_ * nthoRutileSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.800 * _default_ * nthoRutileSize ' range=':= _default_ * nthoRutileSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -4371,18 +4371,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.948 * _default_ * nthoTungstenFreq ' range=':= _default_ * nthoTungstenFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.982 * _default_ * nthoTungstenSize ' range=':= _default_ * nthoTungstenSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.991 * _default_ * nthoTungstenSize ' range=':= _default_ * nthoTungstenSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.982 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.973 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * nthoTungstenSize ' range=':= _default_ * nthoTungstenSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.982 * _default_ * nthoTungstenSize ' range=':= _default_ * nthoTungstenSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.987 * _default_ * nthoTungstenSize ' range=':= _default_ * nthoTungstenSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -4497,18 +4497,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.917 * _default_ * nthoAmberFreq ' range=':= _default_ * nthoAmberFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.242 * _default_ * nthoAmberSize ' range=':= _default_ * nthoAmberSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * nthoAmberSize ' range=':= _default_ * nthoAmberSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.242 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.385 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * nthoAmberSize ' range=':= _default_ * nthoAmberSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.242 * _default_ * nthoAmberSize ' range=':= _default_ * nthoAmberSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.177 * _default_ * nthoAmberSize ' range=':= _default_ * nthoAmberSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -4616,18 +4616,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.948 * _default_ * nthoTennantiteFreq ' range=':= _default_ * nthoTennantiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.982 * _default_ * nthoTennantiteSize ' range=':= _default_ * nthoTennantiteSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.991 * _default_ * nthoTennantiteSize ' range=':= _default_ * nthoTennantiteSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.982 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.973 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * nthoTennantiteSize ' range=':= _default_ * nthoTennantiteSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.982 * _default_ * nthoTennantiteSize ' range=':= _default_ * nthoTennantiteSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.987 * _default_ * nthoTennantiteSize ' range=':= _default_ * nthoTennantiteSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -4742,18 +4742,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.750 * _default_ * nthoSaltFreq ' range=':= _default_ * nthoSaltFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.205 * _default_ * nthoSaltSize ' range=':= _default_ * nthoSaltSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * nthoSaltSize ' range=':= _default_ * nthoSaltSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.205 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.323 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * nthoSaltSize ' range=':= _default_ * nthoSaltSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.205 * _default_ * nthoSaltSize ' range=':= _default_ * nthoSaltSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.150 * _default_ * nthoSaltSize ' range=':= _default_ * nthoSaltSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -4868,18 +4868,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.715 * _default_ * nthoSaltpeterFreq ' range=':= _default_ * nthoSaltpeterFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.197 * _default_ * nthoSaltpeterSize ' range=':= _default_ * nthoSaltpeterSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * nthoSaltpeterSize ' range=':= _default_ * nthoSaltpeterSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.197 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.310 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * nthoSaltpeterSize ' range=':= _default_ * nthoSaltpeterSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.197 * _default_ * nthoSaltpeterSize ' range=':= _default_ * nthoSaltpeterSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.144 * _default_ * nthoSaltpeterSize ' range=':= _default_ * nthoSaltpeterSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -4994,18 +4994,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.566 * _default_ * nthoMagnesiumFreq ' range=':= _default_ * nthoMagnesiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.161 * _default_ * nthoMagnesiumSize ' range=':= _default_ * nthoMagnesiumSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * nthoMagnesiumSize ' range=':= _default_ * nthoMagnesiumSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.161 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.251 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * nthoMagnesiumSize ' range=':= _default_ * nthoMagnesiumSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.161 * _default_ * nthoMagnesiumSize ' range=':= _default_ * nthoMagnesiumSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.119 * _default_ * nthoMagnesiumSize ' range=':= _default_ * nthoMagnesiumSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>

--- a/src/main/resources/config/modules/NetherOres.xml
+++ b/src/main/resources/config/modules/NetherOres.xml
@@ -1,5721 +1,5125 @@
- <!-- ================================================================
-      Custom Ore Generation "Nether Ores" Module: This configuration
-      covers coal, diamond, gold, iron, lapis lazuli, redstone,
-      copper, tin,  emerald, silver, lead, uranium, nikolite, ruby,
-      peridot, sapphire,  platinum, ferrous, pig iron, iridium,
-      osmium, sulphur, titanium,  mithril, adamantium, rutile,
-      tungsten, amber, tennantite, salt,  saltpeter, and magnesium.
-      ================================================================
-      -->
+<!-- =================================================================
+     Custom Ore Generation "Nether Ores" Module: This configuration
+     covers coal, diamond, gold, iron, lapis lazuli, redstone, copper,
+     tin, emerald, silver, lead, uranium, nikolite, ruby, peridot,
+     sapphire, platinum, nickel, steel, iridium, osmium, sulfur,
+     titanium, mithril, adamantium, rutile, tungsten, amber,
+     tennantite, salt, saltpeter, and magnesium.
+     ================================================================= -->
 
-    <!-- Mod detection -->
-    <IfModInstalled name="NetherOres">
-    
-        <!-- Starting Configuration for Custom Ore Generation. -->
+
+
+
+
+
+<!-- Is the "Nether Ores" mod on the system?  Let's find out! -->
+<IfModInstalled name="NetherOres">
+
+    <!-- Starting Configuration for Custom Ore Generation. -->
+    <ConfigSection>
+
+
+
+
+
+        <!-- Setup Screen Configuration -->
         <ConfigSection>
-        
-            
-            <!-- Setup Screen Configuration -->
+            <OptionDisplayGroup name='groupNetherOres' displayName='Nether Ores' displayState='shown'>
+                <Description>
+                    Distribution options for Nether Ores Ores.
+                </Description>
+            </OptionDisplayGroup>
+            <OptionChoice name='enableNetherOres' displayName='Handle Nether Ores Setup?' default='true' displayState='shown_dynamic' displayGroup='groupNetherOres'>
+                <Description> Should Custom Ore Generation handle Nether Ores ore generation? </Description>
+                <Choice value=':= ?true' displayValue='Yes' description='Use Custom Ore Generation to handle Nether Ores ores.'/>
+                <Choice value=':= ?false' displayValue='No' description='Nether Ores ores will be handled by the mod itself.'/>
+            </OptionChoice>
+
+            <!-- Coal Configuration UI Starting -->
             <ConfigSection>
-                <OptionDisplayGroup name='groupNetherOres' displayName='Nether Ores' displayState='shown'> 
-                    <Description>
-                        Distribution options for Nether Ores Ores.
-                    </Description>
-                </OptionDisplayGroup>
-                
-                <!-- Coal Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='nthoCoalDist'  displayState='shown' displayGroup='groupNetherOres'> 
-                        <Description> Controls how Coal is generated </Description> 
-                        <DisplayName>Nether Ores Coal</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Coal is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='nthoCoalFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherOres'>
-                        <Description> Frequency multiplier for Nether Ores Coal distributions </Description>
-                        <DisplayName>Nether Ores Coal Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='nthoCoalSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherOres'>
-                        <Description> Size multiplier for Nether Ores Coal distributions </Description>
-                        <DisplayName>Nether Ores Coal Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Coal Configuration UI Complete -->
-                
-                
-                <!-- Diamond Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='nthoDiamondDist'  displayState='shown' displayGroup='groupNetherOres'> 
-                        <Description> Controls how Diamond is generated </Description> 
-                        <DisplayName>Nether Ores Diamond</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Diamond is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='nthoDiamondFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherOres'>
-                        <Description> Frequency multiplier for Nether Ores Diamond distributions </Description>
-                        <DisplayName>Nether Ores Diamond Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='nthoDiamondSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherOres'>
-                        <Description> Size multiplier for Nether Ores Diamond distributions </Description>
-                        <DisplayName>Nether Ores Diamond Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Diamond Configuration UI Complete -->
-                
-                
-                <!-- Gold Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='nthoGoldDist'  displayState='shown' displayGroup='groupNetherOres'> 
-                        <Description> Controls how Gold is generated </Description> 
-                        <DisplayName>Nether Ores Gold</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Gold is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='nthoGoldFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherOres'>
-                        <Description> Frequency multiplier for Nether Ores Gold distributions </Description>
-                        <DisplayName>Nether Ores Gold Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='nthoGoldSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherOres'>
-                        <Description> Size multiplier for Nether Ores Gold distributions </Description>
-                        <DisplayName>Nether Ores Gold Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Gold Configuration UI Complete -->
-                
-                
-                <!-- Iron Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='nthoIronDist'  displayState='shown' displayGroup='groupNetherOres'> 
-                        <Description> Controls how Iron is generated </Description> 
-                        <DisplayName>Nether Ores Iron</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Iron is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='nthoIronFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherOres'>
-                        <Description> Frequency multiplier for Nether Ores Iron distributions </Description>
-                        <DisplayName>Nether Ores Iron Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='nthoIronSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherOres'>
-                        <Description> Size multiplier for Nether Ores Iron distributions </Description>
-                        <DisplayName>Nether Ores Iron Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Iron Configuration UI Complete -->
-                
-                
-                <!-- Lapis Lazuli Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='nthoLapisLazuliDist'  displayState='shown' displayGroup='groupNetherOres'> 
-                        <Description> Controls how Lapis Lazuli is generated </Description> 
-                        <DisplayName>Nether Ores Lapis Lazuli</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Lapis Lazuli is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='nthoLapisLazuliFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherOres'>
-                        <Description> Frequency multiplier for Nether Ores Lapis Lazuli distributions </Description>
-                        <DisplayName>Nether Ores Lapis Lazuli Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='nthoLapisLazuliSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherOres'>
-                        <Description> Size multiplier for Nether Ores Lapis Lazuli distributions </Description>
-                        <DisplayName>Nether Ores Lapis Lazuli Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Lapis Lazuli Configuration UI Complete -->
-                
-                
-                <!-- Redstone Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='nthoRedstoneDist'  displayState='shown' displayGroup='groupNetherOres'> 
-                        <Description> Controls how Redstone is generated </Description> 
-                        <DisplayName>Nether Ores Redstone</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Redstone is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='nthoRedstoneFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherOres'>
-                        <Description> Frequency multiplier for Nether Ores Redstone distributions </Description>
-                        <DisplayName>Nether Ores Redstone Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='nthoRedstoneSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherOres'>
-                        <Description> Size multiplier for Nether Ores Redstone distributions </Description>
-                        <DisplayName>Nether Ores Redstone Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Redstone Configuration UI Complete -->
-                
-                
-                <!-- Copper Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='nthoCopperDist'  displayState='shown' displayGroup='groupNetherOres'> 
-                        <Description> Controls how Copper is generated </Description> 
-                        <DisplayName>Nether Ores Copper</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Copper is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='nthoCopperFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherOres'>
-                        <Description> Frequency multiplier for Nether Ores Copper distributions </Description>
-                        <DisplayName>Nether Ores Copper Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='nthoCopperSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherOres'>
-                        <Description> Size multiplier for Nether Ores Copper distributions </Description>
-                        <DisplayName>Nether Ores Copper Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Copper Configuration UI Complete -->
-                
-                
-                <!-- Tin Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='nthoTinDist'  displayState='shown' displayGroup='groupNetherOres'> 
-                        <Description> Controls how Tin is generated </Description> 
-                        <DisplayName>Nether Ores Tin</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Tin is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='nthoTinFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherOres'>
-                        <Description> Frequency multiplier for Nether Ores Tin distributions </Description>
-                        <DisplayName>Nether Ores Tin Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='nthoTinSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherOres'>
-                        <Description> Size multiplier for Nether Ores Tin distributions </Description>
-                        <DisplayName>Nether Ores Tin Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Tin Configuration UI Complete -->
-                
-                
-                <!-- Emerald Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='nthoEmeraldDist'  displayState='shown' displayGroup='groupNetherOres'> 
-                        <Description> Controls how Emerald is generated </Description> 
-                        <DisplayName>Nether Ores Emerald</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Emerald is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='nthoEmeraldFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherOres'>
-                        <Description> Frequency multiplier for Nether Ores Emerald distributions </Description>
-                        <DisplayName>Nether Ores Emerald Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='nthoEmeraldSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherOres'>
-                        <Description> Size multiplier for Nether Ores Emerald distributions </Description>
-                        <DisplayName>Nether Ores Emerald Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Emerald Configuration UI Complete -->
-                
-                
-                <!-- Silver Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='nthoSilverDist'  displayState='shown' displayGroup='groupNetherOres'> 
-                        <Description> Controls how Silver is generated </Description> 
-                        <DisplayName>Nether Ores Silver</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Silver is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='nthoSilverFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherOres'>
-                        <Description> Frequency multiplier for Nether Ores Silver distributions </Description>
-                        <DisplayName>Nether Ores Silver Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='nthoSilverSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherOres'>
-                        <Description> Size multiplier for Nether Ores Silver distributions </Description>
-                        <DisplayName>Nether Ores Silver Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Silver Configuration UI Complete -->
-                
-                
-                <!-- Lead Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='nthoLeadDist'  displayState='shown' displayGroup='groupNetherOres'> 
-                        <Description> Controls how Lead is generated </Description> 
-                        <DisplayName>Nether Ores Lead</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Lead is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='nthoLeadFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherOres'>
-                        <Description> Frequency multiplier for Nether Ores Lead distributions </Description>
-                        <DisplayName>Nether Ores Lead Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='nthoLeadSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherOres'>
-                        <Description> Size multiplier for Nether Ores Lead distributions </Description>
-                        <DisplayName>Nether Ores Lead Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Lead Configuration UI Complete -->
-                
-                
-                <!-- Uranium Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='nthoUraniumDist'  displayState='shown' displayGroup='groupNetherOres'> 
-                        <Description> Controls how Uranium is generated </Description> 
-                        <DisplayName>Nether Ores Uranium</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Uranium is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='nthoUraniumFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherOres'>
-                        <Description> Frequency multiplier for Nether Ores Uranium distributions </Description>
-                        <DisplayName>Nether Ores Uranium Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='nthoUraniumSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherOres'>
-                        <Description> Size multiplier for Nether Ores Uranium distributions </Description>
-                        <DisplayName>Nether Ores Uranium Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Uranium Configuration UI Complete -->
-                
-                
-                <!-- Nikolite Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='nthoNikoliteDist'  displayState='shown' displayGroup='groupNetherOres'> 
-                        <Description> Controls how Nikolite is generated </Description> 
-                        <DisplayName>Nether Ores Nikolite</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Nikolite is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='nthoNikoliteFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherOres'>
-                        <Description> Frequency multiplier for Nether Ores Nikolite distributions </Description>
-                        <DisplayName>Nether Ores Nikolite Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='nthoNikoliteSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherOres'>
-                        <Description> Size multiplier for Nether Ores Nikolite distributions </Description>
-                        <DisplayName>Nether Ores Nikolite Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Nikolite Configuration UI Complete -->
-                
-                
-                <!-- Ruby Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='nthoRubyDist'  displayState='shown' displayGroup='groupNetherOres'> 
-                        <Description> Controls how Ruby is generated </Description> 
-                        <DisplayName>Nether Ores Ruby</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Ruby is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='nthoRubyFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherOres'>
-                        <Description> Frequency multiplier for Nether Ores Ruby distributions </Description>
-                        <DisplayName>Nether Ores Ruby Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='nthoRubySize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherOres'>
-                        <Description> Size multiplier for Nether Ores Ruby distributions </Description>
-                        <DisplayName>Nether Ores Ruby Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Ruby Configuration UI Complete -->
-                
-                
-                <!-- Peridot Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='nthoPeridotDist'  displayState='shown' displayGroup='groupNetherOres'> 
-                        <Description> Controls how Peridot is generated </Description> 
-                        <DisplayName>Nether Ores Peridot</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Peridot is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='nthoPeridotFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherOres'>
-                        <Description> Frequency multiplier for Nether Ores Peridot distributions </Description>
-                        <DisplayName>Nether Ores Peridot Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='nthoPeridotSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherOres'>
-                        <Description> Size multiplier for Nether Ores Peridot distributions </Description>
-                        <DisplayName>Nether Ores Peridot Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Peridot Configuration UI Complete -->
-                
-                
-                <!-- Sapphire Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='nthoSapphireDist'  displayState='shown' displayGroup='groupNetherOres'> 
-                        <Description> Controls how Sapphire is generated </Description> 
-                        <DisplayName>Nether Ores Sapphire</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Sapphire is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='nthoSapphireFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherOres'>
-                        <Description> Frequency multiplier for Nether Ores Sapphire distributions </Description>
-                        <DisplayName>Nether Ores Sapphire Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='nthoSapphireSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherOres'>
-                        <Description> Size multiplier for Nether Ores Sapphire distributions </Description>
-                        <DisplayName>Nether Ores Sapphire Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Sapphire Configuration UI Complete -->
-                
-                
-                <!-- Platinum Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='nthoPlatinumDist'  displayState='shown' displayGroup='groupNetherOres'> 
-                        <Description> Controls how Platinum is generated </Description> 
-                        <DisplayName>Nether Ores Platinum</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Platinum is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='nthoPlatinumFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherOres'>
-                        <Description> Frequency multiplier for Nether Ores Platinum distributions </Description>
-                        <DisplayName>Nether Ores Platinum Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='nthoPlatinumSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherOres'>
-                        <Description> Size multiplier for Nether Ores Platinum distributions </Description>
-                        <DisplayName>Nether Ores Platinum Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Platinum Configuration UI Complete -->
-                
-                
-                <!-- Ferrous Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='nthoFerrousDist'  displayState='shown' displayGroup='groupNetherOres'> 
-                        <Description> Controls how Ferrous is generated </Description> 
-                        <DisplayName>Nether Ores Ferrous</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Ferrous is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='nthoFerrousFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherOres'>
-                        <Description> Frequency multiplier for Nether Ores Ferrous distributions </Description>
-                        <DisplayName>Nether Ores Ferrous Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='nthoFerrousSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherOres'>
-                        <Description> Size multiplier for Nether Ores Ferrous distributions </Description>
-                        <DisplayName>Nether Ores Ferrous Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Ferrous Configuration UI Complete -->
-                
-                
-                <!-- Pig Iron Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='nthoPigIronDist'  displayState='shown' displayGroup='groupNetherOres'> 
-                        <Description> Controls how Pig Iron is generated </Description> 
-                        <DisplayName>Nether Ores Pig Iron</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Pig Iron is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='nthoPigIronFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherOres'>
-                        <Description> Frequency multiplier for Nether Ores Pig Iron distributions </Description>
-                        <DisplayName>Nether Ores Pig Iron Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='nthoPigIronSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherOres'>
-                        <Description> Size multiplier for Nether Ores Pig Iron distributions </Description>
-                        <DisplayName>Nether Ores Pig Iron Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Pig Iron Configuration UI Complete -->
-                
-                
-                <!-- Iridium Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='nthoIridiumDist'  displayState='shown' displayGroup='groupNetherOres'> 
-                        <Description> Controls how Iridium is generated </Description> 
-                        <DisplayName>Nether Ores Iridium</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Iridium is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='nthoIridiumFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherOres'>
-                        <Description> Frequency multiplier for Nether Ores Iridium distributions </Description>
-                        <DisplayName>Nether Ores Iridium Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='nthoIridiumSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherOres'>
-                        <Description> Size multiplier for Nether Ores Iridium distributions </Description>
-                        <DisplayName>Nether Ores Iridium Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Iridium Configuration UI Complete -->
-                
-                
-                <!-- Osmium Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='nthoOsmiumDist'  displayState='shown' displayGroup='groupNetherOres'> 
-                        <Description> Controls how Osmium is generated </Description> 
-                        <DisplayName>Nether Ores Osmium</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Osmium is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='nthoOsmiumFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherOres'>
-                        <Description> Frequency multiplier for Nether Ores Osmium distributions </Description>
-                        <DisplayName>Nether Ores Osmium Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='nthoOsmiumSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherOres'>
-                        <Description> Size multiplier for Nether Ores Osmium distributions </Description>
-                        <DisplayName>Nether Ores Osmium Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Osmium Configuration UI Complete -->
-                
-                
-                <!-- Sulphur Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='nthoSulphurDist'  displayState='shown' displayGroup='groupNetherOres'> 
-                        <Description> Controls how Sulphur is generated </Description> 
-                        <DisplayName>Nether Ores Sulphur</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Sulphur is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='nthoSulphurFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherOres'>
-                        <Description> Frequency multiplier for Nether Ores Sulphur distributions </Description>
-                        <DisplayName>Nether Ores Sulphur Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='nthoSulphurSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherOres'>
-                        <Description> Size multiplier for Nether Ores Sulphur distributions </Description>
-                        <DisplayName>Nether Ores Sulphur Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Sulphur Configuration UI Complete -->
-                
-                
-                <!-- Titanium Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='nthoTitaniumDist'  displayState='shown' displayGroup='groupNetherOres'> 
-                        <Description> Controls how Titanium is generated </Description> 
-                        <DisplayName>Nether Ores Titanium</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Titanium is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='nthoTitaniumFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherOres'>
-                        <Description> Frequency multiplier for Nether Ores Titanium distributions </Description>
-                        <DisplayName>Nether Ores Titanium Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='nthoTitaniumSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherOres'>
-                        <Description> Size multiplier for Nether Ores Titanium distributions </Description>
-                        <DisplayName>Nether Ores Titanium Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Titanium Configuration UI Complete -->
-                
-                
-                <!-- Mithril Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='nthoMithrilDist'  displayState='shown' displayGroup='groupNetherOres'> 
-                        <Description> Controls how Mithril is generated </Description> 
-                        <DisplayName>Nether Ores Mithril</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Mithril is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='nthoMithrilFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherOres'>
-                        <Description> Frequency multiplier for Nether Ores Mithril distributions </Description>
-                        <DisplayName>Nether Ores Mithril Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='nthoMithrilSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherOres'>
-                        <Description> Size multiplier for Nether Ores Mithril distributions </Description>
-                        <DisplayName>Nether Ores Mithril Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Mithril Configuration UI Complete -->
-                
-                
-                <!-- Adamantium Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='nthoAdamantiumDist'  displayState='shown' displayGroup='groupNetherOres'> 
-                        <Description> Controls how Adamantium is generated </Description> 
-                        <DisplayName>Nether Ores Adamantium</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Adamantium is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='nthoAdamantiumFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherOres'>
-                        <Description> Frequency multiplier for Nether Ores Adamantium distributions </Description>
-                        <DisplayName>Nether Ores Adamantium Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='nthoAdamantiumSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherOres'>
-                        <Description> Size multiplier for Nether Ores Adamantium distributions </Description>
-                        <DisplayName>Nether Ores Adamantium Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Adamantium Configuration UI Complete -->
-                
-                
-                <!-- Rutile Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='nthoRutileDist'  displayState='shown' displayGroup='groupNetherOres'> 
-                        <Description> Controls how Rutile is generated </Description> 
-                        <DisplayName>Nether Ores Rutile</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Rutile is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='nthoRutileFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherOres'>
-                        <Description> Frequency multiplier for Nether Ores Rutile distributions </Description>
-                        <DisplayName>Nether Ores Rutile Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='nthoRutileSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherOres'>
-                        <Description> Size multiplier for Nether Ores Rutile distributions </Description>
-                        <DisplayName>Nether Ores Rutile Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Rutile Configuration UI Complete -->
-                
-                
-                <!-- Tungsten Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='nthoTungstenDist'  displayState='shown' displayGroup='groupNetherOres'> 
-                        <Description> Controls how Tungsten is generated </Description> 
-                        <DisplayName>Nether Ores Tungsten</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Tungsten is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='nthoTungstenFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherOres'>
-                        <Description> Frequency multiplier for Nether Ores Tungsten distributions </Description>
-                        <DisplayName>Nether Ores Tungsten Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='nthoTungstenSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherOres'>
-                        <Description> Size multiplier for Nether Ores Tungsten distributions </Description>
-                        <DisplayName>Nether Ores Tungsten Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Tungsten Configuration UI Complete -->
-                
-                
-                <!-- Amber Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='nthoAmberDist'  displayState='shown' displayGroup='groupNetherOres'> 
-                        <Description> Controls how Amber is generated </Description> 
-                        <DisplayName>Nether Ores Amber</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Amber is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='nthoAmberFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherOres'>
-                        <Description> Frequency multiplier for Nether Ores Amber distributions </Description>
-                        <DisplayName>Nether Ores Amber Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='nthoAmberSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherOres'>
-                        <Description> Size multiplier for Nether Ores Amber distributions </Description>
-                        <DisplayName>Nether Ores Amber Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Amber Configuration UI Complete -->
-                
-                
-                <!-- Tennantite Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='nthoTennantiteDist'  displayState='shown' displayGroup='groupNetherOres'> 
-                        <Description> Controls how Tennantite is generated </Description> 
-                        <DisplayName>Nether Ores Tennantite</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Tennantite is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='nthoTennantiteFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherOres'>
-                        <Description> Frequency multiplier for Nether Ores Tennantite distributions </Description>
-                        <DisplayName>Nether Ores Tennantite Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='nthoTennantiteSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherOres'>
-                        <Description> Size multiplier for Nether Ores Tennantite distributions </Description>
-                        <DisplayName>Nether Ores Tennantite Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Tennantite Configuration UI Complete -->
-                
-                
-                <!-- Salt Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='nthoSaltDist'  displayState='shown' displayGroup='groupNetherOres'> 
-                        <Description> Controls how Salt is generated </Description> 
-                        <DisplayName>Nether Ores Salt</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Salt is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='nthoSaltFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherOres'>
-                        <Description> Frequency multiplier for Nether Ores Salt distributions </Description>
-                        <DisplayName>Nether Ores Salt Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='nthoSaltSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherOres'>
-                        <Description> Size multiplier for Nether Ores Salt distributions </Description>
-                        <DisplayName>Nether Ores Salt Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Salt Configuration UI Complete -->
-                
-                
-                <!-- Saltpeter Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='nthoSaltpeterDist'  displayState='shown' displayGroup='groupNetherOres'> 
-                        <Description> Controls how Saltpeter is generated </Description> 
-                        <DisplayName>Nether Ores Saltpeter</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Saltpeter is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='nthoSaltpeterFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherOres'>
-                        <Description> Frequency multiplier for Nether Ores Saltpeter distributions </Description>
-                        <DisplayName>Nether Ores Saltpeter Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='nthoSaltpeterSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherOres'>
-                        <Description> Size multiplier for Nether Ores Saltpeter distributions </Description>
-                        <DisplayName>Nether Ores Saltpeter Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Saltpeter Configuration UI Complete -->
-                
-                
-                <!-- Magnesium Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='nthoMagnesiumDist'  displayState='shown' displayGroup='groupNetherOres'> 
-                        <Description> Controls how Magnesium is generated </Description> 
-                        <DisplayName>Nether Ores Magnesium</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Magnesium is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='nthoMagnesiumFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherOres'>
-                        <Description> Frequency multiplier for Nether Ores Magnesium distributions </Description>
-                        <DisplayName>Nether Ores Magnesium Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='nthoMagnesiumSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherOres'>
-                        <Description> Size multiplier for Nether Ores Magnesium distributions </Description>
-                        <DisplayName>Nether Ores Magnesium Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Magnesium Configuration UI Complete -->
-                
+                <OptionChoice name='nthoCoalDist'  displayState=':= if(?enableNetherOres, "shown", "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Controls how Coal is generated </Description>
+                    <DisplayName>Nether Ores Coal</DisplayName>
+                    <Choice value='SparseVeins' displayValue='Sparse Veins'>
+                        <Description>
+                            Large veins filled very lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Coal is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='nthoCoalFreq' default='1'  min='0' max='5' displayState=':= if(?enableNetherOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Frequency multiplier for Nether Ores Coal distributions </Description>
+                    <DisplayName>Nether Ores Coal Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='nthoCoalSize' default='1'  min='0' max='5' displayState=':= if(?enableNetherOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Size multiplier for Nether Ores Coal distributions </Description>
+                    <DisplayName>Nether Ores Coal Size</DisplayName>
+                </OptionNumeric>
             </ConfigSection>
-            <!-- Setup Screen Complete -->
+            <!-- Coal Configuration UI Complete -->
 
 
-            <!-- Setup Nether -->
+            <!-- Diamond Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='nthoDiamondDist'  displayState=':= if(?enableNetherOres, "shown", "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Controls how Diamond is generated </Description>
+                    <DisplayName>Nether Ores Diamond</DisplayName>
+                    <Choice value='PipeVeins' displayValue='Pipe Veins'>
+                        <Description>
+                            Short and sparsely filled compound veins containing one material inside another.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Diamond is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='nthoDiamondFreq' default='1'  min='0' max='5' displayState=':= if(?enableNetherOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Frequency multiplier for Nether Ores Diamond distributions </Description>
+                    <DisplayName>Nether Ores Diamond Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='nthoDiamondSize' default='1'  min='0' max='5' displayState=':= if(?enableNetherOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Size multiplier for Nether Ores Diamond distributions </Description>
+                    <DisplayName>Nether Ores Diamond Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Diamond Configuration UI Complete -->
+
+
+            <!-- Gold Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='nthoGoldDist'  displayState=':= if(?enableNetherOres, "shown", "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Controls how Gold is generated </Description>
+                    <DisplayName>Nether Ores Gold</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                        <Description>
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Gold is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='nthoGoldFreq' default='1'  min='0' max='5' displayState=':= if(?enableNetherOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Frequency multiplier for Nether Ores Gold distributions </Description>
+                    <DisplayName>Nether Ores Gold Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='nthoGoldSize' default='1'  min='0' max='5' displayState=':= if(?enableNetherOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Size multiplier for Nether Ores Gold distributions </Description>
+                    <DisplayName>Nether Ores Gold Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Gold Configuration UI Complete -->
+
+
+            <!-- Iron Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='nthoIronDist'  displayState=':= if(?enableNetherOres, "shown", "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Controls how Iron is generated </Description>
+                    <DisplayName>Nether Ores Iron</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                        <Description>
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Iron is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='nthoIronFreq' default='1'  min='0' max='5' displayState=':= if(?enableNetherOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Frequency multiplier for Nether Ores Iron distributions </Description>
+                    <DisplayName>Nether Ores Iron Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='nthoIronSize' default='1'  min='0' max='5' displayState=':= if(?enableNetherOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Size multiplier for Nether Ores Iron distributions </Description>
+                    <DisplayName>Nether Ores Iron Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Iron Configuration UI Complete -->
+
+
+            <!-- Lapis Lazuli Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='nthoLapisLazuliDist'  displayState=':= if(?enableNetherOres, "shown", "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Controls how Lapis Lazuli is generated </Description>
+                    <DisplayName>Nether Ores Lapis Lazuli</DisplayName>
+                    <Choice value='VerticalVeins' displayValue='Vertical Veins'>
+                        <Description>
+                            Single vertical veins that occur with no motherlodes.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Lapis Lazuli is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='nthoLapisLazuliFreq' default='1'  min='0' max='5' displayState=':= if(?enableNetherOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Frequency multiplier for Nether Ores Lapis Lazuli distributions </Description>
+                    <DisplayName>Nether Ores Lapis Lazuli Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='nthoLapisLazuliSize' default='1'  min='0' max='5' displayState=':= if(?enableNetherOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Size multiplier for Nether Ores Lapis Lazuli distributions </Description>
+                    <DisplayName>Nether Ores Lapis Lazuli Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Lapis Lazuli Configuration UI Complete -->
+
+
+            <!-- Redstone Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='nthoRedstoneDist'  displayState=':= if(?enableNetherOres, "shown", "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Controls how Redstone is generated </Description>
+                    <DisplayName>Nether Ores Redstone</DisplayName>
+                    <Choice value='VerticalVeins' displayValue='Vertical Veins'>
+                        <Description>
+                            Single vertical veins that occur with no motherlodes.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Redstone is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='nthoRedstoneFreq' default='1'  min='0' max='5' displayState=':= if(?enableNetherOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Frequency multiplier for Nether Ores Redstone distributions </Description>
+                    <DisplayName>Nether Ores Redstone Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='nthoRedstoneSize' default='1'  min='0' max='5' displayState=':= if(?enableNetherOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Size multiplier for Nether Ores Redstone distributions </Description>
+                    <DisplayName>Nether Ores Redstone Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Redstone Configuration UI Complete -->
+
+
+            <!-- Copper Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='nthoCopperDist'  displayState=':= if(?enableNetherOres, "shown", "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Controls how Copper is generated </Description>
+                    <DisplayName>Nether Ores Copper</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                        <Description>
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Copper is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='nthoCopperFreq' default='1'  min='0' max='5' displayState=':= if(?enableNetherOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Frequency multiplier for Nether Ores Copper distributions </Description>
+                    <DisplayName>Nether Ores Copper Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='nthoCopperSize' default='1'  min='0' max='5' displayState=':= if(?enableNetherOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Size multiplier for Nether Ores Copper distributions </Description>
+                    <DisplayName>Nether Ores Copper Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Copper Configuration UI Complete -->
+
+
+            <!-- Tin Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='nthoTinDist'  displayState=':= if(?enableNetherOres, "shown", "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Controls how Tin is generated </Description>
+                    <DisplayName>Nether Ores Tin</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                        <Description>
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Tin is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='nthoTinFreq' default='1'  min='0' max='5' displayState=':= if(?enableNetherOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Frequency multiplier for Nether Ores Tin distributions </Description>
+                    <DisplayName>Nether Ores Tin Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='nthoTinSize' default='1'  min='0' max='5' displayState=':= if(?enableNetherOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Size multiplier for Nether Ores Tin distributions </Description>
+                    <DisplayName>Nether Ores Tin Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Tin Configuration UI Complete -->
+
+
+            <!-- Emerald Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='nthoEmeraldDist'  displayState=':= if(?enableNetherOres, "shown", "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Controls how Emerald is generated </Description>
+                    <DisplayName>Nether Ores Emerald</DisplayName>
+                    <Choice value='PipeVeins' displayValue='Pipe Veins'>
+                        <Description>
+                            Short and sparsely filled compound veins containing one material inside another.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Emerald is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='nthoEmeraldFreq' default='1'  min='0' max='5' displayState=':= if(?enableNetherOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Frequency multiplier for Nether Ores Emerald distributions </Description>
+                    <DisplayName>Nether Ores Emerald Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='nthoEmeraldSize' default='1'  min='0' max='5' displayState=':= if(?enableNetherOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Size multiplier for Nether Ores Emerald distributions </Description>
+                    <DisplayName>Nether Ores Emerald Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Emerald Configuration UI Complete -->
+
+
+            <!-- Silver Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='nthoSilverDist'  displayState=':= if(?enableNetherOres, "shown", "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Controls how Silver is generated </Description>
+                    <DisplayName>Nether Ores Silver</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                        <Description>
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Silver is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='nthoSilverFreq' default='1'  min='0' max='5' displayState=':= if(?enableNetherOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Frequency multiplier for Nether Ores Silver distributions </Description>
+                    <DisplayName>Nether Ores Silver Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='nthoSilverSize' default='1'  min='0' max='5' displayState=':= if(?enableNetherOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Size multiplier for Nether Ores Silver distributions </Description>
+                    <DisplayName>Nether Ores Silver Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Silver Configuration UI Complete -->
+
+
+            <!-- Lead Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='nthoLeadDist'  displayState=':= if(?enableNetherOres, "shown", "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Controls how Lead is generated </Description>
+                    <DisplayName>Nether Ores Lead</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                        <Description>
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Lead is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='nthoLeadFreq' default='1'  min='0' max='5' displayState=':= if(?enableNetherOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Frequency multiplier for Nether Ores Lead distributions </Description>
+                    <DisplayName>Nether Ores Lead Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='nthoLeadSize' default='1'  min='0' max='5' displayState=':= if(?enableNetherOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Size multiplier for Nether Ores Lead distributions </Description>
+                    <DisplayName>Nether Ores Lead Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Lead Configuration UI Complete -->
+
+
+            <!-- Uranium Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='nthoUraniumDist'  displayState=':= if(?enableNetherOres, "shown", "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Controls how Uranium is generated </Description>
+                    <DisplayName>Nether Ores Uranium</DisplayName>
+                    <Choice value='SparseVeins' displayValue='Sparse Veins'>
+                        <Description>
+                            Large veins filled very lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Uranium is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='nthoUraniumFreq' default='1'  min='0' max='5' displayState=':= if(?enableNetherOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Frequency multiplier for Nether Ores Uranium distributions </Description>
+                    <DisplayName>Nether Ores Uranium Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='nthoUraniumSize' default='1'  min='0' max='5' displayState=':= if(?enableNetherOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Size multiplier for Nether Ores Uranium distributions </Description>
+                    <DisplayName>Nether Ores Uranium Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Uranium Configuration UI Complete -->
+
+
+            <!-- Nikolite Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='nthoNikoliteDist'  displayState=':= if(?enableNetherOres, "shown", "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Controls how Nikolite is generated </Description>
+                    <DisplayName>Nether Ores Nikolite</DisplayName>
+                    <Choice value='VerticalVeins' displayValue='Vertical Veins'>
+                        <Description>
+                            Single vertical veins that occur with no motherlodes.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Nikolite is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='nthoNikoliteFreq' default='1'  min='0' max='5' displayState=':= if(?enableNetherOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Frequency multiplier for Nether Ores Nikolite distributions </Description>
+                    <DisplayName>Nether Ores Nikolite Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='nthoNikoliteSize' default='1'  min='0' max='5' displayState=':= if(?enableNetherOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Size multiplier for Nether Ores Nikolite distributions </Description>
+                    <DisplayName>Nether Ores Nikolite Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Nikolite Configuration UI Complete -->
+
+
+            <!-- Ruby Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='nthoRubyDist'  displayState=':= if(?enableNetherOres, "shown", "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Controls how Ruby is generated </Description>
+                    <DisplayName>Nether Ores Ruby</DisplayName>
+                    <Choice value='PipeVeins' displayValue='Pipe Veins'>
+                        <Description>
+                            Short and sparsely filled compound veins containing one material inside another.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Ruby is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='nthoRubyFreq' default='1'  min='0' max='5' displayState=':= if(?enableNetherOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Frequency multiplier for Nether Ores Ruby distributions </Description>
+                    <DisplayName>Nether Ores Ruby Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='nthoRubySize' default='1'  min='0' max='5' displayState=':= if(?enableNetherOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Size multiplier for Nether Ores Ruby distributions </Description>
+                    <DisplayName>Nether Ores Ruby Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Ruby Configuration UI Complete -->
+
+
+            <!-- Peridot Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='nthoPeridotDist'  displayState=':= if(?enableNetherOres, "shown", "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Controls how Peridot is generated </Description>
+                    <DisplayName>Nether Ores Peridot</DisplayName>
+                    <Choice value='PipeVeins' displayValue='Pipe Veins'>
+                        <Description>
+                            Short and sparsely filled compound veins containing one material inside another.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Peridot is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='nthoPeridotFreq' default='1'  min='0' max='5' displayState=':= if(?enableNetherOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Frequency multiplier for Nether Ores Peridot distributions </Description>
+                    <DisplayName>Nether Ores Peridot Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='nthoPeridotSize' default='1'  min='0' max='5' displayState=':= if(?enableNetherOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Size multiplier for Nether Ores Peridot distributions </Description>
+                    <DisplayName>Nether Ores Peridot Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Peridot Configuration UI Complete -->
+
+
+            <!-- Sapphire Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='nthoSapphireDist'  displayState=':= if(?enableNetherOres, "shown", "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Controls how Sapphire is generated </Description>
+                    <DisplayName>Nether Ores Sapphire</DisplayName>
+                    <Choice value='PipeVeins' displayValue='Pipe Veins'>
+                        <Description>
+                            Short and sparsely filled compound veins containing one material inside another.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Sapphire is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='nthoSapphireFreq' default='1'  min='0' max='5' displayState=':= if(?enableNetherOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Frequency multiplier for Nether Ores Sapphire distributions </Description>
+                    <DisplayName>Nether Ores Sapphire Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='nthoSapphireSize' default='1'  min='0' max='5' displayState=':= if(?enableNetherOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Size multiplier for Nether Ores Sapphire distributions </Description>
+                    <DisplayName>Nether Ores Sapphire Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Sapphire Configuration UI Complete -->
+
+
+            <!-- Platinum Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='nthoPlatinumDist'  displayState=':= if(?enableNetherOres, "shown", "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Controls how Platinum is generated </Description>
+                    <DisplayName>Nether Ores Platinum</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                        <Description>
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Platinum is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='nthoPlatinumFreq' default='1'  min='0' max='5' displayState=':= if(?enableNetherOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Frequency multiplier for Nether Ores Platinum distributions </Description>
+                    <DisplayName>Nether Ores Platinum Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='nthoPlatinumSize' default='1'  min='0' max='5' displayState=':= if(?enableNetherOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Size multiplier for Nether Ores Platinum distributions </Description>
+                    <DisplayName>Nether Ores Platinum Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Platinum Configuration UI Complete -->
+
+
+            <!-- Nickel Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='nthoNickelDist'  displayState=':= if(?enableNetherOres, "shown", "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Controls how Nickel is generated </Description>
+                    <DisplayName>Nether Ores Nickel</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                        <Description>
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Nickel is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='nthoNickelFreq' default='1'  min='0' max='5' displayState=':= if(?enableNetherOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Frequency multiplier for Nether Ores Nickel distributions </Description>
+                    <DisplayName>Nether Ores Nickel Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='nthoNickelSize' default='1'  min='0' max='5' displayState=':= if(?enableNetherOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Size multiplier for Nether Ores Nickel distributions </Description>
+                    <DisplayName>Nether Ores Nickel Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Nickel Configuration UI Complete -->
+
+
+            <!-- Steel Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='nthoSteelDist'  displayState=':= if(?enableNetherOres, "shown", "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Controls how Steel is generated </Description>
+                    <DisplayName>Nether Ores Steel</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                        <Description>
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Steel is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='nthoSteelFreq' default='1'  min='0' max='5' displayState=':= if(?enableNetherOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Frequency multiplier for Nether Ores Steel distributions </Description>
+                    <DisplayName>Nether Ores Steel Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='nthoSteelSize' default='1'  min='0' max='5' displayState=':= if(?enableNetherOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Size multiplier for Nether Ores Steel distributions </Description>
+                    <DisplayName>Nether Ores Steel Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Steel Configuration UI Complete -->
+
+
+            <!-- Iridium Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='nthoIridiumDist'  displayState=':= if(?enableNetherOres, "shown", "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Controls how Iridium is generated </Description>
+                    <DisplayName>Nether Ores Iridium</DisplayName>
+                    <Choice value='SmallDeposits' displayValue='Small Deposits'>
+                        <Description>
+                            Small motherlodes without any branches.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Iridium is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='nthoIridiumFreq' default='1'  min='0' max='5' displayState=':= if(?enableNetherOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Frequency multiplier for Nether Ores Iridium distributions </Description>
+                    <DisplayName>Nether Ores Iridium Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='nthoIridiumSize' default='1'  min='0' max='5' displayState=':= if(?enableNetherOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Size multiplier for Nether Ores Iridium distributions </Description>
+                    <DisplayName>Nether Ores Iridium Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Iridium Configuration UI Complete -->
+
+
+            <!-- Osmium Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='nthoOsmiumDist'  displayState=':= if(?enableNetherOres, "shown", "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Controls how Osmium is generated </Description>
+                    <DisplayName>Nether Ores Osmium</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                        <Description>
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Osmium is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='nthoOsmiumFreq' default='1'  min='0' max='5' displayState=':= if(?enableNetherOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Frequency multiplier for Nether Ores Osmium distributions </Description>
+                    <DisplayName>Nether Ores Osmium Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='nthoOsmiumSize' default='1'  min='0' max='5' displayState=':= if(?enableNetherOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Size multiplier for Nether Ores Osmium distributions </Description>
+                    <DisplayName>Nether Ores Osmium Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Osmium Configuration UI Complete -->
+
+
+            <!-- Sulfur Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='nthoSulfurDist'  displayState=':= if(?enableNetherOres, "shown", "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Controls how Sulfur is generated </Description>
+                    <DisplayName>Nether Ores Sulfur</DisplayName>
+                    <Choice value='PipeVeins' displayValue='Pipe Veins'>
+                        <Description>
+                            Short and sparsely filled compound veins containing one material inside another.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Sulfur is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='nthoSulfurFreq' default='1'  min='0' max='5' displayState=':= if(?enableNetherOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Frequency multiplier for Nether Ores Sulfur distributions </Description>
+                    <DisplayName>Nether Ores Sulfur Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='nthoSulfurSize' default='1'  min='0' max='5' displayState=':= if(?enableNetherOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Size multiplier for Nether Ores Sulfur distributions </Description>
+                    <DisplayName>Nether Ores Sulfur Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Sulfur Configuration UI Complete -->
+
+
+            <!-- Titanium Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='nthoTitaniumDist'  displayState=':= if(?enableNetherOres, "shown", "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Controls how Titanium is generated </Description>
+                    <DisplayName>Nether Ores Titanium</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                        <Description>
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Titanium is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='nthoTitaniumFreq' default='1'  min='0' max='5' displayState=':= if(?enableNetherOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Frequency multiplier for Nether Ores Titanium distributions </Description>
+                    <DisplayName>Nether Ores Titanium Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='nthoTitaniumSize' default='1'  min='0' max='5' displayState=':= if(?enableNetherOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Size multiplier for Nether Ores Titanium distributions </Description>
+                    <DisplayName>Nether Ores Titanium Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Titanium Configuration UI Complete -->
+
+
+            <!-- Mithril Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='nthoMithrilDist'  displayState=':= if(?enableNetherOres, "shown", "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Controls how Mithril is generated </Description>
+                    <DisplayName>Nether Ores Mithril</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                        <Description>
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Mithril is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='nthoMithrilFreq' default='1'  min='0' max='5' displayState=':= if(?enableNetherOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Frequency multiplier for Nether Ores Mithril distributions </Description>
+                    <DisplayName>Nether Ores Mithril Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='nthoMithrilSize' default='1'  min='0' max='5' displayState=':= if(?enableNetherOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Size multiplier for Nether Ores Mithril distributions </Description>
+                    <DisplayName>Nether Ores Mithril Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Mithril Configuration UI Complete -->
+
+
+            <!-- Adamantium Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='nthoAdamantiumDist'  displayState=':= if(?enableNetherOres, "shown", "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Controls how Adamantium is generated </Description>
+                    <DisplayName>Nether Ores Adamantium</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                        <Description>
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Adamantium is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='nthoAdamantiumFreq' default='1'  min='0' max='5' displayState=':= if(?enableNetherOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Frequency multiplier for Nether Ores Adamantium distributions </Description>
+                    <DisplayName>Nether Ores Adamantium Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='nthoAdamantiumSize' default='1'  min='0' max='5' displayState=':= if(?enableNetherOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Size multiplier for Nether Ores Adamantium distributions </Description>
+                    <DisplayName>Nether Ores Adamantium Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Adamantium Configuration UI Complete -->
+
+
+            <!-- Rutile Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='nthoRutileDist'  displayState=':= if(?enableNetherOres, "shown", "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Controls how Rutile is generated </Description>
+                    <DisplayName>Nether Ores Rutile</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                        <Description>
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Rutile is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='nthoRutileFreq' default='1'  min='0' max='5' displayState=':= if(?enableNetherOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Frequency multiplier for Nether Ores Rutile distributions </Description>
+                    <DisplayName>Nether Ores Rutile Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='nthoRutileSize' default='1'  min='0' max='5' displayState=':= if(?enableNetherOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Size multiplier for Nether Ores Rutile distributions </Description>
+                    <DisplayName>Nether Ores Rutile Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Rutile Configuration UI Complete -->
+
+
+            <!-- Tungsten Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='nthoTungstenDist'  displayState=':= if(?enableNetherOres, "shown", "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Controls how Tungsten is generated </Description>
+                    <DisplayName>Nether Ores Tungsten</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                        <Description>
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Tungsten is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='nthoTungstenFreq' default='1'  min='0' max='5' displayState=':= if(?enableNetherOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Frequency multiplier for Nether Ores Tungsten distributions </Description>
+                    <DisplayName>Nether Ores Tungsten Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='nthoTungstenSize' default='1'  min='0' max='5' displayState=':= if(?enableNetherOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Size multiplier for Nether Ores Tungsten distributions </Description>
+                    <DisplayName>Nether Ores Tungsten Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Tungsten Configuration UI Complete -->
+
+
+            <!-- Amber Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='nthoAmberDist'  displayState=':= if(?enableNetherOres, "shown", "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Controls how Amber is generated </Description>
+                    <DisplayName>Nether Ores Amber</DisplayName>
+                    <Choice value='SparseVeins' displayValue='Sparse Veins'>
+                        <Description>
+                            Large veins filled very lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Amber is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='nthoAmberFreq' default='1'  min='0' max='5' displayState=':= if(?enableNetherOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Frequency multiplier for Nether Ores Amber distributions </Description>
+                    <DisplayName>Nether Ores Amber Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='nthoAmberSize' default='1'  min='0' max='5' displayState=':= if(?enableNetherOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Size multiplier for Nether Ores Amber distributions </Description>
+                    <DisplayName>Nether Ores Amber Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Amber Configuration UI Complete -->
+
+
+            <!-- Tennantite Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='nthoTennantiteDist'  displayState=':= if(?enableNetherOres, "shown", "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Controls how Tennantite is generated </Description>
+                    <DisplayName>Nether Ores Tennantite</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                        <Description>
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Tennantite is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='nthoTennantiteFreq' default='1'  min='0' max='5' displayState=':= if(?enableNetherOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Frequency multiplier for Nether Ores Tennantite distributions </Description>
+                    <DisplayName>Nether Ores Tennantite Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='nthoTennantiteSize' default='1'  min='0' max='5' displayState=':= if(?enableNetherOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Size multiplier for Nether Ores Tennantite distributions </Description>
+                    <DisplayName>Nether Ores Tennantite Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Tennantite Configuration UI Complete -->
+
+
+            <!-- Salt Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='nthoSaltDist'  displayState=':= if(?enableNetherOres, "shown", "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Controls how Salt is generated </Description>
+                    <DisplayName>Nether Ores Salt</DisplayName>
+                    <Choice value='SparseVeins' displayValue='Sparse Veins'>
+                        <Description>
+                            Large veins filled very lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Salt is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='nthoSaltFreq' default='1'  min='0' max='5' displayState=':= if(?enableNetherOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Frequency multiplier for Nether Ores Salt distributions </Description>
+                    <DisplayName>Nether Ores Salt Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='nthoSaltSize' default='1'  min='0' max='5' displayState=':= if(?enableNetherOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Size multiplier for Nether Ores Salt distributions </Description>
+                    <DisplayName>Nether Ores Salt Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Salt Configuration UI Complete -->
+
+
+            <!-- Saltpeter Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='nthoSaltpeterDist'  displayState=':= if(?enableNetherOres, "shown", "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Controls how Saltpeter is generated </Description>
+                    <DisplayName>Nether Ores Saltpeter</DisplayName>
+                    <Choice value='SparseVeins' displayValue='Sparse Veins'>
+                        <Description>
+                            Large veins filled very lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Saltpeter is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='nthoSaltpeterFreq' default='1'  min='0' max='5' displayState=':= if(?enableNetherOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Frequency multiplier for Nether Ores Saltpeter distributions </Description>
+                    <DisplayName>Nether Ores Saltpeter Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='nthoSaltpeterSize' default='1'  min='0' max='5' displayState=':= if(?enableNetherOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Size multiplier for Nether Ores Saltpeter distributions </Description>
+                    <DisplayName>Nether Ores Saltpeter Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Saltpeter Configuration UI Complete -->
+
+
+            <!-- Magnesium Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='nthoMagnesiumDist'  displayState=':= if(?enableNetherOres, "shown", "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Controls how Magnesium is generated </Description>
+                    <DisplayName>Nether Ores Magnesium</DisplayName>
+                    <Choice value='SparseVeins' displayValue='Sparse Veins'>
+                        <Description>
+                            Large veins filled very lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Magnesium is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='nthoMagnesiumFreq' default='1'  min='0' max='5' displayState=':= if(?enableNetherOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Frequency multiplier for Nether Ores Magnesium distributions </Description>
+                    <DisplayName>Nether Ores Magnesium Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='nthoMagnesiumSize' default='1'  min='0' max='5' displayState=':= if(?enableNetherOres, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherOres'>
+                    <Description> Size multiplier for Nether Ores Magnesium distributions </Description>
+                    <DisplayName>Nether Ores Magnesium Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Magnesium Configuration UI Complete -->
+
+        </ConfigSection>
+        <!-- Setup Screen Complete -->
+
+        <IfCondition condition=':= ?enableNetherOres'>
+
+
+
+
+
+            <!-- Nether Setup Beginning -->
+
             <IfCondition condition=':= dimension.generator = "HellRandomLevelSource"'>
-                
-                <!-- Starting Original Nether Ore Removal -->
-                <Substitute name='nthoNetherOreSubstitute0' block='minecraft:netherrack'>
-                    <Description>
-                        Replace vanilla-generated ore clusters.
-                    </Description>
-                    <Comment>
-                        The global option deferredPopulationRange must be large enough to catch all ore clusters (>= 32).
-                    </Comment>
-                    <Replaces block='NetherOres:tile.netherores.ore.0' />
-                    <Replaces block='NetherOres:tile.netherores.ore.0:1' />
-                    <Replaces block='NetherOres:tile.netherores.ore.0:2' />
-                    <Replaces block='NetherOres:tile.netherores.ore.0:3' />
-                    <Replaces block='NetherOres:tile.netherores.ore.0:4' />
-                    <Replaces block='NetherOres:tile.netherores.ore.0:5' />
-                    <Replaces block='NetherOres:tile.netherores.ore.0:6' />
-                    <Replaces block='NetherOres:tile.netherores.ore.0:7' />
-                    <Replaces block='NetherOres:tile.netherores.ore.0:8' />
-                    <Replaces block='NetherOres:tile.netherores.ore.0:9' />
-                    <Replaces block='NetherOres:tile.netherores.ore.0:10' />
-                    <Replaces block='NetherOres:tile.netherores.ore.0:11' />
-                    <Replaces block='NetherOres:tile.netherores.ore.0:12' />
-                    <Replaces block='NetherOres:tile.netherores.ore.0:13' />
-                    <Replaces block='NetherOres:tile.netherores.ore.0:14' />
-                    <Replaces block='NetherOres:tile.netherores.ore.0:15' />
-                    <Replaces block='NetherOres:tile.netherores.ore.1' />
-                    <Replaces block='NetherOres:tile.netherores.ore.1:1' />
-                    <Replaces block='NetherOres:tile.netherores.ore.1:2' />
-                    <Replaces block='NetherOres:tile.netherores.ore.1:3' />
-                    <Replaces block='NetherOres:tile.netherores.ore.1:4' />
-                    <Replaces block='NetherOres:tile.netherores.ore.1:5' />
-                    <Replaces block='NetherOres:tile.netherores.ore.1:6' />
-                    <Replaces block='NetherOres:tile.netherores.ore.1:7' />
-                    <Replaces block='NetherOres:tile.netherores.ore.1:8' />
-                    <Replaces block='NetherOres:tile.netherores.ore.1:9' />
-                    <Replaces block='NetherOres:tile.netherores.ore.1:10' />
-                    <Replaces block='NetherOres:tile.netherores.ore.1:11' />
-                    <Replaces block='NetherOres:tile.netherores.ore.1:12' />
-                    <Replaces block='NetherOres:tile.netherores.ore.1:13' />
-                    <Replaces block='NetherOres:tile.netherores.ore.1:14' />
-                    <Replaces block='NetherOres:tile.netherores.ore.1:15' />
-                </Substitute>
-                <!-- Original Nether Ore Removal Complete -->
-                
-                <!-- Adding ores --> 
-                
-                <!-- Begin Coal Generation --> 
-                
-                <!-- Begin LayeredVeins distribution of Coal -->
-                <IfCondition condition=':= nthoCoalDist = "layeredVeins"'>
-                
-                    <Veins name='nthoCoalBaseVeins' block='NetherOres:tile.netherores.ore.0'  inherits='PresetLayeredVeins' >
+
+                <!-- Starting Original "Nether" Block Removal -->
+
+                <IfCondition condition=':= ?blockExists("minecraft:netherrack")'>
+                    <Substitute name='nthoNetherBlockSubstitute0' block='minecraft:netherrack'>
                         <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
+                            Replace vanilla-generated ore clusters.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x602D2D2D</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoCoalSize * _default_' range=':= 1 * 1 * nthoCoalSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoCoalSize * _default_' range=':= 1 * 1 * nthoCoalSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoCoalFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
+                        <Comment>
+                            The global option  deferredPopulationRange
+                            must be large  enough to catch all ore
+                            clusters (>=  32).
+                        </Comment>
+                        <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0")'> <Replaces block='NetherOres:tile.netherores.ore.0' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:1")'> <Replaces block='NetherOres:tile.netherores.ore.0:1' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:10")'> <Replaces block='NetherOres:tile.netherores.ore.0:10' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:11")'> <Replaces block='NetherOres:tile.netherores.ore.0:11' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:12")'> <Replaces block='NetherOres:tile.netherores.ore.0:12' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:13")'> <Replaces block='NetherOres:tile.netherores.ore.0:13' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:14")'> <Replaces block='NetherOres:tile.netherores.ore.0:14' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:15")'> <Replaces block='NetherOres:tile.netherores.ore.0:15' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:2")'> <Replaces block='NetherOres:tile.netherores.ore.0:2' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:3")'> <Replaces block='NetherOres:tile.netherores.ore.0:3' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:4")'> <Replaces block='NetherOres:tile.netherores.ore.0:4' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:5")'> <Replaces block='NetherOres:tile.netherores.ore.0:5' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:6")'> <Replaces block='NetherOres:tile.netherores.ore.0:6' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:7")'> <Replaces block='NetherOres:tile.netherores.ore.0:7' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:8")'> <Replaces block='NetherOres:tile.netherores.ore.0:8' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:9")'> <Replaces block='NetherOres:tile.netherores.ore.0:9' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:0")'> <Replaces block='NetherOres:tile.netherores.ore.1:0' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:1")'> <Replaces block='NetherOres:tile.netherores.ore.1:1' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:10")'> <Replaces block='NetherOres:tile.netherores.ore.1:10' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:11")'> <Replaces block='NetherOres:tile.netherores.ore.1:11' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:12")'> <Replaces block='NetherOres:tile.netherores.ore.1:12' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:13")'> <Replaces block='NetherOres:tile.netherores.ore.1:13' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:14")'> <Replaces block='NetherOres:tile.netherores.ore.1:14' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:15")'> <Replaces block='NetherOres:tile.netherores.ore.1:15' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:2")'> <Replaces block='NetherOres:tile.netherores.ore.1:2' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:3")'> <Replaces block='NetherOres:tile.netherores.ore.1:3' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:4")'> <Replaces block='NetherOres:tile.netherores.ore.1:4' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:5")'> <Replaces block='NetherOres:tile.netherores.ore.1:5' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:6")'> <Replaces block='NetherOres:tile.netherores.ore.1:6' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:7")'> <Replaces block='NetherOres:tile.netherores.ore.1:7' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:8")'> <Replaces block='NetherOres:tile.netherores.ore.1:8' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:9")'> <Replaces block='NetherOres:tile.netherores.ore.1:9' weight='1.0' /> </IfCondition>
+                    </Substitute>
                 </IfCondition>
-                <!-- End LayeredVeins distribution of Coal -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Coal -->
-                <IfCondition condition=':= nthoCoalDist = "hugeVeins"'>
-                
-                    <Veins name='nthoCoalBaseVeins' block='NetherOres:tile.netherores.ore.0'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x602D2D2D</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoCoalSize * _default_' range=':= 1 * 1 * nthoCoalSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoCoalSize * _default_' range=':= 1 * 1 * nthoCoalSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoCoalFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Coal -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Coal -->
-                <IfCondition condition=':= nthoCoalDist = "strategicCloud"'>
-                
-                    <Cloud name='nthoCoalBaseCloud' block='NetherOres:tile.netherores.ore.0' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x602D2D2D</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1 * nthoCoalSize * _default_' range=':= 1 * 1 * nthoCoalSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * nthoCoalSize * _default_' range=':= 1 * 1 * nthoCoalSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1 * nthoCoalSize * _default_' range=':= 1 * 1 * 1 * nthoCoalSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 1 * nthoCoalFreq *_default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Coal Strategic Cloud Hint Veins -->
-                        <Veins name='nthoCoalBaseHintVeins' block='NetherOres:tile.netherores.ore.0' inherits='PresetHintVeins'>
+
+                <!-- Original "Nether" Block Removal Complete -->
+
+                <!-- Adding blocks -->
+
+                <!-- Begin Coal Generation -->
+
+                <!-- Starting SparseVeins Preset for Coal. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoCoalDist = "SparseVeins"'>
+                        <Veins name='nthoCoalVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x602D2D2D' drawBoundBox='false' boundBoxColor='0x602D2D2D'>
                             <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
+                                Large veins filled very lightly  with
+                                ore.  Because they contain  less ore
+                                per volume, these veins  are
+                                relatively wide and long.  Mining the
+                                ore from them is time  consuming
+                                compared to solid ore  veins.  They
+                                are also more  difficult to follow,
+                                since it is  harder to get an idea of
+                                their  direction while mining.
                             </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x602D2D2D</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0")'> <OreBlock block='NetherOres:tile.netherores.ore.0' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 3.961 * _default_ * nthoCoalFreq ' range=':= _default_ * nthoCoalFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.582 * _default_ * nthoCoalSize ' range=':= _default_ * nthoCoalSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.582 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * nthoCoalSize ' range=':= _default_ * nthoCoalSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.582 * _default_ * nthoCoalSize ' range=':= _default_ * nthoCoalSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
-                        <!-- End Coal Strategic Cloud Hint Veins -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- SparseVeins Preset for Coal is complete. -->
 
-                    </Cloud>
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Coal -->
-                
-                
-                <!-- Begin  Vanilla distribution of Coal -->
-                <IfCondition condition=':= nthoCoalDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='nthoCoalBaseStandard' block='NetherOres:tile.netherores.ore.0' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x602D2D2D</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * nthoCoalSize * _default_'/>
-                        <Setting name='Height' avg=':= 120' range=':= 120' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1 * nthoCoalFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </StandardGen>
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Coal -->
-                
-                <!-- End Coal Generation --> 
 
-                
-                <!-- Begin Diamond Generation --> 
-                
-                <!-- Begin LayeredVeins distribution of Diamond -->
-                <IfCondition condition=':= nthoDiamondDist = "layeredVeins"'>
-                
-                    <Veins name='nthoDiamondBaseVeins' block='NetherOres:tile.netherores.ore.0:1'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x608BF4E3</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoDiamondSize * _default_' range=':= 1 * 1 * nthoDiamondSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoDiamondSize * _default_' range=':= 1 * 1 * nthoDiamondSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoDiamondFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End LayeredVeins distribution of Diamond -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Diamond -->
-                <IfCondition condition=':= nthoDiamondDist = "hugeVeins"'>
-                
-                    <Veins name='nthoDiamondBaseVeins' block='NetherOres:tile.netherores.ore.0:1'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x608BF4E3</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoDiamondSize * _default_' range=':= 1 * 1 * nthoDiamondSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoDiamondSize * _default_' range=':= 1 * 1 * nthoDiamondSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoDiamondFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Diamond -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Diamond -->
-                <IfCondition condition=':= nthoDiamondDist = "strategicCloud"'>
-                
-                    <Cloud name='nthoDiamondBaseCloud' block='NetherOres:tile.netherores.ore.0:1' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x608BF4E3</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1 * nthoDiamondSize * _default_' range=':= 1 * 1 * nthoDiamondSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * nthoDiamondSize * _default_' range=':= 1 * 1 * nthoDiamondSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1 * nthoDiamondSize * _default_' range=':= 1 * 1 * 1 * nthoDiamondSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 1 * nthoDiamondFreq *_default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Diamond Strategic Cloud Hint Veins -->
-                        <Veins name='nthoDiamondBaseHintVeins' block='NetherOres:tile.netherores.ore.0:1' inherits='PresetHintVeins'>
+                <!-- Starting Cloud Preset for Coal. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoCoalDist = "Cloud"'>
+                        <Cloud name='nthoCoalCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x602D2D2D' drawBoundBox='false' boundBoxColor='0x602D2D2D'>
                             <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
                             </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x608BF4E3</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Diamond Strategic Cloud Hint Veins -->
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0")'> <OreBlock block='NetherOres:tile.netherores.ore.0' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.636 * _default_ * nthoCoalSize ' range=':= _default_ * nthoCoalSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.636 * _default_ * nthoCoalSize ' range=':= _default_ * nthoCoalSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 2.676  * _default_ * nthoCoalFreq ' range=':= _default_ * nthoCoalFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Veins name='nthoCoalHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x602D2D2D' drawBoundBox='false' boundBoxColor='0x602D2D2D'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0")'> <OreBlock block='NetherOres:tile.netherores.ore.0' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Coal is complete. -->
 
-                    </Cloud>
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Diamond -->
-                
-                
-                <!-- Begin  Vanilla distribution of Diamond -->
-                <IfCondition condition=':= nthoDiamondDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='nthoDiamondBaseStandard' block='NetherOres:tile.netherores.ore.0:1' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x608BF4E3</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * nthoDiamondSize * _default_'/>
-                        <Setting name='Height' avg=':= 120' range=':= 120' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1 * nthoDiamondFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </StandardGen>
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Diamond -->
-                
-                <!-- End Diamond Generation --> 
 
-                
-                <!-- Begin Gold Generation --> 
-                
-                <!-- Begin LayeredVeins distribution of Gold -->
-                <IfCondition condition=':= nthoGoldDist = "layeredVeins"'>
-                
-                    <Veins name='nthoGoldBaseVeins' block='NetherOres:tile.netherores.ore.0:2'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60EAEF57</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoGoldSize * _default_' range=':= 1 * 1 * nthoGoldSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoGoldSize * _default_' range=':= 1 * 1 * nthoGoldSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoGoldFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End LayeredVeins distribution of Gold -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Gold -->
-                <IfCondition condition=':= nthoGoldDist = "hugeVeins"'>
-                
-                    <Veins name='nthoGoldBaseVeins' block='NetherOres:tile.netherores.ore.0:2'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60EAEF57</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoGoldSize * _default_' range=':= 1 * 1 * nthoGoldSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoGoldSize * _default_' range=':= 1 * 1 * nthoGoldSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoGoldFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Gold -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Gold -->
-                <IfCondition condition=':= nthoGoldDist = "strategicCloud"'>
-                
-                    <Cloud name='nthoGoldBaseCloud' block='NetherOres:tile.netherores.ore.0:2' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60EAEF57</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1 * nthoGoldSize * _default_' range=':= 1 * 1 * nthoGoldSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * nthoGoldSize * _default_' range=':= 1 * 1 * nthoGoldSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1 * nthoGoldSize * _default_' range=':= 1 * 1 * 1 * nthoGoldSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 1 * nthoGoldFreq *_default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Gold Strategic Cloud Hint Veins -->
-                        <Veins name='nthoGoldBaseHintVeins' block='NetherOres:tile.netherores.ore.0:2' inherits='PresetHintVeins'>
+                <!-- Starting Vanilla Preset for Coal. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoCoalDist = "Vanilla"'>
+                        <StandardGen name='nthoCoalStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x602D2D2D' drawBoundBox='false' boundBoxColor='0x602D2D2D'>
                             <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
+                                A master preset for standardgen  ore
+                                distributions.
                             </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60EAEF57</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Gold Strategic Cloud Hint Veins -->
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0")'> <OreBlock block='NetherOres:tile.netherores.ore.0' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 16 * nthoCoalSize ' range=':= _default_ * nthoCoalSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 8 * nthoCoalFreq ' range=':= _default_ * nthoCoalFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Coal is complete. -->
 
-                    </Cloud>
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Gold -->
-                
-                
-                <!-- Begin  Vanilla distribution of Gold -->
-                <IfCondition condition=':= nthoGoldDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='nthoGoldBaseStandard' block='NetherOres:tile.netherores.ore.0:2' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60EAEF57</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * nthoGoldSize * _default_'/>
-                        <Setting name='Height' avg=':= 120' range=':= 120' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1 * nthoGoldFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </StandardGen>
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Gold -->
-                
-                <!-- End Gold Generation --> 
+                <!-- End Coal Generation -->
 
-                
-                <!-- Begin Iron Generation --> 
-                
-                <!-- Begin LayeredVeins distribution of Iron -->
-                <IfCondition condition=':= nthoIronDist = "layeredVeins"'>
-                
-                    <Veins name='nthoIronBaseVeins' block='NetherOres:tile.netherores.ore.0:3'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60DDC2AF</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoIronSize * _default_' range=':= 1 * 1 * nthoIronSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoIronSize * _default_' range=':= 1 * 1 * nthoIronSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoIronFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End LayeredVeins distribution of Iron -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Iron -->
-                <IfCondition condition=':= nthoIronDist = "hugeVeins"'>
-                
-                    <Veins name='nthoIronBaseVeins' block='NetherOres:tile.netherores.ore.0:3'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60DDC2AF</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoIronSize * _default_' range=':= 1 * 1 * nthoIronSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoIronSize * _default_' range=':= 1 * 1 * nthoIronSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoIronFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Iron -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Iron -->
-                <IfCondition condition=':= nthoIronDist = "strategicCloud"'>
-                
-                    <Cloud name='nthoIronBaseCloud' block='NetherOres:tile.netherores.ore.0:3' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60DDC2AF</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1 * nthoIronSize * _default_' range=':= 1 * 1 * nthoIronSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * nthoIronSize * _default_' range=':= 1 * 1 * nthoIronSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1 * nthoIronSize * _default_' range=':= 1 * 1 * 1 * nthoIronSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 1 * nthoIronFreq *_default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Iron Strategic Cloud Hint Veins -->
-                        <Veins name='nthoIronBaseHintVeins' block='NetherOres:tile.netherores.ore.0:3' inherits='PresetHintVeins'>
+
+                <!-- Begin Diamond Generation -->
+
+                <!-- Starting PipeVeins Preset for Diamond. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoDiamondDist = "PipeVeins"'>
+                        <Veins name='nthoDiamondVeins'  inherits='PresetPipeVeins' seed='0xAA9C' drawWireframe='true' wireframeColor='0x608BF4E3' drawBoundBox='false' boundBoxColor='0x608BF4E3'>
                             <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
+                                Short sparsely filled veins  sloping
+                                up from near the bottom  of the map.
                             </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60DDC2AF</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:1")'> <OreBlock block='NetherOres:tile.netherores.ore.0:1' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.478 * _default_ * nthoDiamondFreq ' range=':= _default_ * nthoDiamondFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.782 * _default_ * nthoDiamondSize ' range=':= _default_ * nthoDiamondSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.782 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * nthoDiamondSize ' range=':= _default_ * nthoDiamondSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.782 * _default_ * nthoDiamondSize ' range=':= _default_ * nthoDiamondSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
-                        <!-- End Iron Strategic Cloud Hint Veins -->
 
-                    </Cloud>
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Iron -->
-                
-                
-                <!-- Begin  Vanilla distribution of Iron -->
-                <IfCondition condition=':= nthoIronDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='nthoIronBaseStandard' block='NetherOres:tile.netherores.ore.0:3' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60DDC2AF</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * nthoIronSize * _default_'/>
-                        <Setting name='Height' avg=':= 120' range=':= 120' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1 * nthoIronFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </StandardGen>
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Iron -->
-                
-                <!-- End Iron Generation --> 
+                        <!-- Configuring contained material. -->
+                        <Veins name='nthoDiamondVeinsPipe'  inherits='nthoDiamondVeins' seed='0xAA9C' drawWireframe='true' wireframeColor='0x608BF4E3' drawBoundBox='false' boundBoxColor='0x608BF4E3'>
+                            <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:1")'> <Replaces block='NetherOres:tile.netherores.ore.0:1' weight='1.0' /> </IfCondition>
+                            <Setting name='MotherlodeSize' avg=':= 0.782 * _default_ * nthoDiamondSize  * 0.5 ' range=':= _default_ * nthoDiamondSize  * 0.5 ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.782 * _default_ * nthoDiamondSize  * 0.5 ' range=':= _default_ * nthoDiamondSize  * 0.5 ' type='normal' />
+                            <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- PipeVeins Preset for Diamond is complete. -->
 
-                
-                <!-- Begin Lapis Lazuli Generation --> 
-                
-                <!-- Begin LayeredVeins distribution of Lapis Lazuli -->
-                <IfCondition condition=':= nthoLapisLazuliDist = "layeredVeins"'>
-                
-                    <Veins name='nthoLapisLazuliBaseVeins' block='NetherOres:tile.netherores.ore.0:4'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x601442BA</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoLapisLazuliSize * _default_' range=':= 1 * 1 * nthoLapisLazuliSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoLapisLazuliSize * _default_' range=':= 1 * 1 * nthoLapisLazuliSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoLapisLazuliFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End LayeredVeins distribution of Lapis Lazuli -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Lapis Lazuli -->
-                <IfCondition condition=':= nthoLapisLazuliDist = "hugeVeins"'>
-                
-                    <Veins name='nthoLapisLazuliBaseVeins' block='NetherOres:tile.netherores.ore.0:4'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x601442BA</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoLapisLazuliSize * _default_' range=':= 1 * 1 * nthoLapisLazuliSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoLapisLazuliSize * _default_' range=':= 1 * 1 * nthoLapisLazuliSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoLapisLazuliFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Lapis Lazuli -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Lapis Lazuli -->
-                <IfCondition condition=':= nthoLapisLazuliDist = "strategicCloud"'>
-                
-                    <Cloud name='nthoLapisLazuliBaseCloud' block='NetherOres:tile.netherores.ore.0:4' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x601442BA</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1 * nthoLapisLazuliSize * _default_' range=':= 1 * 1 * nthoLapisLazuliSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * nthoLapisLazuliSize * _default_' range=':= 1 * 1 * nthoLapisLazuliSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1 * nthoLapisLazuliSize * _default_' range=':= 1 * 1 * 1 * nthoLapisLazuliSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 1 * nthoLapisLazuliFreq *_default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Lapis Lazuli Strategic Cloud Hint Veins -->
-                        <Veins name='nthoLapisLazuliBaseHintVeins' block='NetherOres:tile.netherores.ore.0:4' inherits='PresetHintVeins'>
+
+                <!-- Starting Cloud Preset for Diamond. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoDiamondDist = "Cloud"'>
+                        <Cloud name='nthoDiamondCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x608BF4E3' drawBoundBox='false' boundBoxColor='0x608BF4E3'>
                             <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
                             </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x601442BA</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Lapis Lazuli Strategic Cloud Hint Veins -->
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:1")'> <OreBlock block='NetherOres:tile.netherores.ore.0:1' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.905 * _default_ * nthoDiamondSize ' range=':= _default_ * nthoDiamondSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.905 * _default_ * nthoDiamondSize ' range=':= _default_ * nthoDiamondSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * nthoDiamondFreq ' range=':= _default_ * nthoDiamondFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Veins name='nthoDiamondHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x608BF4E3' drawBoundBox='false' boundBoxColor='0x608BF4E3'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:1")'> <OreBlock block='NetherOres:tile.netherores.ore.0:1' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Diamond is complete. -->
 
-                    </Cloud>
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Lapis Lazuli -->
-                
-                
-                <!-- Begin  Vanilla distribution of Lapis Lazuli -->
-                <IfCondition condition=':= nthoLapisLazuliDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='nthoLapisLazuliBaseStandard' block='NetherOres:tile.netherores.ore.0:4' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x601442BA</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * nthoLapisLazuliSize * _default_'/>
-                        <Setting name='Height' avg=':= 120' range=':= 120' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1 * nthoLapisLazuliFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </StandardGen>
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Lapis Lazuli -->
-                
-                <!-- End Lapis Lazuli Generation --> 
 
-                
-                <!-- Begin Redstone Generation --> 
-                
-                <!-- Begin LayeredVeins distribution of Redstone -->
-                <IfCondition condition=':= nthoRedstoneDist = "layeredVeins"'>
-                
-                    <Veins name='nthoRedstoneBaseVeins' block='NetherOres:tile.netherores.ore.0:5'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60A80002</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoRedstoneSize * _default_' range=':= 1 * 1 * nthoRedstoneSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoRedstoneSize * _default_' range=':= 1 * 1 * nthoRedstoneSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoRedstoneFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End LayeredVeins distribution of Redstone -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Redstone -->
-                <IfCondition condition=':= nthoRedstoneDist = "hugeVeins"'>
-                
-                    <Veins name='nthoRedstoneBaseVeins' block='NetherOres:tile.netherores.ore.0:5'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60A80002</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoRedstoneSize * _default_' range=':= 1 * 1 * nthoRedstoneSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoRedstoneSize * _default_' range=':= 1 * 1 * nthoRedstoneSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoRedstoneFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Redstone -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Redstone -->
-                <IfCondition condition=':= nthoRedstoneDist = "strategicCloud"'>
-                
-                    <Cloud name='nthoRedstoneBaseCloud' block='NetherOres:tile.netherores.ore.0:5' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60A80002</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1 * nthoRedstoneSize * _default_' range=':= 1 * 1 * nthoRedstoneSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * nthoRedstoneSize * _default_' range=':= 1 * 1 * nthoRedstoneSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1 * nthoRedstoneSize * _default_' range=':= 1 * 1 * 1 * nthoRedstoneSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 1 * nthoRedstoneFreq *_default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Redstone Strategic Cloud Hint Veins -->
-                        <Veins name='nthoRedstoneBaseHintVeins' block='NetherOres:tile.netherores.ore.0:5' inherits='PresetHintVeins'>
+                <!-- Starting Vanilla Preset for Diamond. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoDiamondDist = "Vanilla"'>
+                        <StandardGen name='nthoDiamondStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x608BF4E3' drawBoundBox='false' boundBoxColor='0x608BF4E3'>
                             <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
+                                A master preset for standardgen  ore
+                                distributions.
                             </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60A80002</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Redstone Strategic Cloud Hint Veins -->
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:1")'> <OreBlock block='NetherOres:tile.netherores.ore.0:1' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 3 * nthoDiamondSize ' range=':= _default_ * nthoDiamondSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4 * nthoDiamondFreq ' range=':= _default_ * nthoDiamondFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Diamond is complete. -->
 
-                    </Cloud>
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Redstone -->
-                
-                
-                <!-- Begin  Vanilla distribution of Redstone -->
-                <IfCondition condition=':= nthoRedstoneDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='nthoRedstoneBaseStandard' block='NetherOres:tile.netherores.ore.0:5' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60A80002</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * nthoRedstoneSize * _default_'/>
-                        <Setting name='Height' avg=':= 120' range=':= 120' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1 * nthoRedstoneFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </StandardGen>
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Redstone -->
-                
-                <!-- End Redstone Generation --> 
+                <!-- End Diamond Generation -->
 
-                
-                <!-- Begin Copper Generation --> 
-                
-                <!-- Begin LayeredVeins distribution of Copper -->
-                <IfCondition condition=':= nthoCopperDist = "layeredVeins"'>
-                
-                    <Veins name='nthoCopperBaseVeins' block='NetherOres:tile.netherores.ore.0:6'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FF8E2B</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoCopperSize * _default_' range=':= 1 * 1 * nthoCopperSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoCopperSize * _default_' range=':= 1 * 1 * nthoCopperSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoCopperFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End LayeredVeins distribution of Copper -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Copper -->
-                <IfCondition condition=':= nthoCopperDist = "hugeVeins"'>
-                
-                    <Veins name='nthoCopperBaseVeins' block='NetherOres:tile.netherores.ore.0:6'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FF8E2B</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoCopperSize * _default_' range=':= 1 * 1 * nthoCopperSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoCopperSize * _default_' range=':= 1 * 1 * nthoCopperSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoCopperFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Copper -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Copper -->
-                <IfCondition condition=':= nthoCopperDist = "strategicCloud"'>
-                
-                    <Cloud name='nthoCopperBaseCloud' block='NetherOres:tile.netherores.ore.0:6' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FF8E2B</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1 * nthoCopperSize * _default_' range=':= 1 * 1 * nthoCopperSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * nthoCopperSize * _default_' range=':= 1 * 1 * nthoCopperSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1 * nthoCopperSize * _default_' range=':= 1 * 1 * 1 * nthoCopperSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 1 * nthoCopperFreq *_default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Copper Strategic Cloud Hint Veins -->
-                        <Veins name='nthoCopperBaseHintVeins' block='NetherOres:tile.netherores.ore.0:6' inherits='PresetHintVeins'>
+
+                <!-- Begin Gold Generation -->
+
+                <!-- Starting LayeredVeins Preset for Gold. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoGoldDist = "LayeredVeins"'>
+                        <Veins name='nthoGoldVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x608BF4E3' drawBoundBox='false' boundBoxColor='0x608BF4E3'>
                             <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
                             </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60FF8E2B</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:2")'> <OreBlock block='NetherOres:tile.netherores.ore.0:2' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.821 * _default_ * nthoGoldFreq ' range=':= _default_ * nthoGoldFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.936 * _default_ * nthoGoldSize ' range=':= _default_ * nthoGoldSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.936 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * nthoGoldSize ' range=':= _default_ * nthoGoldSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.936 * _default_ * nthoGoldSize ' range=':= _default_ * nthoGoldSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
-                        <!-- End Copper Strategic Cloud Hint Veins -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Gold is complete. -->
 
-                    </Cloud>
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Copper -->
-                
-                
-                <!-- Begin  Vanilla distribution of Copper -->
-                <IfCondition condition=':= nthoCopperDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='nthoCopperBaseStandard' block='NetherOres:tile.netherores.ore.0:6' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FF8E2B</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * nthoCopperSize * _default_'/>
-                        <Setting name='Height' avg=':= 120' range=':= 120' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1 * nthoCopperFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </StandardGen>
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Copper -->
-                
-                <!-- End Copper Generation --> 
 
-                
-                <!-- Begin Tin Generation --> 
-                
-                <!-- Begin LayeredVeins distribution of Tin -->
-                <IfCondition condition=':= nthoTinDist = "layeredVeins"'>
-                
-                    <Veins name='nthoTinBaseVeins' block='NetherOres:tile.netherores.ore.0:7'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E8E8E8</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoTinSize * _default_' range=':= 1 * 1 * nthoTinSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoTinSize * _default_' range=':= 1 * 1 * nthoTinSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoTinFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End LayeredVeins distribution of Tin -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Tin -->
-                <IfCondition condition=':= nthoTinDist = "hugeVeins"'>
-                
-                    <Veins name='nthoTinBaseVeins' block='NetherOres:tile.netherores.ore.0:7'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E8E8E8</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoTinSize * _default_' range=':= 1 * 1 * nthoTinSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoTinSize * _default_' range=':= 1 * 1 * nthoTinSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoTinFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Tin -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Tin -->
-                <IfCondition condition=':= nthoTinDist = "strategicCloud"'>
-                
-                    <Cloud name='nthoTinBaseCloud' block='NetherOres:tile.netherores.ore.0:7' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E8E8E8</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1 * nthoTinSize * _default_' range=':= 1 * 1 * nthoTinSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * nthoTinSize * _default_' range=':= 1 * 1 * nthoTinSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1 * nthoTinSize * _default_' range=':= 1 * 1 * 1 * nthoTinSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 1 * nthoTinFreq *_default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Tin Strategic Cloud Hint Veins -->
-                        <Veins name='nthoTinBaseHintVeins' block='NetherOres:tile.netherores.ore.0:7' inherits='PresetHintVeins'>
+                <!-- Starting Cloud Preset for Gold. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoGoldDist = "Cloud"'>
+                        <Cloud name='nthoGoldCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x608BF4E3' drawBoundBox='false' boundBoxColor='0x608BF4E3'>
                             <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
                             </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60E8E8E8</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Tin Strategic Cloud Hint Veins -->
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:2")'> <OreBlock block='NetherOres:tile.netherores.ore.0:2' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.280 * _default_ * nthoGoldSize ' range=':= _default_ * nthoGoldSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.280 * _default_ * nthoGoldSize ' range=':= _default_ * nthoGoldSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.638  * _default_ * nthoGoldFreq ' range=':= _default_ * nthoGoldFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Veins name='nthoGoldHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x608BF4E3' drawBoundBox='false' boundBoxColor='0x608BF4E3'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:2")'> <OreBlock block='NetherOres:tile.netherores.ore.0:2' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Gold is complete. -->
 
-                    </Cloud>
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Tin -->
-                
-                
-                <!-- Begin  Vanilla distribution of Tin -->
-                <IfCondition condition=':= nthoTinDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='nthoTinBaseStandard' block='NetherOres:tile.netherores.ore.0:7' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E8E8E8</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * nthoTinSize * _default_'/>
-                        <Setting name='Height' avg=':= 120' range=':= 120' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1 * nthoTinFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </StandardGen>
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Tin -->
-                
-                <!-- End Tin Generation --> 
 
-                
-                <!-- Begin Emerald Generation --> 
-                
-                <!-- Begin LayeredVeins distribution of Emerald -->
-                <IfCondition condition=':= nthoEmeraldDist = "layeredVeins"'>
-                
-                    <Veins name='nthoEmeraldBaseVeins' block='NetherOres:tile.netherores.ore.0:8'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x606CE391</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoEmeraldSize * _default_' range=':= 1 * 1 * nthoEmeraldSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoEmeraldSize * _default_' range=':= 1 * 1 * nthoEmeraldSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoEmeraldFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End LayeredVeins distribution of Emerald -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Emerald -->
-                <IfCondition condition=':= nthoEmeraldDist = "hugeVeins"'>
-                
-                    <Veins name='nthoEmeraldBaseVeins' block='NetherOres:tile.netherores.ore.0:8'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x606CE391</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoEmeraldSize * _default_' range=':= 1 * 1 * nthoEmeraldSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoEmeraldSize * _default_' range=':= 1 * 1 * nthoEmeraldSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoEmeraldFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Emerald -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Emerald -->
-                <IfCondition condition=':= nthoEmeraldDist = "strategicCloud"'>
-                
-                    <Cloud name='nthoEmeraldBaseCloud' block='NetherOres:tile.netherores.ore.0:8' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x606CE391</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1 * nthoEmeraldSize * _default_' range=':= 1 * 1 * nthoEmeraldSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * nthoEmeraldSize * _default_' range=':= 1 * 1 * nthoEmeraldSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1 * nthoEmeraldSize * _default_' range=':= 1 * 1 * 1 * nthoEmeraldSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 1 * nthoEmeraldFreq *_default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Emerald Strategic Cloud Hint Veins -->
-                        <Veins name='nthoEmeraldBaseHintVeins' block='NetherOres:tile.netherores.ore.0:8' inherits='PresetHintVeins'>
+                <!-- Starting Vanilla Preset for Gold. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoGoldDist = "Vanilla"'>
+                        <StandardGen name='nthoGoldStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x608BF4E3' drawBoundBox='false' boundBoxColor='0x608BF4E3'>
                             <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
+                                A master preset for standardgen  ore
+                                distributions.
                             </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x606CE391</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Emerald Strategic Cloud Hint Veins -->
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:2")'> <OreBlock block='NetherOres:tile.netherores.ore.0:2' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 6 * nthoGoldSize ' range=':= _default_ * nthoGoldSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 8 * nthoGoldFreq ' range=':= _default_ * nthoGoldFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Gold is complete. -->
 
-                    </Cloud>
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Emerald -->
-                
-                
-                <!-- Begin  Vanilla distribution of Emerald -->
-                <IfCondition condition=':= nthoEmeraldDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='nthoEmeraldBaseStandard' block='NetherOres:tile.netherores.ore.0:8' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x606CE391</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * nthoEmeraldSize * _default_'/>
-                        <Setting name='Height' avg=':= 120' range=':= 120' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1 * nthoEmeraldFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </StandardGen>
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Emerald -->
-                
-                <!-- End Emerald Generation --> 
+                <!-- End Gold Generation -->
 
-                
-                <!-- Begin Silver Generation --> 
-                
-                <!-- Begin LayeredVeins distribution of Silver -->
-                <IfCondition condition=':= nthoSilverDist = "layeredVeins"'>
-                
-                    <Veins name='nthoSilverBaseVeins' block='NetherOres:tile.netherores.ore.0:9'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E3F2F7</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoSilverSize * _default_' range=':= 1 * 1 * nthoSilverSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoSilverSize * _default_' range=':= 1 * 1 * nthoSilverSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoSilverFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End LayeredVeins distribution of Silver -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Silver -->
-                <IfCondition condition=':= nthoSilverDist = "hugeVeins"'>
-                
-                    <Veins name='nthoSilverBaseVeins' block='NetherOres:tile.netherores.ore.0:9'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E3F2F7</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoSilverSize * _default_' range=':= 1 * 1 * nthoSilverSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoSilverSize * _default_' range=':= 1 * 1 * nthoSilverSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoSilverFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Silver -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Silver -->
-                <IfCondition condition=':= nthoSilverDist = "strategicCloud"'>
-                
-                    <Cloud name='nthoSilverBaseCloud' block='NetherOres:tile.netherores.ore.0:9' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E3F2F7</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1 * nthoSilverSize * _default_' range=':= 1 * 1 * nthoSilverSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * nthoSilverSize * _default_' range=':= 1 * 1 * nthoSilverSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1 * nthoSilverSize * _default_' range=':= 1 * 1 * 1 * nthoSilverSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 1 * nthoSilverFreq *_default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Silver Strategic Cloud Hint Veins -->
-                        <Veins name='nthoSilverBaseHintVeins' block='NetherOres:tile.netherores.ore.0:9' inherits='PresetHintVeins'>
+
+                <!-- Begin Iron Generation -->
+
+                <!-- Starting LayeredVeins Preset for Iron. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoIronDist = "LayeredVeins"'>
+                        <Veins name='nthoIronVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60DDC2AF' drawBoundBox='false' boundBoxColor='0x60DDC2AF'>
                             <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
                             </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60E3F2F7</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:3")'> <OreBlock block='NetherOres:tile.netherores.ore.0:3' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.948 * _default_ * nthoIronFreq ' range=':= _default_ * nthoIronFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.982 * _default_ * nthoIronSize ' range=':= _default_ * nthoIronSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.982 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * nthoIronSize ' range=':= _default_ * nthoIronSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.982 * _default_ * nthoIronSize ' range=':= _default_ * nthoIronSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
-                        <!-- End Silver Strategic Cloud Hint Veins -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Iron is complete. -->
 
-                    </Cloud>
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Silver -->
-                
-                
-                <!-- Begin  Vanilla distribution of Silver -->
-                <IfCondition condition=':= nthoSilverDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='nthoSilverBaseStandard' block='NetherOres:tile.netherores.ore.0:9' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E3F2F7</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * nthoSilverSize * _default_'/>
-                        <Setting name='Height' avg=':= 120' range=':= 120' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1 * nthoSilverFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </StandardGen>
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Silver -->
-                
-                <!-- End Silver Generation --> 
 
-                
-                <!-- Begin Lead Generation --> 
-                
-                <!-- Begin LayeredVeins distribution of Lead -->
-                <IfCondition condition=':= nthoLeadDist = "layeredVeins"'>
-                
-                    <Veins name='nthoLeadBaseVeins' block='NetherOres:tile.netherores.ore.0:10'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60818EBE</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoLeadSize * _default_' range=':= 1 * 1 * nthoLeadSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoLeadSize * _default_' range=':= 1 * 1 * nthoLeadSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoLeadFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End LayeredVeins distribution of Lead -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Lead -->
-                <IfCondition condition=':= nthoLeadDist = "hugeVeins"'>
-                
-                    <Veins name='nthoLeadBaseVeins' block='NetherOres:tile.netherores.ore.0:10'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60818EBE</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoLeadSize * _default_' range=':= 1 * 1 * nthoLeadSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoLeadSize * _default_' range=':= 1 * 1 * nthoLeadSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoLeadFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Lead -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Lead -->
-                <IfCondition condition=':= nthoLeadDist = "strategicCloud"'>
-                
-                    <Cloud name='nthoLeadBaseCloud' block='NetherOres:tile.netherores.ore.0:10' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60818EBE</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1 * nthoLeadSize * _default_' range=':= 1 * 1 * nthoLeadSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * nthoLeadSize * _default_' range=':= 1 * 1 * nthoLeadSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1 * nthoLeadSize * _default_' range=':= 1 * 1 * 1 * nthoLeadSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 1 * nthoLeadFreq *_default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Lead Strategic Cloud Hint Veins -->
-                        <Veins name='nthoLeadBaseHintVeins' block='NetherOres:tile.netherores.ore.0:10' inherits='PresetHintVeins'>
+                <!-- Starting Cloud Preset for Iron. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoIronDist = "Cloud"'>
+                        <Cloud name='nthoIronCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60DDC2AF' drawBoundBox='false' boundBoxColor='0x60DDC2AF'>
                             <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
                             </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60818EBE</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Lead Strategic Cloud Hint Veins -->
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:3")'> <OreBlock block='NetherOres:tile.netherores.ore.0:3' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.375 * _default_ * nthoIronSize ' range=':= _default_ * nthoIronSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.375 * _default_ * nthoIronSize ' range=':= _default_ * nthoIronSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.892  * _default_ * nthoIronFreq ' range=':= _default_ * nthoIronFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Veins name='nthoIronHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60DDC2AF' drawBoundBox='false' boundBoxColor='0x60DDC2AF'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:3")'> <OreBlock block='NetherOres:tile.netherores.ore.0:3' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Iron is complete. -->
 
-                    </Cloud>
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Lead -->
-                
-                
-                <!-- Begin  Vanilla distribution of Lead -->
-                <IfCondition condition=':= nthoLeadDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='nthoLeadBaseStandard' block='NetherOres:tile.netherores.ore.0:10' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60818EBE</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * nthoLeadSize * _default_'/>
-                        <Setting name='Height' avg=':= 120' range=':= 120' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1 * nthoLeadFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </StandardGen>
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Lead -->
-                
-                <!-- End Lead Generation --> 
 
-                
-                <!-- Begin Uranium Generation --> 
-                
-                <!-- Begin LayeredVeins distribution of Uranium -->
-                <IfCondition condition=':= nthoUraniumDist = "layeredVeins"'>
-                
-                    <Veins name='nthoUraniumBaseVeins' block='NetherOres:tile.netherores.ore.0:11'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60ACFE91</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoUraniumSize * _default_' range=':= 1 * 1 * nthoUraniumSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoUraniumSize * _default_' range=':= 1 * 1 * nthoUraniumSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoUraniumFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End LayeredVeins distribution of Uranium -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Uranium -->
-                <IfCondition condition=':= nthoUraniumDist = "hugeVeins"'>
-                
-                    <Veins name='nthoUraniumBaseVeins' block='NetherOres:tile.netherores.ore.0:11'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60ACFE91</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoUraniumSize * _default_' range=':= 1 * 1 * nthoUraniumSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoUraniumSize * _default_' range=':= 1 * 1 * nthoUraniumSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoUraniumFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Uranium -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Uranium -->
-                <IfCondition condition=':= nthoUraniumDist = "strategicCloud"'>
-                
-                    <Cloud name='nthoUraniumBaseCloud' block='NetherOres:tile.netherores.ore.0:11' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60ACFE91</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1 * nthoUraniumSize * _default_' range=':= 1 * 1 * nthoUraniumSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * nthoUraniumSize * _default_' range=':= 1 * 1 * nthoUraniumSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1 * nthoUraniumSize * _default_' range=':= 1 * 1 * 1 * nthoUraniumSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 1 * nthoUraniumFreq *_default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Uranium Strategic Cloud Hint Veins -->
-                        <Veins name='nthoUraniumBaseHintVeins' block='NetherOres:tile.netherores.ore.0:11' inherits='PresetHintVeins'>
+                <!-- Starting Vanilla Preset for Iron. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoIronDist = "Vanilla"'>
+                        <StandardGen name='nthoIronStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60DDC2AF' drawBoundBox='false' boundBoxColor='0x60DDC2AF'>
                             <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
+                                A master preset for standardgen  ore
+                                distributions.
                             </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60ACFE91</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Uranium Strategic Cloud Hint Veins -->
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:3")'> <OreBlock block='NetherOres:tile.netherores.ore.0:3' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 8 * nthoIronSize ' range=':= _default_ * nthoIronSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 8 * nthoIronFreq ' range=':= _default_ * nthoIronFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Iron is complete. -->
 
-                    </Cloud>
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Uranium -->
-                
-                
-                <!-- Begin  Vanilla distribution of Uranium -->
-                <IfCondition condition=':= nthoUraniumDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='nthoUraniumBaseStandard' block='NetherOres:tile.netherores.ore.0:11' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60ACFE91</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * nthoUraniumSize * _default_'/>
-                        <Setting name='Height' avg=':= 120' range=':= 120' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1 * nthoUraniumFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </StandardGen>
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Uranium -->
-                
-                <!-- End Uranium Generation --> 
+                <!-- End Iron Generation -->
 
-                
-                <!-- Begin Nikolite Generation --> 
-                
-                <!-- Begin LayeredVeins distribution of Nikolite -->
-                <IfCondition condition=':= nthoNikoliteDist = "layeredVeins"'>
-                
-                    <Veins name='nthoNikoliteBaseVeins' block='NetherOres:tile.netherores.ore.0:12'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x6001FFFC</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoNikoliteSize * _default_' range=':= 1 * 1 * nthoNikoliteSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoNikoliteSize * _default_' range=':= 1 * 1 * nthoNikoliteSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoNikoliteFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End LayeredVeins distribution of Nikolite -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Nikolite -->
-                <IfCondition condition=':= nthoNikoliteDist = "hugeVeins"'>
-                
-                    <Veins name='nthoNikoliteBaseVeins' block='NetherOres:tile.netherores.ore.0:12'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x6001FFFC</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoNikoliteSize * _default_' range=':= 1 * 1 * nthoNikoliteSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoNikoliteSize * _default_' range=':= 1 * 1 * nthoNikoliteSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoNikoliteFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Nikolite -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Nikolite -->
-                <IfCondition condition=':= nthoNikoliteDist = "strategicCloud"'>
-                
-                    <Cloud name='nthoNikoliteBaseCloud' block='NetherOres:tile.netherores.ore.0:12' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x6001FFFC</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1 * nthoNikoliteSize * _default_' range=':= 1 * 1 * nthoNikoliteSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * nthoNikoliteSize * _default_' range=':= 1 * 1 * nthoNikoliteSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1 * nthoNikoliteSize * _default_' range=':= 1 * 1 * 1 * nthoNikoliteSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 1 * nthoNikoliteFreq *_default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Nikolite Strategic Cloud Hint Veins -->
-                        <Veins name='nthoNikoliteBaseHintVeins' block='NetherOres:tile.netherores.ore.0:12' inherits='PresetHintVeins'>
+
+                <!-- Begin Lapis Lazuli Generation -->
+
+                <!-- Starting VerticalVeins Preset for Lapis Lazuli. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoLapisLazuliDist = "VerticalVeins"'>
+                        <Veins name='nthoLapisLazuliVeins'  inherits='PresetVerticalVeins' drawWireframe='true' wireframeColor='0x601442BA' drawBoundBox='false' boundBoxColor='0x601442BA'>
                             <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
+                                Single vertical veins that occur  with
+                                no motherlodes.
                             </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x6001FFFC</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:4")'> <OreBlock block='NetherOres:tile.netherores.ore.0:4' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.317 * _default_ * nthoLapisLazuliFreq ' range=':= _default_ * nthoLapisLazuliFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.096 * _default_ * nthoLapisLazuliSize ' range=':= _default_ * nthoLapisLazuliSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.096 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * nthoLapisLazuliSize ' range=':= _default_ * nthoLapisLazuliSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.096 * _default_ * nthoLapisLazuliSize ' range=':= _default_ * nthoLapisLazuliSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
-                        <!-- End Nikolite Strategic Cloud Hint Veins -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- VerticalVeins Preset for Lapis Lazuli is
+                     complete. -->
 
-                    </Cloud>
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Nikolite -->
-                
-                
-                <!-- Begin  Vanilla distribution of Nikolite -->
-                <IfCondition condition=':= nthoNikoliteDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='nthoNikoliteBaseStandard' block='NetherOres:tile.netherores.ore.0:12' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x6001FFFC</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * nthoNikoliteSize * _default_'/>
-                        <Setting name='Height' avg=':= 120' range=':= 120' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1 * nthoNikoliteFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </StandardGen>
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Nikolite -->
-                
-                <!-- End Nikolite Generation --> 
 
-                
-                <!-- Begin Ruby Generation --> 
-                
-                <!-- Begin LayeredVeins distribution of Ruby -->
-                <IfCondition condition=':= nthoRubyDist = "layeredVeins"'>
-                
-                    <Veins name='nthoRubyBaseVeins' block='NetherOres:tile.netherores.ore.0:13'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60D10415</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoRubySize * _default_' range=':= 1 * 1 * nthoRubySize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoRubySize * _default_' range=':= 1 * 1 * nthoRubySize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoRubyFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End LayeredVeins distribution of Ruby -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Ruby -->
-                <IfCondition condition=':= nthoRubyDist = "hugeVeins"'>
-                
-                    <Veins name='nthoRubyBaseVeins' block='NetherOres:tile.netherores.ore.0:13'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60D10415</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoRubySize * _default_' range=':= 1 * 1 * nthoRubySize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoRubySize * _default_' range=':= 1 * 1 * nthoRubySize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoRubyFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Ruby -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Ruby -->
-                <IfCondition condition=':= nthoRubyDist = "strategicCloud"'>
-                
-                    <Cloud name='nthoRubyBaseCloud' block='NetherOres:tile.netherores.ore.0:13' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60D10415</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1 * nthoRubySize * _default_' range=':= 1 * 1 * nthoRubySize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * nthoRubySize * _default_' range=':= 1 * 1 * nthoRubySize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1 * nthoRubySize * _default_' range=':= 1 * 1 * 1 * nthoRubySize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 1 * nthoRubyFreq *_default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Ruby Strategic Cloud Hint Veins -->
-                        <Veins name='nthoRubyBaseHintVeins' block='NetherOres:tile.netherores.ore.0:13' inherits='PresetHintVeins'>
+                <!-- Starting Cloud Preset for Lapis Lazuli. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoLapisLazuliDist = "Cloud"'>
+                        <Cloud name='nthoLapisLazuliCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x601442BA' drawBoundBox='false' boundBoxColor='0x601442BA'>
                             <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
                             </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60D10415</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Ruby Strategic Cloud Hint Veins -->
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:4")'> <OreBlock block='NetherOres:tile.netherores.ore.0:4' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.191 * _default_ * nthoLapisLazuliSize ' range=':= _default_ * nthoLapisLazuliSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.191 * _default_ * nthoLapisLazuliSize ' range=':= _default_ * nthoLapisLazuliSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.419  * _default_ * nthoLapisLazuliFreq ' range=':= _default_ * nthoLapisLazuliFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Veins name='nthoLapisLazuliHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x601442BA' drawBoundBox='false' boundBoxColor='0x601442BA'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:4")'> <OreBlock block='NetherOres:tile.netherores.ore.0:4' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Lapis Lazuli is complete. -->
 
-                    </Cloud>
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Ruby -->
-                
-                
-                <!-- Begin  Vanilla distribution of Ruby -->
-                <IfCondition condition=':= nthoRubyDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='nthoRubyBaseStandard' block='NetherOres:tile.netherores.ore.0:13' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60D10415</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * nthoRubySize * _default_'/>
-                        <Setting name='Height' avg=':= 120' range=':= 120' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1 * nthoRubyFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </StandardGen>
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Ruby -->
-                
-                <!-- End Ruby Generation --> 
 
-                
-                <!-- Begin Peridot Generation --> 
-                
-                <!-- Begin LayeredVeins distribution of Peridot -->
-                <IfCondition condition=':= nthoPeridotDist = "layeredVeins"'>
-                
-                    <Veins name='nthoPeridotBaseVeins' block='NetherOres:tile.netherores.ore.0:14'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x6054A228</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoPeridotSize * _default_' range=':= 1 * 1 * nthoPeridotSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoPeridotSize * _default_' range=':= 1 * 1 * nthoPeridotSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoPeridotFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End LayeredVeins distribution of Peridot -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Peridot -->
-                <IfCondition condition=':= nthoPeridotDist = "hugeVeins"'>
-                
-                    <Veins name='nthoPeridotBaseVeins' block='NetherOres:tile.netherores.ore.0:14'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x6054A228</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoPeridotSize * _default_' range=':= 1 * 1 * nthoPeridotSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoPeridotSize * _default_' range=':= 1 * 1 * nthoPeridotSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoPeridotFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Peridot -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Peridot -->
-                <IfCondition condition=':= nthoPeridotDist = "strategicCloud"'>
-                
-                    <Cloud name='nthoPeridotBaseCloud' block='NetherOres:tile.netherores.ore.0:14' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x6054A228</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1 * nthoPeridotSize * _default_' range=':= 1 * 1 * nthoPeridotSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * nthoPeridotSize * _default_' range=':= 1 * 1 * nthoPeridotSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1 * nthoPeridotSize * _default_' range=':= 1 * 1 * 1 * nthoPeridotSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 1 * nthoPeridotFreq *_default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Peridot Strategic Cloud Hint Veins -->
-                        <Veins name='nthoPeridotBaseHintVeins' block='NetherOres:tile.netherores.ore.0:14' inherits='PresetHintVeins'>
+                <!-- Starting Vanilla Preset for Lapis Lazuli. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoLapisLazuliDist = "Vanilla"'>
+                        <StandardGen name='nthoLapisLazuliStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x601442BA' drawBoundBox='false' boundBoxColor='0x601442BA'>
                             <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
+                                A master preset for standardgen  ore
+                                distributions.
                             </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x6054A228</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Peridot Strategic Cloud Hint Veins -->
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:4")'> <OreBlock block='NetherOres:tile.netherores.ore.0:4' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 6 * nthoLapisLazuliSize ' range=':= _default_ * nthoLapisLazuliSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 6 * nthoLapisLazuliFreq ' range=':= _default_ * nthoLapisLazuliFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Lapis Lazuli is complete. -->
 
-                    </Cloud>
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Peridot -->
-                
-                
-                <!-- Begin  Vanilla distribution of Peridot -->
-                <IfCondition condition=':= nthoPeridotDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='nthoPeridotBaseStandard' block='NetherOres:tile.netherores.ore.0:14' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x6054A228</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * nthoPeridotSize * _default_'/>
-                        <Setting name='Height' avg=':= 120' range=':= 120' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1 * nthoPeridotFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </StandardGen>
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Peridot -->
-                
-                <!-- End Peridot Generation --> 
+                <!-- End Lapis Lazuli Generation -->
 
-                
-                <!-- Begin Sapphire Generation --> 
-                
-                <!-- Begin LayeredVeins distribution of Sapphire -->
-                <IfCondition condition=':= nthoSapphireDist = "layeredVeins"'>
-                
-                    <Veins name='nthoSapphireBaseVeins' block='NetherOres:tile.netherores.ore.0:15'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60554DB4</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoSapphireSize * _default_' range=':= 1 * 1 * nthoSapphireSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoSapphireSize * _default_' range=':= 1 * 1 * nthoSapphireSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoSapphireFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End LayeredVeins distribution of Sapphire -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Sapphire -->
-                <IfCondition condition=':= nthoSapphireDist = "hugeVeins"'>
-                
-                    <Veins name='nthoSapphireBaseVeins' block='NetherOres:tile.netherores.ore.0:15'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60554DB4</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoSapphireSize * _default_' range=':= 1 * 1 * nthoSapphireSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoSapphireSize * _default_' range=':= 1 * 1 * nthoSapphireSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoSapphireFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Sapphire -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Sapphire -->
-                <IfCondition condition=':= nthoSapphireDist = "strategicCloud"'>
-                
-                    <Cloud name='nthoSapphireBaseCloud' block='NetherOres:tile.netherores.ore.0:15' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60554DB4</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1 * nthoSapphireSize * _default_' range=':= 1 * 1 * nthoSapphireSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * nthoSapphireSize * _default_' range=':= 1 * 1 * nthoSapphireSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1 * nthoSapphireSize * _default_' range=':= 1 * 1 * 1 * nthoSapphireSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 1 * nthoSapphireFreq *_default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Sapphire Strategic Cloud Hint Veins -->
-                        <Veins name='nthoSapphireBaseHintVeins' block='NetherOres:tile.netherores.ore.0:15' inherits='PresetHintVeins'>
+
+                <!-- Begin Redstone Generation -->
+
+                <!-- Starting VerticalVeins Preset for Redstone. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoRedstoneDist = "VerticalVeins"'>
+                        <Veins name='nthoRedstoneVeins'  inherits='PresetVerticalVeins' drawWireframe='true' wireframeColor='0x60A80002' drawBoundBox='false' boundBoxColor='0x60A80002'>
                             <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
+                                Single vertical veins that occur  with
+                                no motherlodes.
                             </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60554DB4</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:5")'> <OreBlock block='NetherOres:tile.netherores.ore.0:5' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.521 * _default_ * nthoRedstoneFreq ' range=':= _default_ * nthoRedstoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.150 * _default_ * nthoRedstoneSize ' range=':= _default_ * nthoRedstoneSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.150 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * nthoRedstoneSize ' range=':= _default_ * nthoRedstoneSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.150 * _default_ * nthoRedstoneSize ' range=':= _default_ * nthoRedstoneSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
-                        <!-- End Sapphire Strategic Cloud Hint Veins -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- VerticalVeins Preset for Redstone is complete. -->
 
-                    </Cloud>
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Sapphire -->
-                
-                
-                <!-- Begin  Vanilla distribution of Sapphire -->
-                <IfCondition condition=':= nthoSapphireDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='nthoSapphireBaseStandard' block='NetherOres:tile.netherores.ore.0:15' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60554DB4</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * nthoSapphireSize * _default_'/>
-                        <Setting name='Height' avg=':= 120' range=':= 120' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1 * nthoSapphireFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </StandardGen>
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Sapphire -->
-                
-                <!-- End Sapphire Generation --> 
 
-                
-                <!-- Begin Platinum Generation --> 
-                
-                <!-- Begin LayeredVeins distribution of Platinum -->
-                <IfCondition condition=':= nthoPlatinumDist = "layeredVeins"'>
-                
-                    <Veins name='nthoPlatinumBaseVeins' block='NetherOres:tile.netherores.ore.1'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x6072A0D2</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoPlatinumSize * _default_' range=':= 1 * 1 * nthoPlatinumSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoPlatinumSize * _default_' range=':= 1 * 1 * nthoPlatinumSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoPlatinumFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End LayeredVeins distribution of Platinum -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Platinum -->
-                <IfCondition condition=':= nthoPlatinumDist = "hugeVeins"'>
-                
-                    <Veins name='nthoPlatinumBaseVeins' block='NetherOres:tile.netherores.ore.1'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x6072A0D2</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoPlatinumSize * _default_' range=':= 1 * 1 * nthoPlatinumSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoPlatinumSize * _default_' range=':= 1 * 1 * nthoPlatinumSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoPlatinumFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Platinum -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Platinum -->
-                <IfCondition condition=':= nthoPlatinumDist = "strategicCloud"'>
-                
-                    <Cloud name='nthoPlatinumBaseCloud' block='NetherOres:tile.netherores.ore.1' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x6072A0D2</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1 * nthoPlatinumSize * _default_' range=':= 1 * 1 * nthoPlatinumSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * nthoPlatinumSize * _default_' range=':= 1 * 1 * nthoPlatinumSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1 * nthoPlatinumSize * _default_' range=':= 1 * 1 * 1 * nthoPlatinumSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 1 * nthoPlatinumFreq *_default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Platinum Strategic Cloud Hint Veins -->
-                        <Veins name='nthoPlatinumBaseHintVeins' block='NetherOres:tile.netherores.ore.1' inherits='PresetHintVeins'>
+                <!-- Starting Cloud Preset for Redstone. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoRedstoneDist = "Cloud"'>
+                        <Cloud name='nthoRedstoneCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60A80002' drawBoundBox='false' boundBoxColor='0x60A80002'>
                             <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
                             </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x6072A0D2</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Platinum Strategic Cloud Hint Veins -->
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:5")'> <OreBlock block='NetherOres:tile.netherores.ore.0:5' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.280 * _default_ * nthoRedstoneSize ' range=':= _default_ * nthoRedstoneSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.280 * _default_ * nthoRedstoneSize ' range=':= _default_ * nthoRedstoneSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.638  * _default_ * nthoRedstoneFreq ' range=':= _default_ * nthoRedstoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Veins name='nthoRedstoneHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60A80002' drawBoundBox='false' boundBoxColor='0x60A80002'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:5")'> <OreBlock block='NetherOres:tile.netherores.ore.0:5' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Redstone is complete. -->
 
-                    </Cloud>
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Platinum -->
-                
-                
-                <!-- Begin  Vanilla distribution of Platinum -->
-                <IfCondition condition=':= nthoPlatinumDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='nthoPlatinumBaseStandard' block='NetherOres:tile.netherores.ore.1' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x6072A0D2</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * nthoPlatinumSize * _default_'/>
-                        <Setting name='Height' avg=':= 120' range=':= 120' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1 * nthoPlatinumFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </StandardGen>
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Platinum -->
-                
-                <!-- End Platinum Generation --> 
 
-                
-                <!-- Begin Ferrous Generation --> 
-                
-                <!-- Begin LayeredVeins distribution of Ferrous -->
-                <IfCondition condition=':= nthoFerrousDist = "layeredVeins"'>
-                
-                    <Veins name='nthoFerrousBaseVeins' block='NetherOres:tile.netherores.ore.1:1'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60DDD396</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoFerrousSize * _default_' range=':= 1 * 1 * nthoFerrousSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoFerrousSize * _default_' range=':= 1 * 1 * nthoFerrousSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoFerrousFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End LayeredVeins distribution of Ferrous -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Ferrous -->
-                <IfCondition condition=':= nthoFerrousDist = "hugeVeins"'>
-                
-                    <Veins name='nthoFerrousBaseVeins' block='NetherOres:tile.netherores.ore.1:1'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60DDD396</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoFerrousSize * _default_' range=':= 1 * 1 * nthoFerrousSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoFerrousSize * _default_' range=':= 1 * 1 * nthoFerrousSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoFerrousFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Ferrous -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Ferrous -->
-                <IfCondition condition=':= nthoFerrousDist = "strategicCloud"'>
-                
-                    <Cloud name='nthoFerrousBaseCloud' block='NetherOres:tile.netherores.ore.1:1' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60DDD396</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1 * nthoFerrousSize * _default_' range=':= 1 * 1 * nthoFerrousSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * nthoFerrousSize * _default_' range=':= 1 * 1 * nthoFerrousSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1 * nthoFerrousSize * _default_' range=':= 1 * 1 * 1 * nthoFerrousSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 1 * nthoFerrousFreq *_default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Ferrous Strategic Cloud Hint Veins -->
-                        <Veins name='nthoFerrousBaseHintVeins' block='NetherOres:tile.netherores.ore.1:1' inherits='PresetHintVeins'>
+                <!-- Starting Vanilla Preset for Redstone. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoRedstoneDist = "Vanilla"'>
+                        <StandardGen name='nthoRedstoneStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60A80002' drawBoundBox='false' boundBoxColor='0x60A80002'>
                             <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
+                                A master preset for standardgen  ore
+                                distributions.
                             </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60DDD396</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Ferrous Strategic Cloud Hint Veins -->
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:5")'> <OreBlock block='NetherOres:tile.netherores.ore.0:5' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 8 * nthoRedstoneSize ' range=':= _default_ * nthoRedstoneSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 6 * nthoRedstoneFreq ' range=':= _default_ * nthoRedstoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Redstone is complete. -->
 
-                    </Cloud>
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Ferrous -->
-                
-                
-                <!-- Begin  Vanilla distribution of Ferrous -->
-                <IfCondition condition=':= nthoFerrousDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='nthoFerrousBaseStandard' block='NetherOres:tile.netherores.ore.1:1' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60DDD396</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * nthoFerrousSize * _default_'/>
-                        <Setting name='Height' avg=':= 120' range=':= 120' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1 * nthoFerrousFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </StandardGen>
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Ferrous -->
-                
-                <!-- End Ferrous Generation --> 
+                <!-- End Redstone Generation -->
 
-                
-                <!-- Begin Pig Iron Generation --> 
-                
-                <!-- Begin LayeredVeins distribution of Pig Iron -->
-                <IfCondition condition=':= nthoPigIronDist = "layeredVeins"'>
-                
-                    <Veins name='nthoPigIronBaseVeins' block='NetherOres:tile.netherores.ore.1:2'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E89D97</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoPigIronSize * _default_' range=':= 1 * 1 * nthoPigIronSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoPigIronSize * _default_' range=':= 1 * 1 * nthoPigIronSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoPigIronFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End LayeredVeins distribution of Pig Iron -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Pig Iron -->
-                <IfCondition condition=':= nthoPigIronDist = "hugeVeins"'>
-                
-                    <Veins name='nthoPigIronBaseVeins' block='NetherOres:tile.netherores.ore.1:2'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E89D97</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoPigIronSize * _default_' range=':= 1 * 1 * nthoPigIronSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoPigIronSize * _default_' range=':= 1 * 1 * nthoPigIronSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoPigIronFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Pig Iron -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Pig Iron -->
-                <IfCondition condition=':= nthoPigIronDist = "strategicCloud"'>
-                
-                    <Cloud name='nthoPigIronBaseCloud' block='NetherOres:tile.netherores.ore.1:2' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E89D97</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1 * nthoPigIronSize * _default_' range=':= 1 * 1 * nthoPigIronSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * nthoPigIronSize * _default_' range=':= 1 * 1 * nthoPigIronSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1 * nthoPigIronSize * _default_' range=':= 1 * 1 * 1 * nthoPigIronSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 1 * nthoPigIronFreq *_default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Pig Iron Strategic Cloud Hint Veins -->
-                        <Veins name='nthoPigIronBaseHintVeins' block='NetherOres:tile.netherores.ore.1:2' inherits='PresetHintVeins'>
+
+                <!-- Begin Copper Generation -->
+
+                <!-- Starting LayeredVeins Preset for Copper. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoCopperDist = "LayeredVeins"'>
+                        <Veins name='nthoCopperVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
                             <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
                             </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60E89D97</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:6")'> <OreBlock block='NetherOres:tile.netherores.ore.0:6' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.948 * _default_ * nthoCopperFreq ' range=':= _default_ * nthoCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.982 * _default_ * nthoCopperSize ' range=':= _default_ * nthoCopperSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.982 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * nthoCopperSize ' range=':= _default_ * nthoCopperSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.982 * _default_ * nthoCopperSize ' range=':= _default_ * nthoCopperSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
-                        <!-- End Pig Iron Strategic Cloud Hint Veins -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Copper is complete. -->
 
-                    </Cloud>
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Pig Iron -->
-                
-                
-                <!-- Begin  Vanilla distribution of Pig Iron -->
-                <IfCondition condition=':= nthoPigIronDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='nthoPigIronBaseStandard' block='NetherOres:tile.netherores.ore.1:2' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60E89D97</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * nthoPigIronSize * _default_'/>
-                        <Setting name='Height' avg=':= 120' range=':= 120' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1 * nthoPigIronFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </StandardGen>
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Pig Iron -->
-                
-                <!-- End Pig Iron Generation --> 
 
-                
-                <!-- Begin Iridium Generation --> 
-                
-                <!-- Begin LayeredVeins distribution of Iridium -->
-                <IfCondition condition=':= nthoIridiumDist = "layeredVeins"'>
-                
-                    <Veins name='nthoIridiumBaseVeins' block='NetherOres:tile.netherores.ore.1:3'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60CECECE</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoIridiumSize * _default_' range=':= 1 * 1 * nthoIridiumSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoIridiumSize * _default_' range=':= 1 * 1 * nthoIridiumSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoIridiumFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End LayeredVeins distribution of Iridium -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Iridium -->
-                <IfCondition condition=':= nthoIridiumDist = "hugeVeins"'>
-                
-                    <Veins name='nthoIridiumBaseVeins' block='NetherOres:tile.netherores.ore.1:3'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60CECECE</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoIridiumSize * _default_' range=':= 1 * 1 * nthoIridiumSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoIridiumSize * _default_' range=':= 1 * 1 * nthoIridiumSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoIridiumFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Iridium -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Iridium -->
-                <IfCondition condition=':= nthoIridiumDist = "strategicCloud"'>
-                
-                    <Cloud name='nthoIridiumBaseCloud' block='NetherOres:tile.netherores.ore.1:3' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60CECECE</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1 * nthoIridiumSize * _default_' range=':= 1 * 1 * nthoIridiumSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * nthoIridiumSize * _default_' range=':= 1 * 1 * nthoIridiumSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1 * nthoIridiumSize * _default_' range=':= 1 * 1 * 1 * nthoIridiumSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 1 * nthoIridiumFreq *_default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Iridium Strategic Cloud Hint Veins -->
-                        <Veins name='nthoIridiumBaseHintVeins' block='NetherOres:tile.netherores.ore.1:3' inherits='PresetHintVeins'>
+                <!-- Starting Cloud Preset for Copper. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoCopperDist = "Cloud"'>
+                        <Cloud name='nthoCopperCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
                             <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
                             </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60CECECE</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Iridium Strategic Cloud Hint Veins -->
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:6")'> <OreBlock block='NetherOres:tile.netherores.ore.0:6' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.375 * _default_ * nthoCopperSize ' range=':= _default_ * nthoCopperSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.375 * _default_ * nthoCopperSize ' range=':= _default_ * nthoCopperSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.892  * _default_ * nthoCopperFreq ' range=':= _default_ * nthoCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Veins name='nthoCopperHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:6")'> <OreBlock block='NetherOres:tile.netherores.ore.0:6' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Copper is complete. -->
 
-                    </Cloud>
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Iridium -->
-                
-                
-                <!-- Begin  Vanilla distribution of Iridium -->
-                <IfCondition condition=':= nthoIridiumDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='nthoIridiumBaseStandard' block='NetherOres:tile.netherores.ore.1:3' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60CECECE</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * nthoIridiumSize * _default_'/>
-                        <Setting name='Height' avg=':= 120' range=':= 120' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1 * nthoIridiumFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </StandardGen>
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Iridium -->
-                
-                <!-- End Iridium Generation --> 
 
-                
-                <!-- Begin Osmium Generation --> 
-                
-                <!-- Begin LayeredVeins distribution of Osmium -->
-                <IfCondition condition=':= nthoOsmiumDist = "layeredVeins"'>
-                
-                    <Veins name='nthoOsmiumBaseVeins' block='NetherOres:tile.netherores.ore.1:4'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x6043638A</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoOsmiumSize * _default_' range=':= 1 * 1 * nthoOsmiumSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoOsmiumSize * _default_' range=':= 1 * 1 * nthoOsmiumSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoOsmiumFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End LayeredVeins distribution of Osmium -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Osmium -->
-                <IfCondition condition=':= nthoOsmiumDist = "hugeVeins"'>
-                
-                    <Veins name='nthoOsmiumBaseVeins' block='NetherOres:tile.netherores.ore.1:4'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x6043638A</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoOsmiumSize * _default_' range=':= 1 * 1 * nthoOsmiumSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoOsmiumSize * _default_' range=':= 1 * 1 * nthoOsmiumSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoOsmiumFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Osmium -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Osmium -->
-                <IfCondition condition=':= nthoOsmiumDist = "strategicCloud"'>
-                
-                    <Cloud name='nthoOsmiumBaseCloud' block='NetherOres:tile.netherores.ore.1:4' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x6043638A</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1 * nthoOsmiumSize * _default_' range=':= 1 * 1 * nthoOsmiumSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * nthoOsmiumSize * _default_' range=':= 1 * 1 * nthoOsmiumSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1 * nthoOsmiumSize * _default_' range=':= 1 * 1 * 1 * nthoOsmiumSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 1 * nthoOsmiumFreq *_default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Osmium Strategic Cloud Hint Veins -->
-                        <Veins name='nthoOsmiumBaseHintVeins' block='NetherOres:tile.netherores.ore.1:4' inherits='PresetHintVeins'>
+                <!-- Starting Vanilla Preset for Copper. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoCopperDist = "Vanilla"'>
+                        <StandardGen name='nthoCopperStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60FF8E2B' drawBoundBox='false' boundBoxColor='0x60FF8E2B'>
                             <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
+                                A master preset for standardgen  ore
+                                distributions.
                             </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x6043638A</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Osmium Strategic Cloud Hint Veins -->
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:6")'> <OreBlock block='NetherOres:tile.netherores.ore.0:6' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 8 * nthoCopperSize ' range=':= _default_ * nthoCopperSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 8 * nthoCopperFreq ' range=':= _default_ * nthoCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Copper is complete. -->
 
-                    </Cloud>
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Osmium -->
-                
-                
-                <!-- Begin  Vanilla distribution of Osmium -->
-                <IfCondition condition=':= nthoOsmiumDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='nthoOsmiumBaseStandard' block='NetherOres:tile.netherores.ore.1:4' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x6043638A</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * nthoOsmiumSize * _default_'/>
-                        <Setting name='Height' avg=':= 120' range=':= 120' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1 * nthoOsmiumFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </StandardGen>
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Osmium -->
-                
-                <!-- End Osmium Generation --> 
+                <!-- End Copper Generation -->
 
-                
-                <!-- Begin Sulphur Generation --> 
-                
-                <!-- Begin LayeredVeins distribution of Sulphur -->
-                <IfCondition condition=':= nthoSulphurDist = "layeredVeins"'>
-                
-                    <Veins name='nthoSulphurBaseVeins' block='NetherOres:tile.netherores.ore.1:5'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FDFD11</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoSulphurSize * _default_' range=':= 1 * 1 * nthoSulphurSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoSulphurSize * _default_' range=':= 1 * 1 * nthoSulphurSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoSulphurFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End LayeredVeins distribution of Sulphur -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Sulphur -->
-                <IfCondition condition=':= nthoSulphurDist = "hugeVeins"'>
-                
-                    <Veins name='nthoSulphurBaseVeins' block='NetherOres:tile.netherores.ore.1:5'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FDFD11</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoSulphurSize * _default_' range=':= 1 * 1 * nthoSulphurSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoSulphurSize * _default_' range=':= 1 * 1 * nthoSulphurSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoSulphurFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Sulphur -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Sulphur -->
-                <IfCondition condition=':= nthoSulphurDist = "strategicCloud"'>
-                
-                    <Cloud name='nthoSulphurBaseCloud' block='NetherOres:tile.netherores.ore.1:5' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FDFD11</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1 * nthoSulphurSize * _default_' range=':= 1 * 1 * nthoSulphurSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * nthoSulphurSize * _default_' range=':= 1 * 1 * nthoSulphurSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1 * nthoSulphurSize * _default_' range=':= 1 * 1 * 1 * nthoSulphurSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 1 * nthoSulphurFreq *_default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Sulphur Strategic Cloud Hint Veins -->
-                        <Veins name='nthoSulphurBaseHintVeins' block='NetherOres:tile.netherores.ore.1:5' inherits='PresetHintVeins'>
+
+                <!-- Begin Tin Generation -->
+
+                <!-- Starting LayeredVeins Preset for Tin. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoTinDist = "LayeredVeins"'>
+                        <Veins name='nthoTinVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60E8E8E8'>
                             <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
                             </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60FDFD11</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:7")'> <OreBlock block='NetherOres:tile.netherores.ore.0:7' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.948 * _default_ * nthoTinFreq ' range=':= _default_ * nthoTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.982 * _default_ * nthoTinSize ' range=':= _default_ * nthoTinSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.982 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * nthoTinSize ' range=':= _default_ * nthoTinSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.982 * _default_ * nthoTinSize ' range=':= _default_ * nthoTinSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
-                        <!-- End Sulphur Strategic Cloud Hint Veins -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Tin is complete. -->
 
-                    </Cloud>
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Sulphur -->
-                
-                
-                <!-- Begin  Vanilla distribution of Sulphur -->
-                <IfCondition condition=':= nthoSulphurDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='nthoSulphurBaseStandard' block='NetherOres:tile.netherores.ore.1:5' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FDFD11</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * nthoSulphurSize * _default_'/>
-                        <Setting name='Height' avg=':= 120' range=':= 120' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1 * nthoSulphurFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </StandardGen>
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Sulphur -->
-                
-                <!-- End Sulphur Generation --> 
 
-                
-                <!-- Begin Titanium Generation --> 
-                
-                <!-- Begin LayeredVeins distribution of Titanium -->
-                <IfCondition condition=':= nthoTitaniumDist = "layeredVeins"'>
-                
-                    <Veins name='nthoTitaniumBaseVeins' block='NetherOres:tile.netherores.ore.1:6'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60686868</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoTitaniumSize * _default_' range=':= 1 * 1 * nthoTitaniumSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoTitaniumSize * _default_' range=':= 1 * 1 * nthoTitaniumSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoTitaniumFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End LayeredVeins distribution of Titanium -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Titanium -->
-                <IfCondition condition=':= nthoTitaniumDist = "hugeVeins"'>
-                
-                    <Veins name='nthoTitaniumBaseVeins' block='NetherOres:tile.netherores.ore.1:6'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60686868</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoTitaniumSize * _default_' range=':= 1 * 1 * nthoTitaniumSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoTitaniumSize * _default_' range=':= 1 * 1 * nthoTitaniumSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoTitaniumFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Titanium -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Titanium -->
-                <IfCondition condition=':= nthoTitaniumDist = "strategicCloud"'>
-                
-                    <Cloud name='nthoTitaniumBaseCloud' block='NetherOres:tile.netherores.ore.1:6' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60686868</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1 * nthoTitaniumSize * _default_' range=':= 1 * 1 * nthoTitaniumSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * nthoTitaniumSize * _default_' range=':= 1 * 1 * nthoTitaniumSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1 * nthoTitaniumSize * _default_' range=':= 1 * 1 * 1 * nthoTitaniumSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 1 * nthoTitaniumFreq *_default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Titanium Strategic Cloud Hint Veins -->
-                        <Veins name='nthoTitaniumBaseHintVeins' block='NetherOres:tile.netherores.ore.1:6' inherits='PresetHintVeins'>
+                <!-- Starting Cloud Preset for Tin. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoTinDist = "Cloud"'>
+                        <Cloud name='nthoTinCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60E8E8E8'>
                             <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
                             </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60686868</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Titanium Strategic Cloud Hint Veins -->
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:7")'> <OreBlock block='NetherOres:tile.netherores.ore.0:7' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.375 * _default_ * nthoTinSize ' range=':= _default_ * nthoTinSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.375 * _default_ * nthoTinSize ' range=':= _default_ * nthoTinSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.892  * _default_ * nthoTinFreq ' range=':= _default_ * nthoTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Veins name='nthoTinHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60E8E8E8'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:7")'> <OreBlock block='NetherOres:tile.netherores.ore.0:7' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Tin is complete. -->
 
-                    </Cloud>
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Titanium -->
-                
-                
-                <!-- Begin  Vanilla distribution of Titanium -->
-                <IfCondition condition=':= nthoTitaniumDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='nthoTitaniumBaseStandard' block='NetherOres:tile.netherores.ore.1:6' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60686868</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * nthoTitaniumSize * _default_'/>
-                        <Setting name='Height' avg=':= 120' range=':= 120' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1 * nthoTitaniumFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </StandardGen>
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Titanium -->
-                
-                <!-- End Titanium Generation --> 
 
-                
-                <!-- Begin Mithril Generation --> 
-                
-                <!-- Begin LayeredVeins distribution of Mithril -->
-                <IfCondition condition=':= nthoMithrilDist = "layeredVeins"'>
-                
-                    <Veins name='nthoMithrilBaseVeins' block='NetherOres:tile.netherores.ore.1:7'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x6075E0F6</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoMithrilSize * _default_' range=':= 1 * 1 * nthoMithrilSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoMithrilSize * _default_' range=':= 1 * 1 * nthoMithrilSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoMithrilFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End LayeredVeins distribution of Mithril -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Mithril -->
-                <IfCondition condition=':= nthoMithrilDist = "hugeVeins"'>
-                
-                    <Veins name='nthoMithrilBaseVeins' block='NetherOres:tile.netherores.ore.1:7'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x6075E0F6</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoMithrilSize * _default_' range=':= 1 * 1 * nthoMithrilSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoMithrilSize * _default_' range=':= 1 * 1 * nthoMithrilSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoMithrilFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Mithril -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Mithril -->
-                <IfCondition condition=':= nthoMithrilDist = "strategicCloud"'>
-                
-                    <Cloud name='nthoMithrilBaseCloud' block='NetherOres:tile.netherores.ore.1:7' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x6075E0F6</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1 * nthoMithrilSize * _default_' range=':= 1 * 1 * nthoMithrilSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * nthoMithrilSize * _default_' range=':= 1 * 1 * nthoMithrilSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1 * nthoMithrilSize * _default_' range=':= 1 * 1 * 1 * nthoMithrilSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 1 * nthoMithrilFreq *_default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Mithril Strategic Cloud Hint Veins -->
-                        <Veins name='nthoMithrilBaseHintVeins' block='NetherOres:tile.netherores.ore.1:7' inherits='PresetHintVeins'>
+                <!-- Starting Vanilla Preset for Tin. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoTinDist = "Vanilla"'>
+                        <StandardGen name='nthoTinStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60E8E8E8' drawBoundBox='false' boundBoxColor='0x60E8E8E8'>
                             <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
+                                A master preset for standardgen  ore
+                                distributions.
                             </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x6075E0F6</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Mithril Strategic Cloud Hint Veins -->
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:7")'> <OreBlock block='NetherOres:tile.netherores.ore.0:7' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 8 * nthoTinSize ' range=':= _default_ * nthoTinSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 8 * nthoTinFreq ' range=':= _default_ * nthoTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Tin is complete. -->
 
-                    </Cloud>
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Mithril -->
-                
-                
-                <!-- Begin  Vanilla distribution of Mithril -->
-                <IfCondition condition=':= nthoMithrilDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='nthoMithrilBaseStandard' block='NetherOres:tile.netherores.ore.1:7' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x6075E0F6</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * nthoMithrilSize * _default_'/>
-                        <Setting name='Height' avg=':= 120' range=':= 120' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1 * nthoMithrilFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </StandardGen>
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Mithril -->
-                
-                <!-- End Mithril Generation --> 
+                <!-- End Tin Generation -->
 
-                
-                <!-- Begin Adamantium Generation --> 
-                
-                <!-- Begin LayeredVeins distribution of Adamantium -->
-                <IfCondition condition=':= nthoAdamantiumDist = "layeredVeins"'>
-                
-                    <Veins name='nthoAdamantiumBaseVeins' block='NetherOres:tile.netherores.ore.1:8'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x609CA6B0</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoAdamantiumSize * _default_' range=':= 1 * 1 * nthoAdamantiumSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoAdamantiumSize * _default_' range=':= 1 * 1 * nthoAdamantiumSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoAdamantiumFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End LayeredVeins distribution of Adamantium -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Adamantium -->
-                <IfCondition condition=':= nthoAdamantiumDist = "hugeVeins"'>
-                
-                    <Veins name='nthoAdamantiumBaseVeins' block='NetherOres:tile.netherores.ore.1:8'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x609CA6B0</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoAdamantiumSize * _default_' range=':= 1 * 1 * nthoAdamantiumSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoAdamantiumSize * _default_' range=':= 1 * 1 * nthoAdamantiumSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoAdamantiumFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Adamantium -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Adamantium -->
-                <IfCondition condition=':= nthoAdamantiumDist = "strategicCloud"'>
-                
-                    <Cloud name='nthoAdamantiumBaseCloud' block='NetherOres:tile.netherores.ore.1:8' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x609CA6B0</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1 * nthoAdamantiumSize * _default_' range=':= 1 * 1 * nthoAdamantiumSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * nthoAdamantiumSize * _default_' range=':= 1 * 1 * nthoAdamantiumSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1 * nthoAdamantiumSize * _default_' range=':= 1 * 1 * 1 * nthoAdamantiumSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 1 * nthoAdamantiumFreq *_default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Adamantium Strategic Cloud Hint Veins -->
-                        <Veins name='nthoAdamantiumBaseHintVeins' block='NetherOres:tile.netherores.ore.1:8' inherits='PresetHintVeins'>
+
+                <!-- Begin Emerald Generation -->
+
+                <!-- Starting PipeVeins Preset for Emerald. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoEmeraldDist = "PipeVeins"'>
+                        <Veins name='nthoEmeraldVeins'  inherits='PresetPipeVeins' seed='0x907F' drawWireframe='true' wireframeColor='0x606CE391' drawBoundBox='false' boundBoxColor='0x606CE391'>
                             <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
+                                Short sparsely filled veins  sloping
+                                up from near the bottom  of the map.
                             </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x609CA6B0</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:8")'> <OreBlock block='NetherOres:tile.netherores.ore.0:8' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.338 * _default_ * nthoEmeraldFreq ' range=':= _default_ * nthoEmeraldFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.696 * _default_ * nthoEmeraldSize ' range=':= _default_ * nthoEmeraldSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.696 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * nthoEmeraldSize ' range=':= _default_ * nthoEmeraldSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.696 * _default_ * nthoEmeraldSize ' range=':= _default_ * nthoEmeraldSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
-                        <!-- End Adamantium Strategic Cloud Hint Veins -->
 
-                    </Cloud>
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Adamantium -->
-                
-                
-                <!-- Begin  Vanilla distribution of Adamantium -->
-                <IfCondition condition=':= nthoAdamantiumDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='nthoAdamantiumBaseStandard' block='NetherOres:tile.netherores.ore.1:8' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x609CA6B0</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * nthoAdamantiumSize * _default_'/>
-                        <Setting name='Height' avg=':= 120' range=':= 120' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1 * nthoAdamantiumFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </StandardGen>
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Adamantium -->
-                
-                <!-- End Adamantium Generation --> 
+                        <!-- Configuring contained material. -->
+                        <Veins name='nthoEmeraldVeinsPipe'  inherits='nthoEmeraldVeins' seed='0x907F' drawWireframe='true' wireframeColor='0x606CE391' drawBoundBox='false' boundBoxColor='0x606CE391'>
+                            <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:8")'> <Replaces block='NetherOres:tile.netherores.ore.0:8' weight='1.0' /> </IfCondition>
+                            <Setting name='MotherlodeSize' avg=':= 0.696 * _default_ * nthoEmeraldSize  * 0.5 ' range=':= _default_ * nthoEmeraldSize  * 0.5 ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.696 * _default_ * nthoEmeraldSize  * 0.5 ' range=':= _default_ * nthoEmeraldSize  * 0.5 ' type='normal' />
+                            <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- PipeVeins Preset for Emerald is complete. -->
 
-                
-                <!-- Begin Rutile Generation --> 
-                
-                <!-- Begin LayeredVeins distribution of Rutile -->
-                <IfCondition condition=':= nthoRutileDist = "layeredVeins"'>
-                
-                    <Veins name='nthoRutileBaseVeins' block='NetherOres:tile.netherores.ore.1:9'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60D2C7A9</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoRutileSize * _default_' range=':= 1 * 1 * nthoRutileSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoRutileSize * _default_' range=':= 1 * 1 * nthoRutileSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoRutileFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End LayeredVeins distribution of Rutile -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Rutile -->
-                <IfCondition condition=':= nthoRutileDist = "hugeVeins"'>
-                
-                    <Veins name='nthoRutileBaseVeins' block='NetherOres:tile.netherores.ore.1:9'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60D2C7A9</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoRutileSize * _default_' range=':= 1 * 1 * nthoRutileSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoRutileSize * _default_' range=':= 1 * 1 * nthoRutileSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoRutileFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Rutile -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Rutile -->
-                <IfCondition condition=':= nthoRutileDist = "strategicCloud"'>
-                
-                    <Cloud name='nthoRutileBaseCloud' block='NetherOres:tile.netherores.ore.1:9' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60D2C7A9</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1 * nthoRutileSize * _default_' range=':= 1 * 1 * nthoRutileSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * nthoRutileSize * _default_' range=':= 1 * 1 * nthoRutileSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1 * nthoRutileSize * _default_' range=':= 1 * 1 * 1 * nthoRutileSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 1 * nthoRutileFreq *_default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Rutile Strategic Cloud Hint Veins -->
-                        <Veins name='nthoRutileBaseHintVeins' block='NetherOres:tile.netherores.ore.1:9' inherits='PresetHintVeins'>
+
+                <!-- Starting Cloud Preset for Emerald. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoEmeraldDist = "Cloud"'>
+                        <Cloud name='nthoEmeraldCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x606CE391' drawBoundBox='false' boundBoxColor='0x606CE391'>
                             <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
                             </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60D2C7A9</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Rutile Strategic Cloud Hint Veins -->
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:8")'> <OreBlock block='NetherOres:tile.netherores.ore.0:8' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.761 * _default_ * nthoEmeraldSize ' range=':= _default_ * nthoEmeraldSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.761 * _default_ * nthoEmeraldSize ' range=':= _default_ * nthoEmeraldSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.579  * _default_ * nthoEmeraldFreq ' range=':= _default_ * nthoEmeraldFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Veins name='nthoEmeraldHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x606CE391' drawBoundBox='false' boundBoxColor='0x606CE391'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:8")'> <OreBlock block='NetherOres:tile.netherores.ore.0:8' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Emerald is complete. -->
 
-                    </Cloud>
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Rutile -->
-                
-                
-                <!-- Begin  Vanilla distribution of Rutile -->
-                <IfCondition condition=':= nthoRutileDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='nthoRutileBaseStandard' block='NetherOres:tile.netherores.ore.1:9' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60D2C7A9</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * nthoRutileSize * _default_'/>
-                        <Setting name='Height' avg=':= 120' range=':= 120' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1 * nthoRutileFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </StandardGen>
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Rutile -->
-                
-                <!-- End Rutile Generation --> 
 
-                
-                <!-- Begin Tungsten Generation --> 
-                
-                <!-- Begin LayeredVeins distribution of Tungsten -->
-                <IfCondition condition=':= nthoTungstenDist = "layeredVeins"'>
-                
-                    <Veins name='nthoTungstenBaseVeins' block='NetherOres:tile.netherores.ore.1:10'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60212121</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoTungstenSize * _default_' range=':= 1 * 1 * nthoTungstenSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoTungstenSize * _default_' range=':= 1 * 1 * nthoTungstenSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoTungstenFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End LayeredVeins distribution of Tungsten -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Tungsten -->
-                <IfCondition condition=':= nthoTungstenDist = "hugeVeins"'>
-                
-                    <Veins name='nthoTungstenBaseVeins' block='NetherOres:tile.netherores.ore.1:10'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60212121</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoTungstenSize * _default_' range=':= 1 * 1 * nthoTungstenSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoTungstenSize * _default_' range=':= 1 * 1 * nthoTungstenSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoTungstenFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Tungsten -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Tungsten -->
-                <IfCondition condition=':= nthoTungstenDist = "strategicCloud"'>
-                
-                    <Cloud name='nthoTungstenBaseCloud' block='NetherOres:tile.netherores.ore.1:10' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60212121</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1 * nthoTungstenSize * _default_' range=':= 1 * 1 * nthoTungstenSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * nthoTungstenSize * _default_' range=':= 1 * 1 * nthoTungstenSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1 * nthoTungstenSize * _default_' range=':= 1 * 1 * 1 * nthoTungstenSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 1 * nthoTungstenFreq *_default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Tungsten Strategic Cloud Hint Veins -->
-                        <Veins name='nthoTungstenBaseHintVeins' block='NetherOres:tile.netherores.ore.1:10' inherits='PresetHintVeins'>
+                <!-- Starting Vanilla Preset for Emerald. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoEmeraldDist = "Vanilla"'>
+                        <StandardGen name='nthoEmeraldStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x606CE391' drawBoundBox='false' boundBoxColor='0x606CE391'>
                             <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
+                                A master preset for standardgen  ore
+                                distributions.
                             </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60212121</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Tungsten Strategic Cloud Hint Veins -->
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:8")'> <OreBlock block='NetherOres:tile.netherores.ore.0:8' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 2 * nthoEmeraldSize ' range=':= _default_ * nthoEmeraldSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 3 * nthoEmeraldFreq ' range=':= _default_ * nthoEmeraldFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Emerald is complete. -->
 
-                    </Cloud>
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Tungsten -->
-                
-                
-                <!-- Begin  Vanilla distribution of Tungsten -->
-                <IfCondition condition=':= nthoTungstenDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='nthoTungstenBaseStandard' block='NetherOres:tile.netherores.ore.1:10' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60212121</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * nthoTungstenSize * _default_'/>
-                        <Setting name='Height' avg=':= 120' range=':= 120' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1 * nthoTungstenFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </StandardGen>
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Tungsten -->
-                
-                <!-- End Tungsten Generation --> 
+                <!-- End Emerald Generation -->
 
-                
-                <!-- Begin Amber Generation --> 
-                
-                <!-- Begin LayeredVeins distribution of Amber -->
-                <IfCondition condition=':= nthoAmberDist = "layeredVeins"'>
-                
-                    <Veins name='nthoAmberBaseVeins' block='NetherOres:tile.netherores.ore.1:11'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FEA219</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoAmberSize * _default_' range=':= 1 * 1 * nthoAmberSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoAmberSize * _default_' range=':= 1 * 1 * nthoAmberSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoAmberFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End LayeredVeins distribution of Amber -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Amber -->
-                <IfCondition condition=':= nthoAmberDist = "hugeVeins"'>
-                
-                    <Veins name='nthoAmberBaseVeins' block='NetherOres:tile.netherores.ore.1:11'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FEA219</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoAmberSize * _default_' range=':= 1 * 1 * nthoAmberSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoAmberSize * _default_' range=':= 1 * 1 * nthoAmberSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoAmberFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Amber -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Amber -->
-                <IfCondition condition=':= nthoAmberDist = "strategicCloud"'>
-                
-                    <Cloud name='nthoAmberBaseCloud' block='NetherOres:tile.netherores.ore.1:11' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FEA219</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1 * nthoAmberSize * _default_' range=':= 1 * 1 * nthoAmberSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * nthoAmberSize * _default_' range=':= 1 * 1 * nthoAmberSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1 * nthoAmberSize * _default_' range=':= 1 * 1 * 1 * nthoAmberSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 1 * nthoAmberFreq *_default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Amber Strategic Cloud Hint Veins -->
-                        <Veins name='nthoAmberBaseHintVeins' block='NetherOres:tile.netherores.ore.1:11' inherits='PresetHintVeins'>
+
+                <!-- Begin Silver Generation -->
+
+                <!-- Starting LayeredVeins Preset for Silver. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoSilverDist = "LayeredVeins"'>
+                        <Veins name='nthoSilverVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60E3F2F7' drawBoundBox='false' boundBoxColor='0x60E3F2F7'>
                             <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
                             </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60FEA219</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:9")'> <OreBlock block='NetherOres:tile.netherores.ore.0:9' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.580 * _default_ * nthoSilverFreq ' range=':= _default_ * nthoSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.834 * _default_ * nthoSilverSize ' range=':= _default_ * nthoSilverSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.834 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * nthoSilverSize ' range=':= _default_ * nthoSilverSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.834 * _default_ * nthoSilverSize ' range=':= _default_ * nthoSilverSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
-                        <!-- End Amber Strategic Cloud Hint Veins -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Silver is complete. -->
 
-                    </Cloud>
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Amber -->
-                
-                
-                <!-- Begin  Vanilla distribution of Amber -->
-                <IfCondition condition=':= nthoAmberDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='nthoAmberBaseStandard' block='NetherOres:tile.netherores.ore.1:11' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FEA219</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * nthoAmberSize * _default_'/>
-                        <Setting name='Height' avg=':= 120' range=':= 120' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1 * nthoAmberFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </StandardGen>
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Amber -->
-                
-                <!-- End Amber Generation --> 
 
-                
-                <!-- Begin Tennantite Generation --> 
-                
-                <!-- Begin LayeredVeins distribution of Tennantite -->
-                <IfCondition condition=':= nthoTennantiteDist = "layeredVeins"'>
-                
-                    <Veins name='nthoTennantiteBaseVeins' block='NetherOres:tile.netherores.ore.1:12'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x609EE2B1</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoTennantiteSize * _default_' range=':= 1 * 1 * nthoTennantiteSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoTennantiteSize * _default_' range=':= 1 * 1 * nthoTennantiteSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoTennantiteFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End LayeredVeins distribution of Tennantite -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Tennantite -->
-                <IfCondition condition=':= nthoTennantiteDist = "hugeVeins"'>
-                
-                    <Veins name='nthoTennantiteBaseVeins' block='NetherOres:tile.netherores.ore.1:12'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x609EE2B1</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoTennantiteSize * _default_' range=':= 1 * 1 * nthoTennantiteSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoTennantiteSize * _default_' range=':= 1 * 1 * nthoTennantiteSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoTennantiteFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Tennantite -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Tennantite -->
-                <IfCondition condition=':= nthoTennantiteDist = "strategicCloud"'>
-                
-                    <Cloud name='nthoTennantiteBaseCloud' block='NetherOres:tile.netherores.ore.1:12' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x609EE2B1</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1 * nthoTennantiteSize * _default_' range=':= 1 * 1 * nthoTennantiteSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * nthoTennantiteSize * _default_' range=':= 1 * 1 * nthoTennantiteSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1 * nthoTennantiteSize * _default_' range=':= 1 * 1 * 1 * nthoTennantiteSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 1 * nthoTennantiteFreq *_default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Tennantite Strategic Cloud Hint Veins -->
-                        <Veins name='nthoTennantiteBaseHintVeins' block='NetherOres:tile.netherores.ore.1:12' inherits='PresetHintVeins'>
+                <!-- Starting Cloud Preset for Silver. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoSilverDist = "Cloud"'>
+                        <Cloud name='nthoSilverCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60E3F2F7' drawBoundBox='false' boundBoxColor='0x60E3F2F7'>
                             <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
                             </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x609EE2B1</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Tennantite Strategic Cloud Hint Veins -->
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:9")'> <OreBlock block='NetherOres:tile.netherores.ore.0:9' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.076 * _default_ * nthoSilverSize ' range=':= _default_ * nthoSilverSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.076 * _default_ * nthoSilverSize ' range=':= _default_ * nthoSilverSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.159  * _default_ * nthoSilverFreq ' range=':= _default_ * nthoSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Veins name='nthoSilverHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60E3F2F7' drawBoundBox='false' boundBoxColor='0x60E3F2F7'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:9")'> <OreBlock block='NetherOres:tile.netherores.ore.0:9' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Silver is complete. -->
 
-                    </Cloud>
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Tennantite -->
-                
-                
-                <!-- Begin  Vanilla distribution of Tennantite -->
-                <IfCondition condition=':= nthoTennantiteDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='nthoTennantiteBaseStandard' block='NetherOres:tile.netherores.ore.1:12' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x609EE2B1</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * nthoTennantiteSize * _default_'/>
-                        <Setting name='Height' avg=':= 120' range=':= 120' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1 * nthoTennantiteFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </StandardGen>
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Tennantite -->
-                
-                <!-- End Tennantite Generation --> 
 
-                
-                <!-- Begin Salt Generation --> 
-                
-                <!-- Begin LayeredVeins distribution of Salt -->
-                <IfCondition condition=':= nthoSaltDist = "layeredVeins"'>
-                
-                    <Veins name='nthoSaltBaseVeins' block='NetherOres:tile.netherores.ore.1:13'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FFFFFF</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoSaltSize * _default_' range=':= 1 * 1 * nthoSaltSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoSaltSize * _default_' range=':= 1 * 1 * nthoSaltSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoSaltFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End LayeredVeins distribution of Salt -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Salt -->
-                <IfCondition condition=':= nthoSaltDist = "hugeVeins"'>
-                
-                    <Veins name='nthoSaltBaseVeins' block='NetherOres:tile.netherores.ore.1:13'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FFFFFF</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoSaltSize * _default_' range=':= 1 * 1 * nthoSaltSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoSaltSize * _default_' range=':= 1 * 1 * nthoSaltSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoSaltFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Salt -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Salt -->
-                <IfCondition condition=':= nthoSaltDist = "strategicCloud"'>
-                
-                    <Cloud name='nthoSaltBaseCloud' block='NetherOres:tile.netherores.ore.1:13' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FFFFFF</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1 * nthoSaltSize * _default_' range=':= 1 * 1 * nthoSaltSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * nthoSaltSize * _default_' range=':= 1 * 1 * nthoSaltSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1 * nthoSaltSize * _default_' range=':= 1 * 1 * 1 * nthoSaltSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 1 * nthoSaltFreq *_default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Salt Strategic Cloud Hint Veins -->
-                        <Veins name='nthoSaltBaseHintVeins' block='NetherOres:tile.netherores.ore.1:13' inherits='PresetHintVeins'>
+                <!-- Starting Vanilla Preset for Silver. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoSilverDist = "Vanilla"'>
+                        <StandardGen name='nthoSilverStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60E3F2F7' drawBoundBox='false' boundBoxColor='0x60E3F2F7'>
                             <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
+                                A master preset for standardgen  ore
+                                distributions.
                             </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60FFFFFF</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Salt Strategic Cloud Hint Veins -->
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:9")'> <OreBlock block='NetherOres:tile.netherores.ore.0:9' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 4 * nthoSilverSize ' range=':= _default_ * nthoSilverSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 6 * nthoSilverFreq ' range=':= _default_ * nthoSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Silver is complete. -->
 
-                    </Cloud>
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Salt -->
-                
-                
-                <!-- Begin  Vanilla distribution of Salt -->
-                <IfCondition condition=':= nthoSaltDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='nthoSaltBaseStandard' block='NetherOres:tile.netherores.ore.1:13' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FFFFFF</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * nthoSaltSize * _default_'/>
-                        <Setting name='Height' avg=':= 120' range=':= 120' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1 * nthoSaltFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </StandardGen>
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Salt -->
-                
-                <!-- End Salt Generation --> 
+                <!-- End Silver Generation -->
 
-                
-                <!-- Begin Saltpeter Generation --> 
-                
-                <!-- Begin LayeredVeins distribution of Saltpeter -->
-                <IfCondition condition=':= nthoSaltpeterDist = "layeredVeins"'>
-                
-                    <Veins name='nthoSaltpeterBaseVeins' block='NetherOres:tile.netherores.ore.1:14'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60F4F6F9</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoSaltpeterSize * _default_' range=':= 1 * 1 * nthoSaltpeterSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoSaltpeterSize * _default_' range=':= 1 * 1 * nthoSaltpeterSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoSaltpeterFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End LayeredVeins distribution of Saltpeter -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Saltpeter -->
-                <IfCondition condition=':= nthoSaltpeterDist = "hugeVeins"'>
-                
-                    <Veins name='nthoSaltpeterBaseVeins' block='NetherOres:tile.netherores.ore.1:14'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60F4F6F9</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoSaltpeterSize * _default_' range=':= 1 * 1 * nthoSaltpeterSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoSaltpeterSize * _default_' range=':= 1 * 1 * nthoSaltpeterSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoSaltpeterFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Saltpeter -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Saltpeter -->
-                <IfCondition condition=':= nthoSaltpeterDist = "strategicCloud"'>
-                
-                    <Cloud name='nthoSaltpeterBaseCloud' block='NetherOres:tile.netherores.ore.1:14' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60F4F6F9</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1 * nthoSaltpeterSize * _default_' range=':= 1 * 1 * nthoSaltpeterSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * nthoSaltpeterSize * _default_' range=':= 1 * 1 * nthoSaltpeterSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1 * nthoSaltpeterSize * _default_' range=':= 1 * 1 * 1 * nthoSaltpeterSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 1 * nthoSaltpeterFreq *_default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Saltpeter Strategic Cloud Hint Veins -->
-                        <Veins name='nthoSaltpeterBaseHintVeins' block='NetherOres:tile.netherores.ore.1:14' inherits='PresetHintVeins'>
+
+                <!-- Begin Lead Generation -->
+
+                <!-- Starting LayeredVeins Preset for Lead. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoLeadDist = "LayeredVeins"'>
+                        <Veins name='nthoLeadVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60818EBE' drawBoundBox='false' boundBoxColor='0x60818EBE'>
                             <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
                             </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60F4F6F9</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:10")'> <OreBlock block='NetherOres:tile.netherores.ore.0:10' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.711 * _default_ * nthoLeadFreq ' range=':= _default_ * nthoLeadFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.892 * _default_ * nthoLeadSize ' range=':= _default_ * nthoLeadSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.892 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * nthoLeadSize ' range=':= _default_ * nthoLeadSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.892 * _default_ * nthoLeadSize ' range=':= _default_ * nthoLeadSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
-                        <!-- End Saltpeter Strategic Cloud Hint Veins -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Lead is complete. -->
 
-                    </Cloud>
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Saltpeter -->
-                
-                
-                <!-- Begin  Vanilla distribution of Saltpeter -->
-                <IfCondition condition=':= nthoSaltpeterDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='nthoSaltpeterBaseStandard' block='NetherOres:tile.netherores.ore.1:14' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60F4F6F9</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * nthoSaltpeterSize * _default_'/>
-                        <Setting name='Height' avg=':= 120' range=':= 120' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1 * nthoSaltpeterFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </StandardGen>
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Saltpeter -->
-                
-                <!-- End Saltpeter Generation --> 
 
-                
-                <!-- Begin Magnesium Generation --> 
-                
-                <!-- Begin LayeredVeins distribution of Magnesium -->
-                <IfCondition condition=':= nthoMagnesiumDist = "layeredVeins"'>
-                
-                    <Veins name='nthoMagnesiumBaseVeins' block='NetherOres:tile.netherores.ore.1:15'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60827066</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoMagnesiumSize * _default_' range=':= 1 * 1 * nthoMagnesiumSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoMagnesiumSize * _default_' range=':= 1 * 1 * nthoMagnesiumSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoMagnesiumFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End LayeredVeins distribution of Magnesium -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Magnesium -->
-                <IfCondition condition=':= nthoMagnesiumDist = "hugeVeins"'>
-                
-                    <Veins name='nthoMagnesiumBaseVeins' block='NetherOres:tile.netherores.ore.1:15'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60827066</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * nthoMagnesiumSize * _default_' range=':= 1 * 1 * nthoMagnesiumSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * nthoMagnesiumSize * _default_' range=':= 1 * 1 * nthoMagnesiumSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 1 * 1 * nthoMagnesiumFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Magnesium -->
-                
-                
-                <!-- Begin  StrategicCloud distribution of Magnesium -->
-                <IfCondition condition=':= nthoMagnesiumDist = "strategicCloud"'>
-                
-                    <Cloud name='nthoMagnesiumBaseCloud' block='NetherOres:tile.netherores.ore.1:15' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60827066</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 1 * 1 * nthoMagnesiumSize * _default_' range=':= 1 * 1 * nthoMagnesiumSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * nthoMagnesiumSize * _default_' range=':= 1 * 1 * nthoMagnesiumSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 1 * 1 * 1 * nthoMagnesiumSize * _default_' range=':= 1 * 1 * 1 * nthoMagnesiumSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 1 * 1 * nthoMagnesiumFreq *_default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Magnesium Strategic Cloud Hint Veins -->
-                        <Veins name='nthoMagnesiumBaseHintVeins' block='NetherOres:tile.netherores.ore.1:15' inherits='PresetHintVeins'>
+                <!-- Starting Cloud Preset for Lead. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoLeadDist = "Cloud"'>
+                        <Cloud name='nthoLeadCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60818EBE' drawBoundBox='false' boundBoxColor='0x60818EBE'>
                             <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
                             </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60827066</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:10")'> <OreBlock block='NetherOres:tile.netherores.ore.0:10' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.191 * _default_ * nthoLeadSize ' range=':= _default_ * nthoLeadSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.191 * _default_ * nthoLeadSize ' range=':= _default_ * nthoLeadSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.419  * _default_ * nthoLeadFreq ' range=':= _default_ * nthoLeadFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Veins name='nthoLeadHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60818EBE' drawBoundBox='false' boundBoxColor='0x60818EBE'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:10")'> <OreBlock block='NetherOres:tile.netherores.ore.0:10' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Lead is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Lead. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoLeadDist = "Vanilla"'>
+                        <StandardGen name='nthoLeadStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60818EBE' drawBoundBox='false' boundBoxColor='0x60818EBE'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:10")'> <OreBlock block='NetherOres:tile.netherores.ore.0:10' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 6 * nthoLeadSize ' range=':= _default_ * nthoLeadSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 6 * nthoLeadFreq ' range=':= _default_ * nthoLeadFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Lead is complete. -->
+
+                <!-- End Lead Generation -->
+
+
+                <!-- Begin Uranium Generation -->
+
+                <!-- Starting SparseVeins Preset for Uranium. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoUraniumDist = "SparseVeins"'>
+                        <Veins name='nthoUraniumVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60ACFE91' drawBoundBox='false' boundBoxColor='0x60ACFE91'>
+                            <Description>
+                                Large veins filled very lightly  with
+                                ore.  Because they contain  less ore
+                                per volume, these veins  are
+                                relatively wide and long.  Mining the
+                                ore from them is time  consuming
+                                compared to solid ore  veins.  They
+                                are also more  difficult to follow,
+                                since it is  harder to get an idea of
+                                their  direction while mining.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:11")'> <OreBlock block='NetherOres:tile.netherores.ore.0:11' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.857 * _default_ * nthoUraniumFreq ' range=':= _default_ * nthoUraniumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.950 * _default_ * nthoUraniumSize ' range=':= _default_ * nthoUraniumSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.950 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * nthoUraniumSize ' range=':= _default_ * nthoUraniumSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.950 * _default_ * nthoUraniumSize ' range=':= _default_ * nthoUraniumSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
-                        <!-- End Magnesium Strategic Cloud Hint Veins -->
+                    </IfCondition>
+                </ConfigSection>
+                <!-- SparseVeins Preset for Uranium is complete. -->
 
-                    </Cloud>
-                
-                </IfCondition>
-                <!-- End  StrategicCloud distribution of Magnesium -->
-                
-                
-                <!-- Begin  Vanilla distribution of Magnesium -->
-                <IfCondition condition=':= nthoMagnesiumDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='nthoMagnesiumBaseStandard' block='NetherOres:tile.netherores.ore.1:15' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60827066</WireframeColor>
-                        <Setting name='Size' avg=':= 1 * 1 * nthoMagnesiumSize * _default_'/>
-                        <Setting name='Height' avg=':= 120' range=':= 120' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 1 * 1 * nthoMagnesiumFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </StandardGen>
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Magnesium -->
-                
-                <!-- End Magnesium Generation --> 
 
-                <!-- Done adding ores -->
-            
+                <!-- Starting Cloud Preset for Uranium. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoUraniumDist = "Cloud"'>
+                        <Cloud name='nthoUraniumCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60ACFE91' drawBoundBox='false' boundBoxColor='0x60ACFE91'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:11")'> <OreBlock block='NetherOres:tile.netherores.ore.0:11' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.761 * _default_ * nthoUraniumSize ' range=':= _default_ * nthoUraniumSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.761 * _default_ * nthoUraniumSize ' range=':= _default_ * nthoUraniumSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.579  * _default_ * nthoUraniumFreq ' range=':= _default_ * nthoUraniumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Veins name='nthoUraniumHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60ACFE91' drawBoundBox='false' boundBoxColor='0x60ACFE91'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:11")'> <OreBlock block='NetherOres:tile.netherores.ore.0:11' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Uranium is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Uranium. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoUraniumDist = "Vanilla"'>
+                        <StandardGen name='nthoUraniumStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60ACFE91' drawBoundBox='false' boundBoxColor='0x60ACFE91'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:11")'> <OreBlock block='NetherOres:tile.netherores.ore.0:11' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 2 * nthoUraniumSize ' range=':= _default_ * nthoUraniumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 3 * nthoUraniumFreq ' range=':= _default_ * nthoUraniumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Uranium is complete. -->
+
+                <!-- End Uranium Generation -->
+
+
+                <!-- Begin Nikolite Generation -->
+
+                <!-- Starting VerticalVeins Preset for Nikolite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoNikoliteDist = "VerticalVeins"'>
+                        <Veins name='nthoNikoliteVeins'  inherits='PresetVerticalVeins' drawWireframe='true' wireframeColor='0x6001FFFC' drawBoundBox='false' boundBoxColor='0x6001FFFC'>
+                            <Description>
+                                Single vertical veins that occur  with
+                                no motherlodes.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:12")'> <OreBlock block='NetherOres:tile.netherores.ore.0:12' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.242 * _default_ * nthoNikoliteFreq ' range=':= _default_ * nthoNikoliteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.075 * _default_ * nthoNikoliteSize ' range=':= _default_ * nthoNikoliteSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.075 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * nthoNikoliteSize ' range=':= _default_ * nthoNikoliteSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.075 * _default_ * nthoNikoliteSize ' range=':= _default_ * nthoNikoliteSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- VerticalVeins Preset for Nikolite is complete. -->
+
+
+                <!-- Starting Cloud Preset for Nikolite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoNikoliteDist = "Cloud"'>
+                        <Cloud name='nthoNikoliteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x6001FFFC' drawBoundBox='false' boundBoxColor='0x6001FFFC'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:12")'> <OreBlock block='NetherOres:tile.netherores.ore.0:12' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.157 * _default_ * nthoNikoliteSize ' range=':= _default_ * nthoNikoliteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.157 * _default_ * nthoNikoliteSize ' range=':= _default_ * nthoNikoliteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.338  * _default_ * nthoNikoliteFreq ' range=':= _default_ * nthoNikoliteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Veins name='nthoNikoliteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x6001FFFC' drawBoundBox='false' boundBoxColor='0x6001FFFC'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:12")'> <OreBlock block='NetherOres:tile.netherores.ore.0:12' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Nikolite is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Nikolite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoNikoliteDist = "Vanilla"'>
+                        <StandardGen name='nthoNikoliteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x6001FFFC' drawBoundBox='false' boundBoxColor='0x6001FFFC'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:12")'> <OreBlock block='NetherOres:tile.netherores.ore.0:12' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 4 * nthoNikoliteSize ' range=':= _default_ * nthoNikoliteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 8 * nthoNikoliteFreq ' range=':= _default_ * nthoNikoliteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Nikolite is complete. -->
+
+                <!-- End Nikolite Generation -->
+
+
+                <!-- Begin Ruby Generation -->
+
+                <!-- Starting PipeVeins Preset for Ruby. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoRubyDist = "PipeVeins"'>
+                        <Veins name='nthoRubyVeins'  inherits='PresetPipeVeins' seed='0xD0DC' drawWireframe='true' wireframeColor='0x60D10415' drawBoundBox='false' boundBoxColor='0x60D10415'>
+                            <Description>
+                                Short sparsely filled veins  sloping
+                                up from near the bottom  of the map.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:13")'> <OreBlock block='NetherOres:tile.netherores.ore.0:13' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.585 * _default_ * nthoRubyFreq ' range=':= _default_ * nthoRubyFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.836 * _default_ * nthoRubySize ' range=':= _default_ * nthoRubySize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.836 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * nthoRubySize ' range=':= _default_ * nthoRubySize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.836 * _default_ * nthoRubySize ' range=':= _default_ * nthoRubySize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                        </Veins>
+
+                        <!-- Configuring contained material. -->
+                        <Veins name='nthoRubyVeinsPipe'  inherits='nthoRubyVeins' seed='0xD0DC' drawWireframe='true' wireframeColor='0x60D10415' drawBoundBox='false' boundBoxColor='0x60D10415'>
+                            <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:13")'> <Replaces block='NetherOres:tile.netherores.ore.0:13' weight='1.0' /> </IfCondition>
+                            <Setting name='MotherlodeSize' avg=':= 0.836 * _default_ * nthoRubySize  * 0.5 ' range=':= _default_ * nthoRubySize  * 0.5 ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.836 * _default_ * nthoRubySize  * 0.5 ' range=':= _default_ * nthoRubySize  * 0.5 ' type='normal' />
+                            <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- PipeVeins Preset for Ruby is complete. -->
+
+
+                <!-- Starting Cloud Preset for Ruby. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoRubyDist = "Cloud"'>
+                        <Cloud name='nthoRubyCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60D10415' drawBoundBox='false' boundBoxColor='0x60D10415'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:13")'> <OreBlock block='NetherOres:tile.netherores.ore.0:13' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.002 * _default_ * nthoRubySize ' range=':= _default_ * nthoRubySize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.002 * _default_ * nthoRubySize ' range=':= _default_ * nthoRubySize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.003  * _default_ * nthoRubyFreq ' range=':= _default_ * nthoRubyFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Veins name='nthoRubyHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60D10415' drawBoundBox='false' boundBoxColor='0x60D10415'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:13")'> <OreBlock block='NetherOres:tile.netherores.ore.0:13' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Ruby is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Ruby. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoRubyDist = "Vanilla"'>
+                        <StandardGen name='nthoRubyStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60D10415' drawBoundBox='false' boundBoxColor='0x60D10415'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:13")'> <OreBlock block='NetherOres:tile.netherores.ore.0:13' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 3 * nthoRubySize ' range=':= _default_ * nthoRubySize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 6 * nthoRubyFreq ' range=':= _default_ * nthoRubyFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Ruby is complete. -->
+
+                <!-- End Ruby Generation -->
+
+
+                <!-- Begin Peridot Generation -->
+
+                <!-- Starting PipeVeins Preset for Peridot. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoPeridotDist = "PipeVeins"'>
+                        <Veins name='nthoPeridotVeins'  inherits='PresetPipeVeins' seed='0x6CA7' drawWireframe='true' wireframeColor='0x6054A228' drawBoundBox='false' boundBoxColor='0x6054A228'>
+                            <Description>
+                                Short sparsely filled veins  sloping
+                                up from near the bottom  of the map.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:14")'> <OreBlock block='NetherOres:tile.netherores.ore.0:14' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.585 * _default_ * nthoPeridotFreq ' range=':= _default_ * nthoPeridotFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.836 * _default_ * nthoPeridotSize ' range=':= _default_ * nthoPeridotSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.836 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * nthoPeridotSize ' range=':= _default_ * nthoPeridotSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.836 * _default_ * nthoPeridotSize ' range=':= _default_ * nthoPeridotSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                        </Veins>
+
+                        <!-- Configuring contained material. -->
+                        <Veins name='nthoPeridotVeinsPipe'  inherits='nthoPeridotVeins' seed='0x6CA7' drawWireframe='true' wireframeColor='0x6054A228' drawBoundBox='false' boundBoxColor='0x6054A228'>
+                            <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:14")'> <Replaces block='NetherOres:tile.netherores.ore.0:14' weight='1.0' /> </IfCondition>
+                            <Setting name='MotherlodeSize' avg=':= 0.836 * _default_ * nthoPeridotSize  * 0.5 ' range=':= _default_ * nthoPeridotSize  * 0.5 ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.836 * _default_ * nthoPeridotSize  * 0.5 ' range=':= _default_ * nthoPeridotSize  * 0.5 ' type='normal' />
+                            <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- PipeVeins Preset for Peridot is complete. -->
+
+
+                <!-- Starting Cloud Preset for Peridot. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoPeridotDist = "Cloud"'>
+                        <Cloud name='nthoPeridotCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x6054A228' drawBoundBox='false' boundBoxColor='0x6054A228'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:14")'> <OreBlock block='NetherOres:tile.netherores.ore.0:14' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.002 * _default_ * nthoPeridotSize ' range=':= _default_ * nthoPeridotSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.002 * _default_ * nthoPeridotSize ' range=':= _default_ * nthoPeridotSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.003  * _default_ * nthoPeridotFreq ' range=':= _default_ * nthoPeridotFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Veins name='nthoPeridotHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x6054A228' drawBoundBox='false' boundBoxColor='0x6054A228'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:14")'> <OreBlock block='NetherOres:tile.netherores.ore.0:14' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Peridot is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Peridot. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoPeridotDist = "Vanilla"'>
+                        <StandardGen name='nthoPeridotStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x6054A228' drawBoundBox='false' boundBoxColor='0x6054A228'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:14")'> <OreBlock block='NetherOres:tile.netherores.ore.0:14' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 3 * nthoPeridotSize ' range=':= _default_ * nthoPeridotSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 6 * nthoPeridotFreq ' range=':= _default_ * nthoPeridotFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Peridot is complete. -->
+
+                <!-- End Peridot Generation -->
+
+
+                <!-- Begin Sapphire Generation -->
+
+                <!-- Starting PipeVeins Preset for Sapphire. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoSapphireDist = "PipeVeins"'>
+                        <Veins name='nthoSapphireVeins'  inherits='PresetPipeVeins' seed='0x83DD' drawWireframe='true' wireframeColor='0x60554DB4' drawBoundBox='false' boundBoxColor='0x60554DB4'>
+                            <Description>
+                                Short sparsely filled veins  sloping
+                                up from near the bottom  of the map.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:15")'> <OreBlock block='NetherOres:tile.netherores.ore.0:15' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.585 * _default_ * nthoSapphireFreq ' range=':= _default_ * nthoSapphireFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.836 * _default_ * nthoSapphireSize ' range=':= _default_ * nthoSapphireSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.836 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * nthoSapphireSize ' range=':= _default_ * nthoSapphireSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.836 * _default_ * nthoSapphireSize ' range=':= _default_ * nthoSapphireSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                        </Veins>
+
+                        <!-- Configuring contained material. -->
+                        <Veins name='nthoSapphireVeinsPipe'  inherits='nthoSapphireVeins' seed='0x83DD' drawWireframe='true' wireframeColor='0x60554DB4' drawBoundBox='false' boundBoxColor='0x60554DB4'>
+                            <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:15")'> <Replaces block='NetherOres:tile.netherores.ore.0:15' weight='1.0' /> </IfCondition>
+                            <Setting name='MotherlodeSize' avg=':= 0.836 * _default_ * nthoSapphireSize  * 0.5 ' range=':= _default_ * nthoSapphireSize  * 0.5 ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.836 * _default_ * nthoSapphireSize  * 0.5 ' range=':= _default_ * nthoSapphireSize  * 0.5 ' type='normal' />
+                            <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- PipeVeins Preset for Sapphire is complete. -->
+
+
+                <!-- Starting Cloud Preset for Sapphire. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoSapphireDist = "Cloud"'>
+                        <Cloud name='nthoSapphireCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60554DB4' drawBoundBox='false' boundBoxColor='0x60554DB4'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:15")'> <OreBlock block='NetherOres:tile.netherores.ore.0:15' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.002 * _default_ * nthoSapphireSize ' range=':= _default_ * nthoSapphireSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.002 * _default_ * nthoSapphireSize ' range=':= _default_ * nthoSapphireSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.003  * _default_ * nthoSapphireFreq ' range=':= _default_ * nthoSapphireFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Veins name='nthoSapphireHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60554DB4' drawBoundBox='false' boundBoxColor='0x60554DB4'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:15")'> <OreBlock block='NetherOres:tile.netherores.ore.0:15' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Sapphire is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Sapphire. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoSapphireDist = "Vanilla"'>
+                        <StandardGen name='nthoSapphireStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60554DB4' drawBoundBox='false' boundBoxColor='0x60554DB4'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:15")'> <OreBlock block='NetherOres:tile.netherores.ore.0:15' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 3 * nthoSapphireSize ' range=':= _default_ * nthoSapphireSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 6 * nthoSapphireFreq ' range=':= _default_ * nthoSapphireFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Sapphire is complete. -->
+
+                <!-- End Sapphire Generation -->
+
+
+                <!-- Begin Platinum Generation -->
+
+                <!-- Starting LayeredVeins Preset for Platinum. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoPlatinumDist = "LayeredVeins"'>
+                        <Veins name='nthoPlatinumVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x6072A0D2' drawBoundBox='false' boundBoxColor='0x6072A0D2'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:0")'> <OreBlock block='NetherOres:tile.netherores.ore.1:0' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.205 * _default_ * nthoPlatinumFreq ' range=':= _default_ * nthoPlatinumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.590 * _default_ * nthoPlatinumSize ' range=':= _default_ * nthoPlatinumSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.590 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * nthoPlatinumSize ' range=':= _default_ * nthoPlatinumSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.590 * _default_ * nthoPlatinumSize ' range=':= _default_ * nthoPlatinumSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Platinum is complete. -->
+
+
+                <!-- Starting Cloud Preset for Platinum. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoPlatinumDist = "Cloud"'>
+                        <Cloud name='nthoPlatinumCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x6072A0D2' drawBoundBox='false' boundBoxColor='0x6072A0D2'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:0")'> <OreBlock block='NetherOres:tile.netherores.ore.1:0' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.640 * _default_ * nthoPlatinumSize ' range=':= _default_ * nthoPlatinumSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.640 * _default_ * nthoPlatinumSize ' range=':= _default_ * nthoPlatinumSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.410  * _default_ * nthoPlatinumFreq ' range=':= _default_ * nthoPlatinumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Veins name='nthoPlatinumHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x6072A0D2' drawBoundBox='false' boundBoxColor='0x6072A0D2'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:0")'> <OreBlock block='NetherOres:tile.netherores.ore.1:0' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Platinum is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Platinum. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoPlatinumDist = "Vanilla"'>
+                        <StandardGen name='nthoPlatinumStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x6072A0D2' drawBoundBox='false' boundBoxColor='0x6072A0D2'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:0")'> <OreBlock block='NetherOres:tile.netherores.ore.1:0' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 3 * nthoPlatinumSize ' range=':= _default_ * nthoPlatinumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1 * nthoPlatinumFreq ' range=':= _default_ * nthoPlatinumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Platinum is complete. -->
+
+                <!-- End Platinum Generation -->
+
+
+                <!-- Begin Nickel Generation -->
+
+                <!-- Starting LayeredVeins Preset for Nickel. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoNickelDist = "LayeredVeins"'>
+                        <Veins name='nthoNickelVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60DDD396' drawBoundBox='false' boundBoxColor='0x60DDD396'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:1")'> <OreBlock block='NetherOres:tile.netherores.ore.1:1' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.580 * _default_ * nthoNickelFreq ' range=':= _default_ * nthoNickelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.834 * _default_ * nthoNickelSize ' range=':= _default_ * nthoNickelSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.834 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * nthoNickelSize ' range=':= _default_ * nthoNickelSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.834 * _default_ * nthoNickelSize ' range=':= _default_ * nthoNickelSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Nickel is complete. -->
+
+
+                <!-- Starting Cloud Preset for Nickel. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoNickelDist = "Cloud"'>
+                        <Cloud name='nthoNickelCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60DDD396' drawBoundBox='false' boundBoxColor='0x60DDD396'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:1")'> <OreBlock block='NetherOres:tile.netherores.ore.1:1' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.076 * _default_ * nthoNickelSize ' range=':= _default_ * nthoNickelSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.076 * _default_ * nthoNickelSize ' range=':= _default_ * nthoNickelSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.159  * _default_ * nthoNickelFreq ' range=':= _default_ * nthoNickelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Veins name='nthoNickelHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60DDD396' drawBoundBox='false' boundBoxColor='0x60DDD396'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:1")'> <OreBlock block='NetherOres:tile.netherores.ore.1:1' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Nickel is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Nickel. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoNickelDist = "Vanilla"'>
+                        <StandardGen name='nthoNickelStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60DDD396' drawBoundBox='false' boundBoxColor='0x60DDD396'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:1")'> <OreBlock block='NetherOres:tile.netherores.ore.1:1' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 4 * nthoNickelSize ' range=':= _default_ * nthoNickelSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 6 * nthoNickelFreq ' range=':= _default_ * nthoNickelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Nickel is complete. -->
+
+                <!-- End Nickel Generation -->
+
+
+                <!-- Begin Steel Generation -->
+
+                <!-- Starting LayeredVeins Preset for Steel. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoSteelDist = "LayeredVeins"'>
+                        <Veins name='nthoSteelVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60E89D97' drawBoundBox='false' boundBoxColor='0x60E89D97'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:2")'> <OreBlock block='NetherOres:tile.netherores.ore.1:2' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.410 * _default_ * nthoSteelFreq ' range=':= _default_ * nthoSteelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.743 * _default_ * nthoSteelSize ' range=':= _default_ * nthoSteelSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.743 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * nthoSteelSize ' range=':= _default_ * nthoSteelSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.743 * _default_ * nthoSteelSize ' range=':= _default_ * nthoSteelSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Steel is complete. -->
+
+
+                <!-- Starting Cloud Preset for Steel. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoSteelDist = "Cloud"'>
+                        <Cloud name='nthoSteelCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60E89D97' drawBoundBox='false' boundBoxColor='0x60E89D97'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:2")'> <OreBlock block='NetherOres:tile.netherores.ore.1:2' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.905 * _default_ * nthoSteelSize ' range=':= _default_ * nthoSteelSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.905 * _default_ * nthoSteelSize ' range=':= _default_ * nthoSteelSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * nthoSteelFreq ' range=':= _default_ * nthoSteelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Veins name='nthoSteelHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60E89D97' drawBoundBox='false' boundBoxColor='0x60E89D97'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:2")'> <OreBlock block='NetherOres:tile.netherores.ore.1:2' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Steel is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Steel. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoSteelDist = "Vanilla"'>
+                        <StandardGen name='nthoSteelStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60E89D97' drawBoundBox='false' boundBoxColor='0x60E89D97'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:2")'> <OreBlock block='NetherOres:tile.netherores.ore.1:2' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 4 * nthoSteelSize ' range=':= _default_ * nthoSteelSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 3 * nthoSteelFreq ' range=':= _default_ * nthoSteelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Steel is complete. -->
+
+                <!-- End Steel Generation -->
+
+
+                <!-- Begin Iridium Generation -->
+
+                <!-- Starting SmallDeposits Preset for Iridium. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoIridiumDist = "SmallDeposits"'>
+                        <Veins name='nthoIridiumVeins'  inherits='PresetSmallDeposits' drawWireframe='true' wireframeColor='0x60CECECE' drawBoundBox='false' boundBoxColor='0x60CECECE'>
+                            <Description>
+                                Small motherlodes without any
+                                branches.  Similar to the  deposits
+                                produced by StandardGen
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:3")'> <OreBlock block='NetherOres:tile.netherores.ore.1:3' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.270 * _default_ * nthoIridiumFreq ' range=':= _default_ * nthoIridiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.647 * _default_ * nthoIridiumSize ' range=':= _default_ * nthoIridiumSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.647 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * nthoIridiumSize ' range=':= _default_ * nthoIridiumSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.647 * _default_ * nthoIridiumSize ' range=':= _default_ * nthoIridiumSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- SmallDeposits Preset for Iridium is complete. -->
+
+
+                <!-- Starting Cloud Preset for Iridium. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoIridiumDist = "Cloud"'>
+                        <Cloud name='nthoIridiumCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60CECECE' drawBoundBox='false' boundBoxColor='0x60CECECE'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:3")'> <OreBlock block='NetherOres:tile.netherores.ore.1:3' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.578 * _default_ * nthoIridiumSize ' range=':= _default_ * nthoIridiumSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.578 * _default_ * nthoIridiumSize ' range=':= _default_ * nthoIridiumSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.334  * _default_ * nthoIridiumFreq ' range=':= _default_ * nthoIridiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Veins name='nthoIridiumHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60CECECE' drawBoundBox='false' boundBoxColor='0x60CECECE'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:3")'> <OreBlock block='NetherOres:tile.netherores.ore.1:3' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Iridium is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Iridium. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoIridiumDist = "Vanilla"'>
+                        <StandardGen name='nthoIridiumStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60CECECE' drawBoundBox='false' boundBoxColor='0x60CECECE'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:3")'> <OreBlock block='NetherOres:tile.netherores.ore.1:3' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 2 * nthoIridiumSize ' range=':= _default_ * nthoIridiumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1 * nthoIridiumFreq ' range=':= _default_ * nthoIridiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Iridium is complete. -->
+
+                <!-- End Iridium Generation -->
+
+
+                <!-- Begin Osmium Generation -->
+
+                <!-- Starting LayeredVeins Preset for Osmium. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoOsmiumDist = "LayeredVeins"'>
+                        <Veins name='nthoOsmiumVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x6043638A' drawBoundBox='false' boundBoxColor='0x6043638A'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:4")'> <OreBlock block='NetherOres:tile.netherores.ore.1:4' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.886 * _default_ * nthoOsmiumFreq ' range=':= _default_ * nthoOsmiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.961 * _default_ * nthoOsmiumSize ' range=':= _default_ * nthoOsmiumSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.961 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * nthoOsmiumSize ' range=':= _default_ * nthoOsmiumSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.961 * _default_ * nthoOsmiumSize ' range=':= _default_ * nthoOsmiumSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Osmium is complete. -->
+
+
+                <!-- Starting Cloud Preset for Osmium. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoOsmiumDist = "Cloud"'>
+                        <Cloud name='nthoOsmiumCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x6043638A' drawBoundBox='false' boundBoxColor='0x6043638A'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:4")'> <OreBlock block='NetherOres:tile.netherores.ore.1:4' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.330 * _default_ * nthoOsmiumSize ' range=':= _default_ * nthoOsmiumSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.330 * _default_ * nthoOsmiumSize ' range=':= _default_ * nthoOsmiumSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.770  * _default_ * nthoOsmiumFreq ' range=':= _default_ * nthoOsmiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Veins name='nthoOsmiumHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x6043638A' drawBoundBox='false' boundBoxColor='0x6043638A'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:4")'> <OreBlock block='NetherOres:tile.netherores.ore.1:4' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Osmium is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Osmium. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoOsmiumDist = "Vanilla"'>
+                        <StandardGen name='nthoOsmiumStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x6043638A' drawBoundBox='false' boundBoxColor='0x6043638A'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:4")'> <OreBlock block='NetherOres:tile.netherores.ore.1:4' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 7 * nthoOsmiumSize ' range=':= _default_ * nthoOsmiumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 8 * nthoOsmiumFreq ' range=':= _default_ * nthoOsmiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Osmium is complete. -->
+
+                <!-- End Osmium Generation -->
+
+
+                <!-- Begin Sulfur Generation -->
+
+                <!-- Starting PipeVeins Preset for Sulfur. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoSulfurDist = "PipeVeins"'>
+                        <Veins name='nthoSulfurVeins'  inherits='PresetPipeVeins' seed='0xCB5E' drawWireframe='true' wireframeColor='0x60FDFD11' drawBoundBox='false' boundBoxColor='0x60FDFD11'>
+                            <Description>
+                                Short sparsely filled veins  sloping
+                                up from near the bottom  of the map.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:5")'> <OreBlock block='NetherOres:tile.netherores.ore.1:5' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.655 * _default_ * nthoSulfurFreq ' range=':= _default_ * nthoSulfurFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.183 * _default_ * nthoSulfurSize ' range=':= _default_ * nthoSulfurSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.183 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * nthoSulfurSize ' range=':= _default_ * nthoSulfurSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.183 * _default_ * nthoSulfurSize ' range=':= _default_ * nthoSulfurSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                        </Veins>
+
+                        <!-- Configuring contained material. -->
+                        <Veins name='nthoSulfurVeinsPipe'  inherits='nthoSulfurVeins' seed='0xCB5E' drawWireframe='true' wireframeColor='0x60FDFD11' drawBoundBox='false' boundBoxColor='0x60FDFD11'>
+                            <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:5")'> <Replaces block='NetherOres:tile.netherores.ore.1:5' weight='1.0' /> </IfCondition>
+                            <Setting name='MotherlodeSize' avg=':= 1.183 * _default_ * nthoSulfurSize  * 0.5 ' range=':= _default_ * nthoSulfurSize  * 0.5 ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.183 * _default_ * nthoSulfurSize  * 0.5 ' range=':= _default_ * nthoSulfurSize  * 0.5 ' type='normal' />
+                            <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- PipeVeins Preset for Sulfur is complete. -->
+
+
+                <!-- Starting Cloud Preset for Sulfur. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoSulfurDist = "Cloud"'>
+                        <Cloud name='nthoSulfurCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60FDFD11' drawBoundBox='false' boundBoxColor='0x60FDFD11'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:5")'> <OreBlock block='NetherOres:tile.netherores.ore.1:5' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.685 * _default_ * nthoSulfurSize ' range=':= _default_ * nthoSulfurSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.685 * _default_ * nthoSulfurSize ' range=':= _default_ * nthoSulfurSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 2.838  * _default_ * nthoSulfurFreq ' range=':= _default_ * nthoSulfurFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Veins name='nthoSulfurHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FDFD11' drawBoundBox='false' boundBoxColor='0x60FDFD11'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:5")'> <OreBlock block='NetherOres:tile.netherores.ore.1:5' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Sulfur is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Sulfur. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoSulfurDist = "Vanilla"'>
+                        <StandardGen name='nthoSulfurStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60FDFD11' drawBoundBox='false' boundBoxColor='0x60FDFD11'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:5")'> <OreBlock block='NetherOres:tile.netherores.ore.1:5' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 12 * nthoSulfurSize ' range=':= _default_ * nthoSulfurSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 12 * nthoSulfurFreq ' range=':= _default_ * nthoSulfurFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Sulfur is complete. -->
+
+                <!-- End Sulfur Generation -->
+
+
+                <!-- Begin Titanium Generation -->
+
+                <!-- Starting LayeredVeins Preset for Titanium. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoTitaniumDist = "LayeredVeins"'>
+                        <Veins name='nthoTitaniumVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60686868' drawBoundBox='false' boundBoxColor='0x60686868'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:6")'> <OreBlock block='NetherOres:tile.netherores.ore.1:6' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.290 * _default_ * nthoTitaniumFreq ' range=':= _default_ * nthoTitaniumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.662 * _default_ * nthoTitaniumSize ' range=':= _default_ * nthoTitaniumSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.662 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * nthoTitaniumSize ' range=':= _default_ * nthoTitaniumSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.662 * _default_ * nthoTitaniumSize ' range=':= _default_ * nthoTitaniumSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Titanium is complete. -->
+
+
+                <!-- Starting Cloud Preset for Titanium. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoTitaniumDist = "Cloud"'>
+                        <Cloud name='nthoTitaniumCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60686868' drawBoundBox='false' boundBoxColor='0x60686868'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:6")'> <OreBlock block='NetherOres:tile.netherores.ore.1:6' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.761 * _default_ * nthoTitaniumSize ' range=':= _default_ * nthoTitaniumSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.761 * _default_ * nthoTitaniumSize ' range=':= _default_ * nthoTitaniumSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.579  * _default_ * nthoTitaniumFreq ' range=':= _default_ * nthoTitaniumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Veins name='nthoTitaniumHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60686868' drawBoundBox='false' boundBoxColor='0x60686868'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:6")'> <OreBlock block='NetherOres:tile.netherores.ore.1:6' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Titanium is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Titanium. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoTitaniumDist = "Vanilla"'>
+                        <StandardGen name='nthoTitaniumStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60686868' drawBoundBox='false' boundBoxColor='0x60686868'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:6")'> <OreBlock block='NetherOres:tile.netherores.ore.1:6' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 2 * nthoTitaniumSize ' range=':= _default_ * nthoTitaniumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 3 * nthoTitaniumFreq ' range=':= _default_ * nthoTitaniumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Titanium is complete. -->
+
+                <!-- End Titanium Generation -->
+
+
+                <!-- Begin Mithril Generation -->
+
+                <!-- Starting LayeredVeins Preset for Mithril. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoMithrilDist = "LayeredVeins"'>
+                        <Veins name='nthoMithrilVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x6075E0F6' drawBoundBox='false' boundBoxColor='0x6075E0F6'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:7")'> <OreBlock block='NetherOres:tile.netherores.ore.1:7' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.711 * _default_ * nthoMithrilFreq ' range=':= _default_ * nthoMithrilFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.892 * _default_ * nthoMithrilSize ' range=':= _default_ * nthoMithrilSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.892 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * nthoMithrilSize ' range=':= _default_ * nthoMithrilSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.892 * _default_ * nthoMithrilSize ' range=':= _default_ * nthoMithrilSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Mithril is complete. -->
+
+
+                <!-- Starting Cloud Preset for Mithril. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoMithrilDist = "Cloud"'>
+                        <Cloud name='nthoMithrilCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x6075E0F6' drawBoundBox='false' boundBoxColor='0x6075E0F6'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:7")'> <OreBlock block='NetherOres:tile.netherores.ore.1:7' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.191 * _default_ * nthoMithrilSize ' range=':= _default_ * nthoMithrilSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.191 * _default_ * nthoMithrilSize ' range=':= _default_ * nthoMithrilSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.419  * _default_ * nthoMithrilFreq ' range=':= _default_ * nthoMithrilFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Veins name='nthoMithrilHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x6075E0F6' drawBoundBox='false' boundBoxColor='0x6075E0F6'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:7")'> <OreBlock block='NetherOres:tile.netherores.ore.1:7' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Mithril is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Mithril. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoMithrilDist = "Vanilla"'>
+                        <StandardGen name='nthoMithrilStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x6075E0F6' drawBoundBox='false' boundBoxColor='0x6075E0F6'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:7")'> <OreBlock block='NetherOres:tile.netherores.ore.1:7' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 6 * nthoMithrilSize ' range=':= _default_ * nthoMithrilSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 6 * nthoMithrilFreq ' range=':= _default_ * nthoMithrilFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Mithril is complete. -->
+
+                <!-- End Mithril Generation -->
+
+
+                <!-- Begin Adamantium Generation -->
+
+                <!-- Starting LayeredVeins Preset for Adamantium. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoAdamantiumDist = "LayeredVeins"'>
+                        <Veins name='nthoAdamantiumVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x609CA6B0' drawBoundBox='false' boundBoxColor='0x609CA6B0'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:8")'> <OreBlock block='NetherOres:tile.netherores.ore.1:8' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.530 * _default_ * nthoAdamantiumFreq ' range=':= _default_ * nthoAdamantiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.809 * _default_ * nthoAdamantiumSize ' range=':= _default_ * nthoAdamantiumSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.809 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * nthoAdamantiumSize ' range=':= _default_ * nthoAdamantiumSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.809 * _default_ * nthoAdamantiumSize ' range=':= _default_ * nthoAdamantiumSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Adamantium is complete. -->
+
+
+                <!-- Starting Cloud Preset for Adamantium. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoAdamantiumDist = "Cloud"'>
+                        <Cloud name='nthoAdamantiumCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x609CA6B0' drawBoundBox='false' boundBoxColor='0x609CA6B0'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:8")'> <OreBlock block='NetherOres:tile.netherores.ore.1:8' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.028 * _default_ * nthoAdamantiumSize ' range=':= _default_ * nthoAdamantiumSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.028 * _default_ * nthoAdamantiumSize ' range=':= _default_ * nthoAdamantiumSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.058  * _default_ * nthoAdamantiumFreq ' range=':= _default_ * nthoAdamantiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Veins name='nthoAdamantiumHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x609CA6B0' drawBoundBox='false' boundBoxColor='0x609CA6B0'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:8")'> <OreBlock block='NetherOres:tile.netherores.ore.1:8' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Adamantium is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Adamantium. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoAdamantiumDist = "Vanilla"'>
+                        <StandardGen name='nthoAdamantiumStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x609CA6B0' drawBoundBox='false' boundBoxColor='0x609CA6B0'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:8")'> <OreBlock block='NetherOres:tile.netherores.ore.1:8' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 4 * nthoAdamantiumSize ' range=':= _default_ * nthoAdamantiumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 5 * nthoAdamantiumFreq ' range=':= _default_ * nthoAdamantiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Adamantium is complete. -->
+
+                <!-- End Adamantium Generation -->
+
+
+                <!-- Begin Rutile Generation -->
+
+                <!-- Starting LayeredVeins Preset for Rutile. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoRutileDist = "LayeredVeins"'>
+                        <Veins name='nthoRutileVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60D2C7A9' drawBoundBox='false' boundBoxColor='0x60D2C7A9'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:9")'> <OreBlock block='NetherOres:tile.netherores.ore.1:9' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.410 * _default_ * nthoRutileFreq ' range=':= _default_ * nthoRutileFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.743 * _default_ * nthoRutileSize ' range=':= _default_ * nthoRutileSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.743 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * nthoRutileSize ' range=':= _default_ * nthoRutileSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.743 * _default_ * nthoRutileSize ' range=':= _default_ * nthoRutileSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Rutile is complete. -->
+
+
+                <!-- Starting Cloud Preset for Rutile. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoRutileDist = "Cloud"'>
+                        <Cloud name='nthoRutileCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60D2C7A9' drawBoundBox='false' boundBoxColor='0x60D2C7A9'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:9")'> <OreBlock block='NetherOres:tile.netherores.ore.1:9' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.905 * _default_ * nthoRutileSize ' range=':= _default_ * nthoRutileSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.905 * _default_ * nthoRutileSize ' range=':= _default_ * nthoRutileSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.819  * _default_ * nthoRutileFreq ' range=':= _default_ * nthoRutileFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Veins name='nthoRutileHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60D2C7A9' drawBoundBox='false' boundBoxColor='0x60D2C7A9'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:9")'> <OreBlock block='NetherOres:tile.netherores.ore.1:9' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Rutile is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Rutile. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoRutileDist = "Vanilla"'>
+                        <StandardGen name='nthoRutileStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60D2C7A9' drawBoundBox='false' boundBoxColor='0x60D2C7A9'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:9")'> <OreBlock block='NetherOres:tile.netherores.ore.1:9' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 4 * nthoRutileSize ' range=':= _default_ * nthoRutileSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 3 * nthoRutileFreq ' range=':= _default_ * nthoRutileFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Rutile is complete. -->
+
+                <!-- End Rutile Generation -->
+
+
+                <!-- Begin Tungsten Generation -->
+
+                <!-- Starting LayeredVeins Preset for Tungsten. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoTungstenDist = "LayeredVeins"'>
+                        <Veins name='nthoTungstenVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60212121' drawBoundBox='false' boundBoxColor='0x60212121'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:10")'> <OreBlock block='NetherOres:tile.netherores.ore.1:10' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.948 * _default_ * nthoTungstenFreq ' range=':= _default_ * nthoTungstenFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.982 * _default_ * nthoTungstenSize ' range=':= _default_ * nthoTungstenSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.982 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * nthoTungstenSize ' range=':= _default_ * nthoTungstenSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.982 * _default_ * nthoTungstenSize ' range=':= _default_ * nthoTungstenSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Tungsten is complete. -->
+
+
+                <!-- Starting Cloud Preset for Tungsten. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoTungstenDist = "Cloud"'>
+                        <Cloud name='nthoTungstenCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60212121' drawBoundBox='false' boundBoxColor='0x60212121'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:10")'> <OreBlock block='NetherOres:tile.netherores.ore.1:10' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.375 * _default_ * nthoTungstenSize ' range=':= _default_ * nthoTungstenSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.375 * _default_ * nthoTungstenSize ' range=':= _default_ * nthoTungstenSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.892  * _default_ * nthoTungstenFreq ' range=':= _default_ * nthoTungstenFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Veins name='nthoTungstenHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60212121' drawBoundBox='false' boundBoxColor='0x60212121'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:10")'> <OreBlock block='NetherOres:tile.netherores.ore.1:10' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Tungsten is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Tungsten. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoTungstenDist = "Vanilla"'>
+                        <StandardGen name='nthoTungstenStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60212121' drawBoundBox='false' boundBoxColor='0x60212121'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:10")'> <OreBlock block='NetherOres:tile.netherores.ore.1:10' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 8 * nthoTungstenSize ' range=':= _default_ * nthoTungstenSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 8 * nthoTungstenFreq ' range=':= _default_ * nthoTungstenFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Tungsten is complete. -->
+
+                <!-- End Tungsten Generation -->
+
+
+                <!-- Begin Amber Generation -->
+
+                <!-- Starting SparseVeins Preset for Amber. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoAmberDist = "SparseVeins"'>
+                        <Veins name='nthoAmberVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60FEA219' drawBoundBox='false' boundBoxColor='0x60FEA219'>
+                            <Description>
+                                Large veins filled very lightly  with
+                                ore.  Because they contain  less ore
+                                per volume, these veins  are
+                                relatively wide and long.  Mining the
+                                ore from them is time  consuming
+                                compared to solid ore  veins.  They
+                                are also more  difficult to follow,
+                                since it is  harder to get an idea of
+                                their  direction while mining.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:11")'> <OreBlock block='NetherOres:tile.netherores.ore.1:11' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.917 * _default_ * nthoAmberFreq ' range=':= _default_ * nthoAmberFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.242 * _default_ * nthoAmberSize ' range=':= _default_ * nthoAmberSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.242 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * nthoAmberSize ' range=':= _default_ * nthoAmberSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.242 * _default_ * nthoAmberSize ' range=':= _default_ * nthoAmberSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- SparseVeins Preset for Amber is complete. -->
+
+
+                <!-- Starting Cloud Preset for Amber. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoAmberDist = "Cloud"'>
+                        <Cloud name='nthoAmberCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60FEA219' drawBoundBox='false' boundBoxColor='0x60FEA219'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:11")'> <OreBlock block='NetherOres:tile.netherores.ore.1:11' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.138 * _default_ * nthoAmberSize ' range=':= _default_ * nthoAmberSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.138 * _default_ * nthoAmberSize ' range=':= _default_ * nthoAmberSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.295  * _default_ * nthoAmberFreq ' range=':= _default_ * nthoAmberFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Veins name='nthoAmberHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FEA219' drawBoundBox='false' boundBoxColor='0x60FEA219'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:11")'> <OreBlock block='NetherOres:tile.netherores.ore.1:11' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Amber is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Amber. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoAmberDist = "Vanilla"'>
+                        <StandardGen name='nthoAmberStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60FEA219' drawBoundBox='false' boundBoxColor='0x60FEA219'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:11")'> <OreBlock block='NetherOres:tile.netherores.ore.1:11' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 6 * nthoAmberSize ' range=':= _default_ * nthoAmberSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 5 * nthoAmberFreq ' range=':= _default_ * nthoAmberFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Amber is complete. -->
+
+                <!-- End Amber Generation -->
+
+
+                <!-- Begin Tennantite Generation -->
+
+                <!-- Starting LayeredVeins Preset for Tennantite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoTennantiteDist = "LayeredVeins"'>
+                        <Veins name='nthoTennantiteVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x609EE2B1' drawBoundBox='false' boundBoxColor='0x609EE2B1'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:12")'> <OreBlock block='NetherOres:tile.netherores.ore.1:12' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.948 * _default_ * nthoTennantiteFreq ' range=':= _default_ * nthoTennantiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.982 * _default_ * nthoTennantiteSize ' range=':= _default_ * nthoTennantiteSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.982 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * nthoTennantiteSize ' range=':= _default_ * nthoTennantiteSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.982 * _default_ * nthoTennantiteSize ' range=':= _default_ * nthoTennantiteSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Tennantite is complete. -->
+
+
+                <!-- Starting Cloud Preset for Tennantite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoTennantiteDist = "Cloud"'>
+                        <Cloud name='nthoTennantiteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x609EE2B1' drawBoundBox='false' boundBoxColor='0x609EE2B1'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:12")'> <OreBlock block='NetherOres:tile.netherores.ore.1:12' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.375 * _default_ * nthoTennantiteSize ' range=':= _default_ * nthoTennantiteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.375 * _default_ * nthoTennantiteSize ' range=':= _default_ * nthoTennantiteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.892  * _default_ * nthoTennantiteFreq ' range=':= _default_ * nthoTennantiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Veins name='nthoTennantiteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x609EE2B1' drawBoundBox='false' boundBoxColor='0x609EE2B1'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:12")'> <OreBlock block='NetherOres:tile.netherores.ore.1:12' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Tennantite is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Tennantite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoTennantiteDist = "Vanilla"'>
+                        <StandardGen name='nthoTennantiteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x609EE2B1' drawBoundBox='false' boundBoxColor='0x609EE2B1'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:12")'> <OreBlock block='NetherOres:tile.netherores.ore.1:12' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 8 * nthoTennantiteSize ' range=':= _default_ * nthoTennantiteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 8 * nthoTennantiteFreq ' range=':= _default_ * nthoTennantiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Tennantite is complete. -->
+
+                <!-- End Tennantite Generation -->
+
+
+                <!-- Begin Salt Generation -->
+
+                <!-- Starting SparseVeins Preset for Salt. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoSaltDist = "SparseVeins"'>
+                        <Veins name='nthoSaltVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60FFFFFF' drawBoundBox='false' boundBoxColor='0x60FFFFFF'>
+                            <Description>
+                                Large veins filled very lightly  with
+                                ore.  Because they contain  less ore
+                                per volume, these veins  are
+                                relatively wide and long.  Mining the
+                                ore from them is time  consuming
+                                compared to solid ore  veins.  They
+                                are also more  difficult to follow,
+                                since it is  harder to get an idea of
+                                their  direction while mining.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:13")'> <OreBlock block='NetherOres:tile.netherores.ore.1:13' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.750 * _default_ * nthoSaltFreq ' range=':= _default_ * nthoSaltFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.205 * _default_ * nthoSaltSize ' range=':= _default_ * nthoSaltSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.205 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * nthoSaltSize ' range=':= _default_ * nthoSaltSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.205 * _default_ * nthoSaltSize ' range=':= _default_ * nthoSaltSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- SparseVeins Preset for Salt is complete. -->
+
+
+                <!-- Starting Cloud Preset for Salt. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoSaltDist = "Cloud"'>
+                        <Cloud name='nthoSaltCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60FFFFFF' drawBoundBox='false' boundBoxColor='0x60FFFFFF'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:13")'> <OreBlock block='NetherOres:tile.netherores.ore.1:13' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.087 * _default_ * nthoSaltSize ' range=':= _default_ * nthoSaltSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.087 * _default_ * nthoSaltSize ' range=':= _default_ * nthoSaltSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.182  * _default_ * nthoSaltFreq ' range=':= _default_ * nthoSaltFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Veins name='nthoSaltHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FFFFFF' drawBoundBox='false' boundBoxColor='0x60FFFFFF'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:13")'> <OreBlock block='NetherOres:tile.netherores.ore.1:13' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Salt is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Salt. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoSaltDist = "Vanilla"'>
+                        <StandardGen name='nthoSaltStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60FFFFFF' drawBoundBox='false' boundBoxColor='0x60FFFFFF'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:13")'> <OreBlock block='NetherOres:tile.netherores.ore.1:13' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 5 * nthoSaltSize ' range=':= _default_ * nthoSaltSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 5 * nthoSaltFreq ' range=':= _default_ * nthoSaltFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Salt is complete. -->
+
+                <!-- End Salt Generation -->
+
+
+                <!-- Begin Saltpeter Generation -->
+
+                <!-- Starting SparseVeins Preset for Saltpeter. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoSaltpeterDist = "SparseVeins"'>
+                        <Veins name='nthoSaltpeterVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60F4F6F9' drawBoundBox='false' boundBoxColor='0x60F4F6F9'>
+                            <Description>
+                                Large veins filled very lightly  with
+                                ore.  Because they contain  less ore
+                                per volume, these veins  are
+                                relatively wide and long.  Mining the
+                                ore from them is time  consuming
+                                compared to solid ore  veins.  They
+                                are also more  difficult to follow,
+                                since it is  harder to get an idea of
+                                their  direction while mining.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:14")'> <OreBlock block='NetherOres:tile.netherores.ore.1:14' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.715 * _default_ * nthoSaltpeterFreq ' range=':= _default_ * nthoSaltpeterFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.197 * _default_ * nthoSaltpeterSize ' range=':= _default_ * nthoSaltpeterSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.197 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * nthoSaltpeterSize ' range=':= _default_ * nthoSaltpeterSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.197 * _default_ * nthoSaltpeterSize ' range=':= _default_ * nthoSaltpeterSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- SparseVeins Preset for Saltpeter is complete. -->
+
+
+                <!-- Starting Cloud Preset for Saltpeter. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoSaltpeterDist = "Cloud"'>
+                        <Cloud name='nthoSaltpeterCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60F4F6F9' drawBoundBox='false' boundBoxColor='0x60F4F6F9'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:14")'> <OreBlock block='NetherOres:tile.netherores.ore.1:14' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.076 * _default_ * nthoSaltpeterSize ' range=':= _default_ * nthoSaltpeterSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.076 * _default_ * nthoSaltpeterSize ' range=':= _default_ * nthoSaltpeterSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.159  * _default_ * nthoSaltpeterFreq ' range=':= _default_ * nthoSaltpeterFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Veins name='nthoSaltpeterHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60F4F6F9' drawBoundBox='false' boundBoxColor='0x60F4F6F9'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:14")'> <OreBlock block='NetherOres:tile.netherores.ore.1:14' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Saltpeter is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Saltpeter. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoSaltpeterDist = "Vanilla"'>
+                        <StandardGen name='nthoSaltpeterStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60F4F6F9' drawBoundBox='false' boundBoxColor='0x60F4F6F9'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:14")'> <OreBlock block='NetherOres:tile.netherores.ore.1:14' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 4 * nthoSaltpeterSize ' range=':= _default_ * nthoSaltpeterSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 6 * nthoSaltpeterFreq ' range=':= _default_ * nthoSaltpeterFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Saltpeter is complete. -->
+
+                <!-- End Saltpeter Generation -->
+
+
+                <!-- Begin Magnesium Generation -->
+
+                <!-- Starting SparseVeins Preset for Magnesium. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoMagnesiumDist = "SparseVeins"'>
+                        <Veins name='nthoMagnesiumVeins'  inherits='PresetSparseVeins' drawWireframe='true' wireframeColor='0x60827066' drawBoundBox='false' boundBoxColor='0x60827066'>
+                            <Description>
+                                Large veins filled very lightly  with
+                                ore.  Because they contain  less ore
+                                per volume, these veins  are
+                                relatively wide and long.  Mining the
+                                ore from them is time  consuming
+                                compared to solid ore  veins.  They
+                                are also more  difficult to follow,
+                                since it is  harder to get an idea of
+                                their  direction while mining.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:15")'> <OreBlock block='NetherOres:tile.netherores.ore.1:15' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.566 * _default_ * nthoMagnesiumFreq ' range=':= _default_ * nthoMagnesiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.161 * _default_ * nthoMagnesiumSize ' range=':= _default_ * nthoMagnesiumSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.161 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * nthoMagnesiumSize ' range=':= _default_ * nthoMagnesiumSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.161 * _default_ * nthoMagnesiumSize ' range=':= _default_ * nthoMagnesiumSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- SparseVeins Preset for Magnesium is complete. -->
+
+
+                <!-- Starting Cloud Preset for Magnesium. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoMagnesiumDist = "Cloud"'>
+                        <Cloud name='nthoMagnesiumCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60827066' drawBoundBox='false' boundBoxColor='0x60827066'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:15")'> <OreBlock block='NetherOres:tile.netherores.ore.1:15' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.028 * _default_ * nthoMagnesiumSize ' range=':= _default_ * nthoMagnesiumSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.028 * _default_ * nthoMagnesiumSize ' range=':= _default_ * nthoMagnesiumSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.058  * _default_ * nthoMagnesiumFreq ' range=':= _default_ * nthoMagnesiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Veins name='nthoMagnesiumHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60827066' drawBoundBox='false' boundBoxColor='0x60827066'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:15")'> <OreBlock block='NetherOres:tile.netherores.ore.1:15' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Magnesium is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Magnesium. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthoMagnesiumDist = "Vanilla"'>
+                        <StandardGen name='nthoMagnesiumStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60827066' drawBoundBox='false' boundBoxColor='0x60827066'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:15")'> <OreBlock block='NetherOres:tile.netherores.ore.1:15' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 5 * nthoMagnesiumSize ' range=':= _default_ * nthoMagnesiumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4 * nthoMagnesiumFreq ' range=':= _default_ * nthoMagnesiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Magnesium is complete. -->
+
+                <!-- End Magnesium Generation -->
+
+                <!-- Finished adding blocks -->
+
             </IfCondition>
             <!-- Nether Setup Complete -->
 
-        
-        </ConfigSection>
-        <!-- Configuration for Custom Ore Generation Complete! -->
-    
-    </IfModInstalled> 
- 
+
+        </IfCondition>
+
+    </ConfigSection>
+    <!-- Configuration for Custom Ore Generation Complete! -->
+
+</IfModInstalled>
+<!-- The "Nether Ores" mod is now configured. -->
 
 
-<!-- This file was made using the Sprocket Configuration Generator. -->
+
+
+
+<!-- =================================================================
+     This file was made using the Sprocket Configuration Generator.
+     If you wish to make your own configurations for a mod not
+     currently supported by Custom Ore Generation, and you don't want
+     the hassle of writing XML, you can find the generator script at
+     its GitHub page: http://https://github.com/reteo/Sprocket
+     ================================================================= -->

--- a/src/main/resources/config/modules/Netherrocks.xml
+++ b/src/main/resources/config/modules/Netherrocks.xml
@@ -1,1116 +1,923 @@
- <!-- ================================================================
-      Custom Ore Generation "Netherrocks" Module: This configuration
-      covers malachite, dragonstone, illumenite, fyrite, ashtone, and
-      argonite.
-      ================================================================
-      -->
+<!-- =================================================================
+     Custom Ore Generation "Netherrocks" Module: This configuration
+     covers fyrite, malachite, ashtone, illumenite, dragonstone, and
+     argonite.
+     ================================================================= -->
 
-    <!-- Mod detection -->
-    <IfModInstalled name="netherrocks">
-    
-        <!-- Starting Configuration for Custom Ore Generation. -->
+
+
+
+
+
+<!-- Is the "Netherrocks" mod on the system?  Let's find out! -->
+<IfModInstalled name="netherrocks">
+
+    <!-- Starting Configuration for Custom Ore Generation. -->
+    <ConfigSection>
+
+
+
+
+
+        <!-- Setup Screen Configuration -->
         <ConfigSection>
-        
-            
-            <!-- Setup Screen Configuration -->
+            <OptionDisplayGroup name='groupNetherrocks' displayName='Netherrocks' displayState='shown'>
+                <Description>
+                    Distribution options for Netherrocks Ores.
+                </Description>
+            </OptionDisplayGroup>
+            <OptionChoice name='enableNetherrocks' displayName='Handle Netherrocks Setup?' default='true' displayState='shown_dynamic' displayGroup='groupNetherrocks'>
+                <Description> Should Custom Ore Generation handle Netherrocks ore generation? </Description>
+                <Choice value=':= ?true' displayValue='Yes' description='Use Custom Ore Generation to handle Netherrocks ores.'/>
+                <Choice value=':= ?false' displayValue='No' description='Netherrocks ores will be handled by the mod itself.'/>
+            </OptionChoice>
+
+            <!-- Fyrite Configuration UI Starting -->
             <ConfigSection>
-                <OptionDisplayGroup name='groupNetherrocks' displayName='Netherrocks' displayState='shown'> 
-                    <Description>
-                        Distribution options for Netherrocks Ores.
-                    </Description>
-                </OptionDisplayGroup>
-                
-                <!-- Malachite Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='nthrMalachiteDist'  displayState='shown' displayGroup='groupNetherrocks'> 
-                        <Description> Controls how Malachite is generated </Description> 
-                        <DisplayName>Netherrocks Malachite</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Malachite is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='nthrMalachiteFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherrocks'>
-                        <Description> Frequency multiplier for Netherrocks Malachite distributions </Description>
-                        <DisplayName>Netherrocks Malachite Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='nthrMalachiteSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherrocks'>
-                        <Description> Size multiplier for Netherrocks Malachite distributions </Description>
-                        <DisplayName>Netherrocks Malachite Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Malachite Configuration UI Complete -->
-                
-                
-                <!-- Dragonstone Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='nthrDragonstoneDist'  displayState='shown' displayGroup='groupNetherrocks'> 
-                        <Description> Controls how Dragonstone is generated </Description> 
-                        <DisplayName>Netherrocks Dragonstone</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Dragonstone is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='nthrDragonstoneFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherrocks'>
-                        <Description> Frequency multiplier for Netherrocks Dragonstone distributions </Description>
-                        <DisplayName>Netherrocks Dragonstone Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='nthrDragonstoneSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherrocks'>
-                        <Description> Size multiplier for Netherrocks Dragonstone distributions </Description>
-                        <DisplayName>Netherrocks Dragonstone Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Dragonstone Configuration UI Complete -->
-                
-                
-                <!-- Illumenite Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='nthrIllumeniteDist'  displayState='shown' displayGroup='groupNetherrocks'> 
-                        <Description> Controls how Illumenite is generated </Description> 
-                        <DisplayName>Netherrocks Illumenite</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Illumenite is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='nthrIllumeniteFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherrocks'>
-                        <Description> Frequency multiplier for Netherrocks Illumenite distributions </Description>
-                        <DisplayName>Netherrocks Illumenite Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='nthrIllumeniteSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherrocks'>
-                        <Description> Size multiplier for Netherrocks Illumenite distributions </Description>
-                        <DisplayName>Netherrocks Illumenite Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Illumenite Configuration UI Complete -->
-                
-                
-                <!-- Fyrite Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='nthrFyriteDist'  displayState='shown' displayGroup='groupNetherrocks'> 
-                        <Description> Controls how Fyrite is generated </Description> 
-                        <DisplayName>Netherrocks Fyrite</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Fyrite is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='nthrFyriteFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherrocks'>
-                        <Description> Frequency multiplier for Netherrocks Fyrite distributions </Description>
-                        <DisplayName>Netherrocks Fyrite Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='nthrFyriteSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherrocks'>
-                        <Description> Size multiplier for Netherrocks Fyrite distributions </Description>
-                        <DisplayName>Netherrocks Fyrite Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Fyrite Configuration UI Complete -->
-                
-                
-                <!-- Ashtone Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='nthrAshtoneDist'  displayState='shown' displayGroup='groupNetherrocks'> 
-                        <Description> Controls how Ashtone is generated </Description> 
-                        <DisplayName>Netherrocks Ashtone</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Ashtone is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='nthrAshtoneFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherrocks'>
-                        <Description> Frequency multiplier for Netherrocks Ashtone distributions </Description>
-                        <DisplayName>Netherrocks Ashtone Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='nthrAshtoneSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherrocks'>
-                        <Description> Size multiplier for Netherrocks Ashtone distributions </Description>
-                        <DisplayName>Netherrocks Ashtone Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Ashtone Configuration UI Complete -->
-                
-                
-                <!-- Argonite Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='nthrArgoniteDist'  displayState='shown' displayGroup='groupNetherrocks'> 
-                        <Description> Controls how Argonite is generated </Description> 
-                        <DisplayName>Netherrocks Argonite</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='hugeVeins' displayValue='Huge Veins'>
-                            <Description>
-                                Huge Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='strategicCloud' displayValue='Clouds'>
-                            <Description>
-                                Strategic Clouds.
-                            </Description>
-                        </Choice>
-                        <Choice value='vanillaStdGen' displayValue='Vanilla'>
-                            <Description>
-                                Vanilla-style clusters.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Argonite is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='nthrArgoniteFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherrocks'>
-                        <Description> Frequency multiplier for Netherrocks Argonite distributions </Description>
-                        <DisplayName>Netherrocks Argonite Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='nthrArgoniteSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupNetherrocks'>
-                        <Description> Size multiplier for Netherrocks Argonite distributions </Description>
-                        <DisplayName>Netherrocks Argonite Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Argonite Configuration UI Complete -->
-                
+                <OptionChoice name='nthrFyriteDist'  displayState=':= if(?enableNetherrocks, "shown", "hidden")' displayGroup='groupNetherrocks'>
+                    <Description> Controls how Fyrite is generated </Description>
+                    <DisplayName>Netherrocks Fyrite</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                        <Description>
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Fyrite is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='nthrFyriteFreq' default='1'  min='0' max='5' displayState=':= if(?enableNetherrocks, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherrocks'>
+                    <Description> Frequency multiplier for Netherrocks Fyrite distributions </Description>
+                    <DisplayName>Netherrocks Fyrite Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='nthrFyriteSize' default='1'  min='0' max='5' displayState=':= if(?enableNetherrocks, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherrocks'>
+                    <Description> Size multiplier for Netherrocks Fyrite distributions </Description>
+                    <DisplayName>Netherrocks Fyrite Size</DisplayName>
+                </OptionNumeric>
             </ConfigSection>
-            <!-- Setup Screen Complete -->
+            <!-- Fyrite Configuration UI Complete -->
 
 
-            <!-- Setup Nether -->
-            <IfCondition condition=':= dimension.generator = "HellRandomLevelSource"'>
-                
-                <!-- Starting Original Nether Ore Removal -->
-                <Substitute name='nthrNetherOreSubstitute0' block='minecraft:netherrack'>
-                    <Description>
-                        Replace vanilla-generated ore clusters.
-                    </Description>
-                    <Comment>
-                        The global option deferredPopulationRange must be large enough to catch all ore clusters (>= 32).
-                    </Comment>
-                    <Replaces block='netherrocks:malachite_ore' />
-                    <Replaces block='netherrocks:dragonstone_ore' />
-                    <Replaces block='netherrocks:illumenite_ore' />
-                    <Replaces block='netherrocks:fyrite_ore' />
-                    <Replaces block='netherrocks:ashstone_ore' />
-                    <Replaces block='netherrocks:argonite_ore' />
-                </Substitute>
-                <!-- Original Nether Ore Removal Complete -->
-                
-                <!-- Adding ores --> 
-                
-                <!-- Begin Malachite Generation --> 
-                
-                <!-- Begin Layered Veins distribution of Malachite -->
-                <IfCondition condition=':= nthrMalachiteDist = "layeredVeins"'>
-                
-                    <Veins name='nthrMalachiteBaseVeins' block='netherrocks:malachite_ore'  inherits='PresetLayeredVeins' >
+            <!-- Malachite Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='nthrMalachiteDist'  displayState=':= if(?enableNetherrocks, "shown", "hidden")' displayGroup='groupNetherrocks'>
+                    <Description> Controls how Malachite is generated </Description>
+                    <DisplayName>Netherrocks Malachite</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
                         <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60046652</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 3 * 1 * nthrMalachiteSize * _default_' range=':= 3 * 1 * nthrMalachiteSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 3 * 1 * nthrMalachiteSize * _default_' range=':= 3 * 1 * nthrMalachiteSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * nthrMalachiteFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End Layered Veins distribution of Malachite -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Malachite -->
-                <IfCondition condition=':= nthrMalachiteDist = "hugeVeins"'>
-                
-                    <Veins name='nthrMalachiteBaseVeins' block='netherrocks:malachite_ore'  inherits='PresetHugeVeins' >
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
                         <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
+                            Large irregular clouds filled lightly with ore.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60046652</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 3 * 1 * nthrMalachiteSize * _default_' range=':= 3 * 1 * nthrMalachiteSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 3 * 1 * nthrMalachiteSize * _default_' range=':= 3 * 1 * nthrMalachiteSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * nthrMalachiteFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Malachite -->
-                
-                
-                <!-- Begin  Strategic Cloud distribution of Malachite -->
-                <IfCondition condition=':= nthrMalachiteDist = "strategicCloud"'>
-                
-                    <Cloud name='nthrMalachiteBaseCloud' block='netherrocks:malachite_ore' inherits='PresetStrategicCloud'>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
                         <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
+                            Simulates Vanilla Minecraft.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60046652</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 3 * 1 * nthrMalachiteSize * _default_' range=':= 3 * 1 * nthrMalachiteSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 3 * 1 * nthrMalachiteSize * _default_' range=':= 3 * 1 * nthrMalachiteSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 3 * 1 * 1 * nthrMalachiteSize * _default_' range=':= 3 * 1 * 1 * nthrMalachiteSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 3 * 1 * nthrMalachiteFreq *_default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Malachite Strategic Cloud Hint Veins -->
-                        <Veins name='nthrMalachiteBaseHintVeins' block='netherrocks:malachite_ore' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60046652</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Malachite Strategic Cloud Hint Veins -->
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Malachite is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='nthrMalachiteFreq' default='1'  min='0' max='5' displayState=':= if(?enableNetherrocks, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherrocks'>
+                    <Description> Frequency multiplier for Netherrocks Malachite distributions </Description>
+                    <DisplayName>Netherrocks Malachite Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='nthrMalachiteSize' default='1'  min='0' max='5' displayState=':= if(?enableNetherrocks, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherrocks'>
+                    <Description> Size multiplier for Netherrocks Malachite distributions </Description>
+                    <DisplayName>Netherrocks Malachite Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Malachite Configuration UI Complete -->
 
-                    </Cloud>
-                
-                </IfCondition>
-                <!-- End  Strategic Cloud distribution of Malachite -->
-                
-                
-                <!-- Begin  Vanilla distribution of Malachite -->
-                <IfCondition condition=':= nthrMalachiteDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='nthrMalachiteBaseStandard' block='netherrocks:malachite_ore' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60046652</WireframeColor>
-                        <Setting name='Size' avg=':= 3 * 1 * nthrMalachiteSize * _default_'/>
-                        <Setting name='Height' avg=':= 120' range=':= 120' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 3 * 1 * nthrMalachiteFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </StandardGen>
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Malachite -->
-                
-                <!-- End Malachite Generation --> 
 
-                
-                <!-- Begin Dragonstone Generation --> 
-                
-                <!-- Begin Layered Veins distribution of Dragonstone -->
-                <IfCondition condition=':= nthrDragonstoneDist = "layeredVeins"'>
-                
-                    <Veins name='nthrDragonstoneBaseVeins' block='netherrocks:dragonstone_ore'  inherits='PresetLayeredVeins' >
+            <!-- Ashtone Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='nthrAshtoneDist'  displayState=':= if(?enableNetherrocks, "shown", "hidden")' displayGroup='groupNetherrocks'>
+                    <Description> Controls how Ashtone is generated </Description>
+                    <DisplayName>Netherrocks Ashtone</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
                         <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x602F0E0F</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 3 * 1 * nthrDragonstoneSize * _default_' range=':= 3 * 1 * nthrDragonstoneSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 3 * 1 * nthrDragonstoneSize * _default_' range=':= 3 * 1 * nthrDragonstoneSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * nthrDragonstoneFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End Layered Veins distribution of Dragonstone -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Dragonstone -->
-                <IfCondition condition=':= nthrDragonstoneDist = "hugeVeins"'>
-                
-                    <Veins name='nthrDragonstoneBaseVeins' block='netherrocks:dragonstone_ore'  inherits='PresetHugeVeins' >
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
                         <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
+                            Large irregular clouds filled lightly with ore.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x602F0E0F</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 3 * 1 * nthrDragonstoneSize * _default_' range=':= 3 * 1 * nthrDragonstoneSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 3 * 1 * nthrDragonstoneSize * _default_' range=':= 3 * 1 * nthrDragonstoneSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * nthrDragonstoneFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Dragonstone -->
-                
-                
-                <!-- Begin  Strategic Cloud distribution of Dragonstone -->
-                <IfCondition condition=':= nthrDragonstoneDist = "strategicCloud"'>
-                
-                    <Cloud name='nthrDragonstoneBaseCloud' block='netherrocks:dragonstone_ore' inherits='PresetStrategicCloud'>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
                         <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
+                            Simulates Vanilla Minecraft.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x602F0E0F</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 3 * 1 * nthrDragonstoneSize * _default_' range=':= 3 * 1 * nthrDragonstoneSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 3 * 1 * nthrDragonstoneSize * _default_' range=':= 3 * 1 * nthrDragonstoneSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 3 * 1 * 1 * nthrDragonstoneSize * _default_' range=':= 3 * 1 * 1 * nthrDragonstoneSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 3 * 1 * nthrDragonstoneFreq *_default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Dragonstone Strategic Cloud Hint Veins -->
-                        <Veins name='nthrDragonstoneBaseHintVeins' block='netherrocks:dragonstone_ore' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x602F0E0F</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Dragonstone Strategic Cloud Hint Veins -->
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Ashtone is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='nthrAshtoneFreq' default='1'  min='0' max='5' displayState=':= if(?enableNetherrocks, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherrocks'>
+                    <Description> Frequency multiplier for Netherrocks Ashtone distributions </Description>
+                    <DisplayName>Netherrocks Ashtone Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='nthrAshtoneSize' default='1'  min='0' max='5' displayState=':= if(?enableNetherrocks, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherrocks'>
+                    <Description> Size multiplier for Netherrocks Ashtone distributions </Description>
+                    <DisplayName>Netherrocks Ashtone Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Ashtone Configuration UI Complete -->
 
-                    </Cloud>
-                
-                </IfCondition>
-                <!-- End  Strategic Cloud distribution of Dragonstone -->
-                
-                
-                <!-- Begin  Vanilla distribution of Dragonstone -->
-                <IfCondition condition=':= nthrDragonstoneDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='nthrDragonstoneBaseStandard' block='netherrocks:dragonstone_ore' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x602F0E0F</WireframeColor>
-                        <Setting name='Size' avg=':= 3 * 1 * nthrDragonstoneSize * _default_'/>
-                        <Setting name='Height' avg=':= 120' range=':= 120' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 3 * 1 * nthrDragonstoneFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </StandardGen>
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Dragonstone -->
-                
-                <!-- End Dragonstone Generation --> 
 
-                
-                <!-- Begin Illumenite Generation --> 
-                
-                <!-- Begin Layered Veins distribution of Illumenite -->
-                <IfCondition condition=':= nthrIllumeniteDist = "layeredVeins"'>
-                
-                    <Veins name='nthrIllumeniteBaseVeins' block='netherrocks:illumenite_ore'  inherits='PresetLayeredVeins' >
+            <!-- Illumenite Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='nthrIllumeniteDist'  displayState=':= if(?enableNetherrocks, "shown", "hidden")' displayGroup='groupNetherrocks'>
+                    <Description> Controls how Illumenite is generated </Description>
+                    <DisplayName>Netherrocks Illumenite</DisplayName>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
                         <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
+                            Simulates Vanilla Minecraft.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FCFEB0</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 3 * 1 * nthrIllumeniteSize * _default_' range=':= 3 * 1 * nthrIllumeniteSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 3 * 1 * nthrIllumeniteSize * _default_' range=':= 3 * 1 * nthrIllumeniteSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * nthrIllumeniteFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End Layered Veins distribution of Illumenite -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Illumenite -->
-                <IfCondition condition=':= nthrIllumeniteDist = "hugeVeins"'>
-                
-                    <Veins name='nthrIllumeniteBaseVeins' block='netherrocks:illumenite_ore'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FCFEB0</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 3 * 1 * nthrIllumeniteSize * _default_' range=':= 3 * 1 * nthrIllumeniteSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 3 * 1 * nthrIllumeniteSize * _default_' range=':= 3 * 1 * nthrIllumeniteSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * nthrIllumeniteFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Illumenite -->
-                
-                
-                <!-- Begin  Strategic Cloud distribution of Illumenite -->
-                <IfCondition condition=':= nthrIllumeniteDist = "strategicCloud"'>
-                
-                    <Cloud name='nthrIllumeniteBaseCloud' block='netherrocks:illumenite_ore' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FCFEB0</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 3 * 1 * nthrIllumeniteSize * _default_' range=':= 3 * 1 * nthrIllumeniteSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 3 * 1 * nthrIllumeniteSize * _default_' range=':= 3 * 1 * nthrIllumeniteSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 3 * 1 * 1 * nthrIllumeniteSize * _default_' range=':= 3 * 1 * 1 * nthrIllumeniteSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 3 * 1 * nthrIllumeniteFreq *_default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Illumenite Strategic Cloud Hint Veins -->
-                        <Veins name='nthrIllumeniteBaseHintVeins' block='netherrocks:illumenite_ore' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60FCFEB0</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Illumenite Strategic Cloud Hint Veins -->
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Illumenite is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='nthrIllumeniteFreq' default='1'  min='0' max='5' displayState=':= if(?enableNetherrocks, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherrocks'>
+                    <Description> Frequency multiplier for Netherrocks Illumenite distributions </Description>
+                    <DisplayName>Netherrocks Illumenite Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='nthrIllumeniteSize' default='1'  min='0' max='5' displayState=':= if(?enableNetherrocks, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherrocks'>
+                    <Description> Size multiplier for Netherrocks Illumenite distributions </Description>
+                    <DisplayName>Netherrocks Illumenite Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Illumenite Configuration UI Complete -->
 
-                    </Cloud>
-                
-                </IfCondition>
-                <!-- End  Strategic Cloud distribution of Illumenite -->
-                
-                
-                <!-- Begin  Vanilla distribution of Illumenite -->
-                <IfCondition condition=':= nthrIllumeniteDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='nthrIllumeniteBaseStandard' block='netherrocks:illumenite_ore' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60FCFEB0</WireframeColor>
-                        <Setting name='Size' avg=':= 3 * 1 * nthrIllumeniteSize * _default_'/>
-                        <Setting name='Height' avg=':= 120' range=':= 120' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 3 * 1 * nthrIllumeniteFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </StandardGen>
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Illumenite -->
-                
-                <!-- End Illumenite Generation --> 
 
-                
-                <!-- Begin Fyrite Generation --> 
-                
-                <!-- Begin Layered Veins distribution of Fyrite -->
-                <IfCondition condition=':= nthrFyriteDist = "layeredVeins"'>
-                
-                    <Veins name='nthrFyriteBaseVeins' block='netherrocks:fyrite_ore'  inherits='PresetLayeredVeins' >
+            <!-- Dragonstone Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='nthrDragonstoneDist'  displayState=':= if(?enableNetherrocks, "shown", "hidden")' displayGroup='groupNetherrocks'>
+                    <Description> Controls how Dragonstone is generated </Description>
+                    <DisplayName>Netherrocks Dragonstone</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
                         <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60BF0000</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 3 * 1 * nthrFyriteSize * _default_' range=':= 3 * 1 * nthrFyriteSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 3 * 1 * nthrFyriteSize * _default_' range=':= 3 * 1 * nthrFyriteSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * nthrFyriteFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End Layered Veins distribution of Fyrite -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Fyrite -->
-                <IfCondition condition=':= nthrFyriteDist = "hugeVeins"'>
-                
-                    <Veins name='nthrFyriteBaseVeins' block='netherrocks:fyrite_ore'  inherits='PresetHugeVeins' >
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
                         <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
+                            Large irregular clouds filled lightly with ore.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60BF0000</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 3 * 1 * nthrFyriteSize * _default_' range=':= 3 * 1 * nthrFyriteSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 3 * 1 * nthrFyriteSize * _default_' range=':= 3 * 1 * nthrFyriteSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * nthrFyriteFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Fyrite -->
-                
-                
-                <!-- Begin  Strategic Cloud distribution of Fyrite -->
-                <IfCondition condition=':= nthrFyriteDist = "strategicCloud"'>
-                
-                    <Cloud name='nthrFyriteBaseCloud' block='netherrocks:fyrite_ore' inherits='PresetStrategicCloud'>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
                         <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
+                            Simulates Vanilla Minecraft.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60BF0000</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 3 * 1 * nthrFyriteSize * _default_' range=':= 3 * 1 * nthrFyriteSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 3 * 1 * nthrFyriteSize * _default_' range=':= 3 * 1 * nthrFyriteSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 3 * 1 * 1 * nthrFyriteSize * _default_' range=':= 3 * 1 * 1 * nthrFyriteSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 3 * 1 * nthrFyriteFreq *_default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Fyrite Strategic Cloud Hint Veins -->
-                        <Veins name='nthrFyriteBaseHintVeins' block='netherrocks:fyrite_ore' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x60BF0000</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Fyrite Strategic Cloud Hint Veins -->
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Dragonstone is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='nthrDragonstoneFreq' default='1'  min='0' max='5' displayState=':= if(?enableNetherrocks, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherrocks'>
+                    <Description> Frequency multiplier for Netherrocks Dragonstone distributions </Description>
+                    <DisplayName>Netherrocks Dragonstone Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='nthrDragonstoneSize' default='1'  min='0' max='5' displayState=':= if(?enableNetherrocks, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherrocks'>
+                    <Description> Size multiplier for Netherrocks Dragonstone distributions </Description>
+                    <DisplayName>Netherrocks Dragonstone Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Dragonstone Configuration UI Complete -->
 
-                    </Cloud>
-                
-                </IfCondition>
-                <!-- End  Strategic Cloud distribution of Fyrite -->
-                
-                
-                <!-- Begin  Vanilla distribution of Fyrite -->
-                <IfCondition condition=':= nthrFyriteDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='nthrFyriteBaseStandard' block='netherrocks:fyrite_ore' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60BF0000</WireframeColor>
-                        <Setting name='Size' avg=':= 3 * 1 * nthrFyriteSize * _default_'/>
-                        <Setting name='Height' avg=':= 120' range=':= 120' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 3 * 1 * nthrFyriteFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </StandardGen>
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Fyrite -->
-                
-                <!-- End Fyrite Generation --> 
 
-                
-                <!-- Begin Ashtone Generation --> 
-                
-                <!-- Begin Layered Veins distribution of Ashtone -->
-                <IfCondition condition=':= nthrAshtoneDist = "layeredVeins"'>
-                
-                    <Veins name='nthrAshtoneBaseVeins' block='netherrocks:ashstone_ore'  inherits='PresetLayeredVeins' >
+            <!-- Argonite Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='nthrArgoniteDist'  displayState=':= if(?enableNetherrocks, "shown", "hidden")' displayGroup='groupNetherrocks'>
+                    <Description> Controls how Argonite is generated </Description>
+                    <DisplayName>Netherrocks Argonite</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
                         <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x603F3F60</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 3 * 1 * nthrAshtoneSize * _default_' range=':= 3 * 1 * nthrAshtoneSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 3 * 1 * nthrAshtoneSize * _default_' range=':= 3 * 1 * nthrAshtoneSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * nthrAshtoneFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End Layered Veins distribution of Ashtone -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Ashtone -->
-                <IfCondition condition=':= nthrAshtoneDist = "hugeVeins"'>
-                
-                    <Veins name='nthrAshtoneBaseVeins' block='netherrocks:ashstone_ore'  inherits='PresetHugeVeins' >
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
                         <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
+                            Large irregular clouds filled lightly with ore.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x603F3F60</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 3 * 1 * nthrAshtoneSize * _default_' range=':= 3 * 1 * nthrAshtoneSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 3 * 1 * nthrAshtoneSize * _default_' range=':= 3 * 1 * nthrAshtoneSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * nthrAshtoneFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Ashtone -->
-                
-                
-                <!-- Begin  Strategic Cloud distribution of Ashtone -->
-                <IfCondition condition=':= nthrAshtoneDist = "strategicCloud"'>
-                
-                    <Cloud name='nthrAshtoneBaseCloud' block='netherrocks:ashstone_ore' inherits='PresetStrategicCloud'>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
                         <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
+                            Simulates Vanilla Minecraft.
                         </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x603F3F60</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 3 * 1 * nthrAshtoneSize * _default_' range=':= 3 * 1 * nthrAshtoneSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 3 * 1 * nthrAshtoneSize * _default_' range=':= 3 * 1 * nthrAshtoneSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 3 * 1 * 1 * nthrAshtoneSize * _default_' range=':= 3 * 1 * 1 * nthrAshtoneSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 3 * 1 * nthrAshtoneFreq *_default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Ashtone Strategic Cloud Hint Veins -->
-                        <Veins name='nthrAshtoneBaseHintVeins' block='netherrocks:ashstone_ore' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x603F3F60</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Ashtone Strategic Cloud Hint Veins -->
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Argonite is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='nthrArgoniteFreq' default='1'  min='0' max='5' displayState=':= if(?enableNetherrocks, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherrocks'>
+                    <Description> Frequency multiplier for Netherrocks Argonite distributions </Description>
+                    <DisplayName>Netherrocks Argonite Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='nthrArgoniteSize' default='1'  min='0' max='5' displayState=':= if(?enableNetherrocks, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupNetherrocks'>
+                    <Description> Size multiplier for Netherrocks Argonite distributions </Description>
+                    <DisplayName>Netherrocks Argonite Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Argonite Configuration UI Complete -->
 
-                    </Cloud>
-                
-                </IfCondition>
-                <!-- End  Strategic Cloud distribution of Ashtone -->
-                
-                
-                <!-- Begin  Vanilla distribution of Ashtone -->
-                <IfCondition condition=':= nthrAshtoneDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='nthrAshtoneBaseStandard' block='netherrocks:ashstone_ore' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x603F3F60</WireframeColor>
-                        <Setting name='Size' avg=':= 3 * 1 * nthrAshtoneSize * _default_'/>
-                        <Setting name='Height' avg=':= 120' range=':= 120' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 3 * 1 * nthrAshtoneFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </StandardGen>
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Ashtone -->
-                
-                <!-- End Ashtone Generation --> 
-
-                
-                <!-- Begin Argonite Generation --> 
-                
-                <!-- Begin Layered Veins distribution of Argonite -->
-                <IfCondition condition=':= nthrArgoniteDist = "layeredVeins"'>
-                
-                    <Veins name='nthrArgoniteBaseVeins' block='netherrocks:argonite_ore'  inherits='PresetLayeredVeins' >
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4
-                            horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x600F0035</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 3 * 1 * nthrArgoniteSize * _default_' range=':= 3 * 1 * nthrArgoniteSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 3 * 1 * nthrArgoniteSize * _default_' range=':= 3 * 1 * nthrArgoniteSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * nthrArgoniteFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End Layered Veins distribution of Argonite -->
-                
-                
-                <!-- Begin  Huge Veins distribution of Argonite -->
-                <IfCondition condition=':= nthrArgoniteDist = "hugeVeins"'>
-                
-                    <Veins name='nthrArgoniteBaseVeins' block='netherrocks:argonite_ore'  inherits='PresetHugeVeins' >
-                        <Description>
-                            Very large, extremely rare motherlodes.
-                            Each motherlode has many long slender
-                            branches - so thin that parts of the
-                            branch won't contain any ore at all.
-                            This, combined with the incredible length
-                            of the branches, makes them more
-                            challenging to follow underground.  Once
-                            found, however, a motherlode contains
-                            enough ore to keep a player supplied for a
-                            very long time.  The rarity of these veins
-                            might be too frustrating in a single-
-                            player setting.  In SMP, though, teamwork
-                            could make finding them much easier and
-                            the motherlodes are big enough to supply
-                            several people without shortage.  This
-                            might be a good way to add challenge to
-                            multiplayer worlds.  Credit: based on
-                            feedback by dyrewulf from the MC forums.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x600F0035</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 3 * 1 * nthrArgoniteSize * _default_' range=':= 3 * 1 * nthrArgoniteSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel' /> 
-                        <Setting name='SegmentRadius' avg=':= 3 * 1 * nthrArgoniteSize * _default_' range=':= 3 * 1 * nthrArgoniteSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * nthrArgoniteFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </Veins>
-                
-                </IfCondition>
-                <!-- End  Huge Veins distribution of Argonite -->
-                
-                
-                <!-- Begin  Strategic Cloud distribution of Argonite -->
-                <IfCondition condition=':= nthrArgoniteDist = "strategicCloud"'>
-                
-                    <Cloud name='nthrArgoniteBaseCloud' block='netherrocks:argonite_ore' inherits='PresetStrategicCloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with
-                            ore.  These are huge, spanning several
-                            adjacent chunks, and consequently rather
-                            rare.  They contain a sizeable amount of
-                            ore, but it takes some time and effort to
-                            mine due to low density.  The intent for
-                            strategic clouds is that the player will
-                            need to actively search for one and then
-                            set up a semi-permanent mining base and
-                            spend some time actually mining the ore.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x600F0035</WireframeColor>
-                        <Setting name='CloudRadius' avg=':= 3 * 1 * nthrArgoniteSize * _default_' range=':= 3 * 1 * nthrArgoniteSize * _default_'/>
-                        <Setting name='CloudThickness' avg=':= 3 * 1 * nthrArgoniteSize * _default_' range=':= 3 * 1 * nthrArgoniteSize * _default_'/>
-                        <Setting name='CloudHeight' avg=':= 120' range=':= 120' type='uniform' scaleTo='SeaLevel'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='CloudThickness' avg=':= 3 * 1 * 1 * nthrArgoniteSize * _default_' range=':= 3 * 1 * 1 * nthrArgoniteSize  * _default_'/>
-                        <Setting name='DistributionFrequency' avg=':= 3 * 1 * nthrArgoniteFreq *_default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                        
-                        <!-- Begin Argonite Strategic Cloud Hint Veins -->
-                        <Veins name='nthrArgoniteBaseHintVeins' block='netherrocks:argonite_ore' inherits='PresetHintVeins'>
-                            <Description>
-                                Single blocks, generously scattered
-                                through all heights (density is about
-                                that of vanilla iron ore).  They will
-                                replace dirt and sandstone (but not
-                                grass or sand), so they can be found
-                                nearer to the surface than most ores.
-                                Intened to be used as a child
-                                distribution for large, rare strategic
-                                deposits that would otherwise be very
-                                difficult to find.
-                            </Description>
-                            <DrawWireframe>:=drawWireframes</DrawWireframe>
-                            <WireframeColor>0x600F0035</WireframeColor>
-                            <Replaces block='minecraft:dirt'/>
-                            <Replaces block='minecraft:sandstone'/>
-                            <Replaces block='minecraft:netherrack'/>
-                        </Veins>
-                        <!-- End Argonite Strategic Cloud Hint Veins -->
-
-                    </Cloud>
-                
-                </IfCondition>
-                <!-- End  Strategic Cloud distribution of Argonite -->
-                
-                
-                <!-- Begin  Vanilla distribution of Argonite -->
-                <IfCondition condition=':= nthrArgoniteDist = "vanillaStdGen"'>
-                
-                    <StandardGen name='nthrArgoniteBaseStandard' block='netherrocks:argonite_ore' inherits='PresetStandardGen'>
-                        <Description>
-                            This mimics vanilla ore generation.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x600F0035</WireframeColor>
-                        <Setting name='Size' avg=':= 3 * 1 * nthrArgoniteSize * _default_'/>
-                        <Setting name='Height' avg=':= 120' range=':= 120' type='uniform'/> 
-                        <Setting name='Frequency' avg=':= 3 * 1 * nthrArgoniteFreq * _default_'/>
-                        <Replaces block='minecraft:netherrack'/>
-                    </StandardGen>
-                
-                </IfCondition>
-                <!-- End  Vanilla distribution of Argonite -->
-                
-                <!-- End Argonite Generation --> 
-
-                <!-- Done adding ores -->
-            
-            </IfCondition>
-            <!-- Nether Setup Complete -->
-
-        
         </ConfigSection>
-        <!-- Configuration for Custom Ore Generation Complete! -->
-    
-    </IfModInstalled> 
- 
+        <!-- Setup Screen Complete -->
+
+        <IfCondition condition=':= ?enableNetherrocks'>
 
 
-<!-- This file was made using the Sprocket Configuration Generator. -->
+
+
+            <!-- Overworld Setup Beginning -->
+
+            <IfCondition condition=':= ?COGActive'>
+
+                <!-- Starting Original "Overworld" Block Removal -->
+
+                <IfCondition condition=':= ?blockExists("minecraft:glowstone")'>
+                    <Substitute name='nthrOverworldBlockSubstitute0' block='minecraft:glowstone'>
+                        <Description>
+                            Replace vanilla-generated ore clusters.
+                        </Description>
+                        <Comment>
+                            The global option  deferredPopulationRange
+                            must be large  enough to catch all ore
+                            clusters (>=  32).
+                        </Comment>
+                        <IfCondition condition=':= ?blockExists("netherrocks:illumenite_ore")'> <Replaces block='netherrocks:illumenite_ore' weight='1.0' /> </IfCondition>
+                    </Substitute>
+                </IfCondition>
+
+
+                <IfCondition condition=':= ?blockExists("minecraft:netherrack")'>
+                    <Substitute name='nthrOverworldBlockSubstitute1' block='minecraft:netherrack'>
+                        <Description>
+                            Replace vanilla-generated ore clusters.
+                        </Description>
+                        <Comment>
+                            The global option  deferredPopulationRange
+                            must be large  enough to catch all ore
+                            clusters (>=  32).
+                        </Comment>
+                        <IfCondition condition=':= ?blockExists("netherrocks:argonite_ore")'> <Replaces block='netherrocks:argonite_ore' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("netherrocks:ashstone_ore")'> <Replaces block='netherrocks:ashstone_ore' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("netherrocks:dragonstone_ore")'> <Replaces block='netherrocks:dragonstone_ore' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("netherrocks:fyrite_ore")'> <Replaces block='netherrocks:fyrite_ore' weight='1.0' /> </IfCondition>
+                        <IfCondition condition=':= ?blockExists("netherrocks:malachite_ore")'> <Replaces block='netherrocks:malachite_ore' weight='1.0' /> </IfCondition>
+                    </Substitute>
+                </IfCondition>
+
+                <!-- Original "Overworld" Block Removal Complete -->
+
+                <!-- Adding blocks -->
+
+                <!-- Begin Fyrite Generation -->
+
+                <!-- Starting LayeredVeins Preset for Fyrite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthrFyriteDist = "LayeredVeins"'>
+                        <Veins name='nthrFyriteVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x600F0035' drawBoundBox='false' boundBoxColor='0x60BF0000'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("netherrocks:fyrite_ore")'> <OreBlock block='netherrocks:fyrite_ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.917 * _default_ * nthrFyriteFreq ' range=':= _default_ * nthrFyriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.986 * _default_ * nthrFyriteSize ' range=':= _default_ * nthrFyriteSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.958 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * nthrFyriteSize ' range=':= _default_ * nthrFyriteSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.979 * _default_ * nthrFyriteSize ' range=':= _default_ * nthrFyriteSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Fyrite is complete. -->
+
+
+                <!-- Starting Cloud Preset for Fyrite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthrFyriteDist = "Cloud"'>
+                        <Cloud name='nthrFyriteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x600F0035' drawBoundBox='false' boundBoxColor='0x60BF0000'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("netherrocks:fyrite_ore")'> <OreBlock block='netherrocks:fyrite_ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.353 * _default_ * nthrFyriteSize ' range=':= _default_ * nthrFyriteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.353 * _default_ * nthrFyriteSize ' range=':= _default_ * nthrFyriteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.832  * _default_ * nthrFyriteFreq ' range=':= _default_ * nthrFyriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Veins name='nthrFyriteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x600F0035' drawBoundBox='false' boundBoxColor='0x60BF0000'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("netherrocks:fyrite_ore")'> <OreBlock block='netherrocks:fyrite_ore' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Fyrite is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Fyrite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthrFyriteDist = "Vanilla"'>
+                        <StandardGen name='nthrFyriteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x600F0035' drawBoundBox='false' boundBoxColor='0x60BF0000'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("netherrocks:fyrite_ore")'> <OreBlock block='netherrocks:fyrite_ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 6 * nthrFyriteSize ' range=':= _default_ * nthrFyriteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 10 * nthrFyriteFreq ' range=':= _default_ * nthrFyriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Fyrite is complete. -->
+
+                <!-- End Fyrite Generation -->
+
+
+                <!-- Begin Malachite Generation -->
+
+                <!-- Starting LayeredVeins Preset for Malachite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthrMalachiteDist = "LayeredVeins"'>
+                        <Veins name='nthrMalachiteVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x600F0035' drawBoundBox='false' boundBoxColor='0x60046652'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("netherrocks:malachite_ore")'> <OreBlock block='netherrocks:malachite_ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.991 * _default_ * nthrMalachiteFreq ' range=':= _default_ * nthrMalachiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.998 * _default_ * nthrMalachiteSize ' range=':= _default_ * nthrMalachiteSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.995 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * nthrMalachiteSize ' range=':= _default_ * nthrMalachiteSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.998 * _default_ * nthrMalachiteSize ' range=':= _default_ * nthrMalachiteSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Malachite is complete. -->
+
+
+                <!-- Starting Cloud Preset for Malachite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthrMalachiteDist = "Cloud"'>
+                        <Cloud name='nthrMalachiteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x600F0035' drawBoundBox='false' boundBoxColor='0x60046652'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("netherrocks:malachite_ore")'> <OreBlock block='netherrocks:malachite_ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.407 * _default_ * nthrMalachiteSize ' range=':= _default_ * nthrMalachiteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.407 * _default_ * nthrMalachiteSize ' range=':= _default_ * nthrMalachiteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.979  * _default_ * nthrMalachiteFreq ' range=':= _default_ * nthrMalachiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Veins name='nthrMalachiteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x600F0035' drawBoundBox='false' boundBoxColor='0x60046652'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("netherrocks:malachite_ore")'> <OreBlock block='netherrocks:malachite_ore' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Malachite is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Malachite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthrMalachiteDist = "Vanilla"'>
+                        <StandardGen name='nthrMalachiteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x600F0035' drawBoundBox='false' boundBoxColor='0x60046652'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("netherrocks:malachite_ore")'> <OreBlock block='netherrocks:malachite_ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 7 * nthrMalachiteSize ' range=':= _default_ * nthrMalachiteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 10 * nthrMalachiteFreq ' range=':= _default_ * nthrMalachiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Malachite is complete. -->
+
+                <!-- End Malachite Generation -->
+
+
+                <!-- Begin Ashtone Generation -->
+
+                <!-- Starting LayeredVeins Preset for Ashtone. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthrAshtoneDist = "LayeredVeins"'>
+                        <Veins name='nthrAshtoneVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x600F0035' drawBoundBox='false' boundBoxColor='0x603F3F60'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("netherrocks:ashstone_ore")'> <OreBlock block='netherrocks:ashstone_ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.838 * _default_ * nthrAshtoneFreq ' range=':= _default_ * nthrAshtoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.971 * _default_ * nthrAshtoneSize ' range=':= _default_ * nthrAshtoneSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.915 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * nthrAshtoneSize ' range=':= _default_ * nthrAshtoneSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.957 * _default_ * nthrAshtoneSize ' range=':= _default_ * nthrAshtoneSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Ashtone is complete. -->
+
+
+                <!-- Starting Cloud Preset for Ashtone. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthrAshtoneDist = "Cloud"'>
+                        <Cloud name='nthrAshtoneCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x600F0035' drawBoundBox='false' boundBoxColor='0x603F3F60'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("netherrocks:ashstone_ore")'> <OreBlock block='netherrocks:ashstone_ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.293 * _default_ * nthrAshtoneSize ' range=':= _default_ * nthrAshtoneSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.293 * _default_ * nthrAshtoneSize ' range=':= _default_ * nthrAshtoneSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.672  * _default_ * nthrAshtoneFreq ' range=':= _default_ * nthrAshtoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Veins name='nthrAshtoneHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x600F0035' drawBoundBox='false' boundBoxColor='0x603F3F60'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("netherrocks:ashstone_ore")'> <OreBlock block='netherrocks:ashstone_ore' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Ashtone is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Ashtone. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthrAshtoneDist = "Vanilla"'>
+                        <StandardGen name='nthrAshtoneStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x600F0035' drawBoundBox='false' boundBoxColor='0x603F3F60'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("netherrocks:ashstone_ore")'> <OreBlock block='netherrocks:ashstone_ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 5 * nthrAshtoneSize ' range=':= _default_ * nthrAshtoneSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 10 * nthrAshtoneFreq ' range=':= _default_ * nthrAshtoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Ashtone is complete. -->
+
+                <!-- End Ashtone Generation -->
+
+
+                <!-- Begin Illumenite Generation -->
+
+                <!-- Starting Vanilla Preset for Illumenite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthrIllumeniteDist = "Vanilla"'>
+                        <StandardGen name='nthrIllumeniteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x600F0035' drawBoundBox='false' boundBoxColor='0x60FCFEB0'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("netherrocks:illumenite_ore")'> <OreBlock block='netherrocks:illumenite_ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:glowstone")'> <Replaces block='minecraft:glowstone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 15 * nthrIllumeniteSize ' range=':= _default_ * nthrIllumeniteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 350 * nthrIllumeniteFreq ' range=':= _default_ * nthrIllumeniteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Illumenite is complete. -->
+
+                <!-- End Illumenite Generation -->
+
+
+                <!-- Begin Dragonstone Generation -->
+
+                <!-- Starting LayeredVeins Preset for Dragonstone. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthrDragonstoneDist = "LayeredVeins"'>
+                        <Veins name='nthrDragonstoneVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x600F0035' drawBoundBox='false' boundBoxColor='0x602F0E0F'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("netherrocks:dragonstone_ore")'> <OreBlock block='netherrocks:dragonstone_ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.649 * _default_ * nthrDragonstoneFreq ' range=':= _default_ * nthrDragonstoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.930 * _default_ * nthrDragonstoneSize ' range=':= _default_ * nthrDragonstoneSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.805 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * nthrDragonstoneSize ' range=':= _default_ * nthrDragonstoneSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.897 * _default_ * nthrDragonstoneSize ' range=':= _default_ * nthrDragonstoneSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Dragonstone is complete. -->
+
+
+                <!-- Starting Cloud Preset for Dragonstone. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthrDragonstoneDist = "Cloud"'>
+                        <Cloud name='nthrDragonstoneCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x600F0035' drawBoundBox='false' boundBoxColor='0x602F0E0F'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("netherrocks:dragonstone_ore")'> <OreBlock block='netherrocks:dragonstone_ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.138 * _default_ * nthrDragonstoneSize ' range=':= _default_ * nthrDragonstoneSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.138 * _default_ * nthrDragonstoneSize ' range=':= _default_ * nthrDragonstoneSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.295  * _default_ * nthrDragonstoneFreq ' range=':= _default_ * nthrDragonstoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Veins name='nthrDragonstoneHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x600F0035' drawBoundBox='false' boundBoxColor='0x602F0E0F'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("netherrocks:dragonstone_ore")'> <OreBlock block='netherrocks:dragonstone_ore' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Dragonstone is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Dragonstone. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthrDragonstoneDist = "Vanilla"'>
+                        <StandardGen name='nthrDragonstoneStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x600F0035' drawBoundBox='false' boundBoxColor='0x602F0E0F'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("netherrocks:dragonstone_ore")'> <OreBlock block='netherrocks:dragonstone_ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 5 * nthrDragonstoneSize ' range=':= _default_ * nthrDragonstoneSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 6 * nthrDragonstoneFreq ' range=':= _default_ * nthrDragonstoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Dragonstone is complete. -->
+
+                <!-- End Dragonstone Generation -->
+
+
+                <!-- Begin Argonite Generation -->
+
+                <!-- Starting LayeredVeins Preset for Argonite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthrArgoniteDist = "LayeredVeins"'>
+                        <Veins name='nthrArgoniteVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x600F0035' drawBoundBox='false' boundBoxColor='0x600F0035'>
+                            <Description>
+                                Small, fairly rare motherlodes  with
+                                2-4 horizontal veins each.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("netherrocks:argonite_ore")'> <OreBlock block='netherrocks:argonite_ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.917 * _default_ * nthrArgoniteFreq ' range=':= _default_ * nthrArgoniteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.986 * _default_ * nthrArgoniteSize ' range=':= _default_ * nthrArgoniteSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.958 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * nthrArgoniteSize ' range=':= _default_ * nthrArgoniteSize ' type='normal' />
+                            <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.979 * _default_ * nthrArgoniteSize ' range=':= _default_ * nthrArgoniteSize ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                        </Veins>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- LayeredVeins Preset for Argonite is complete. -->
+
+
+                <!-- Starting Cloud Preset for Argonite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthrArgoniteDist = "Cloud"'>
+                        <Cloud name='nthrArgoniteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x600F0035' drawBoundBox='false' boundBoxColor='0x600F0035'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("netherrocks:argonite_ore")'> <OreBlock block='netherrocks:argonite_ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 1.353 * _default_ * nthrArgoniteSize ' range=':= _default_ * nthrArgoniteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.353 * _default_ * nthrArgoniteSize ' range=':= _default_ * nthrArgoniteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.832  * _default_ * nthrArgoniteFreq ' range=':= _default_ * nthrArgoniteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Veins name='nthrArgoniteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x600F0035' drawBoundBox='false' boundBoxColor='0x600F0035'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <IfCondition condition=':= ?blockExists("netherrocks:argonite_ore")'> <OreBlock block='netherrocks:argonite_ore' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            </Veins>
+                        </Cloud>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Cloud Preset for Argonite is complete. -->
+
+
+                <!-- Starting Vanilla Preset for Argonite. -->
+                <ConfigSection>
+                    <IfCondition condition=':= nthrArgoniteDist = "Vanilla"'>
+                        <StandardGen name='nthrArgoniteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x600F0035' drawBoundBox='false' boundBoxColor='0x600F0035'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("netherrocks:argonite_ore")'> <OreBlock block='netherrocks:argonite_ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 6 * nthrArgoniteSize ' range=':= _default_ * nthrArgoniteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 10 * nthrArgoniteFreq ' range=':= _default_ * nthrArgoniteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Argonite is complete. -->
+
+                <!-- End Argonite Generation -->
+
+                <!-- Finished adding blocks -->
+
+            </IfCondition>
+            <!-- Overworld Setup Complete -->
+
+
+
+        </IfCondition>
+
+    </ConfigSection>
+    <!-- Configuration for Custom Ore Generation Complete! -->
+
+</IfModInstalled>
+<!-- The "Netherrocks" mod is now configured. -->
+
+
+
+
+
+<!-- =================================================================
+     This file was made using the Sprocket Configuration Generator.
+     If you wish to make your own configurations for a mod not
+     currently supported by Custom Ore Generation, and you don't want
+     the hassle of writing XML, you can find the generator script at
+     its GitHub page: http://https://github.com/reteo/Sprocket
+     ================================================================= -->

--- a/src/main/resources/config/modules/PamsHarvestCraft.xml
+++ b/src/main/resources/config/modules/PamsHarvestCraft.xml
@@ -117,18 +117,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 4.287 * _default_ * hvstSaltFreq ' range=':= _default_ * hvstSaltFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.625 * _default_ * hvstSaltSize ' range=':= _default_ * hvstSaltSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * _default_ * hvstSaltSize ' range=':= _default_ * hvstSaltSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.625 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 2.071 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * hvstSaltSize ' range=':= _default_ * hvstSaltSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.625 * _default_ * hvstSaltSize ' range=':= _default_ * hvstSaltSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.439 * _default_ * hvstSaltSize ' range=':= _default_ * hvstSaltSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>

--- a/src/main/resources/config/modules/ProjectRed.xml
+++ b/src/main/resources/config/modules/ProjectRed.xml
@@ -356,18 +356,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * predRubyFreq ' range=':= _default_ * predRubyFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * predRubySize ' range=':= _default_ * predRubySize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * predRubySize ' range=':= _default_ * predRubySize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 16 ' range=':= 4 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.371 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * predRubySize ' range=':= _default_ * predRubySize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * predRubySize ' range=':= _default_ * predRubySize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.609 * _default_ * predRubySize ' range=':= _default_ * predRubySize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -377,8 +377,8 @@
                             <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore")'> <Replaces block='ProjRed|Exploration:projectred.exploration.ore' weight='1.0' /> </IfCondition>
-                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * predRubySize  * 0.5 ' range=':= _default_ * predRubySize  * 0.5 ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * predRubySize  * 0.5 ' range=':= _default_ * predRubySize  * 0.5 ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * predRubySize  * 0.5 ' range=':= _default_ * predRubySize  * 0.5 ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.609 * _default_ * predRubySize  * 0.5 ' range=':= _default_ * predRubySize  * 0.5 ' type='normal' />
                             <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
                         </Veins>
                     </IfCondition>
@@ -485,18 +485,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * predSapphireFreq ' range=':= _default_ * predSapphireFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * predSapphireSize ' range=':= _default_ * predSapphireSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * predSapphireSize ' range=':= _default_ * predSapphireSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 16 ' range=':= 4 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.371 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * predSapphireSize ' range=':= _default_ * predSapphireSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * predSapphireSize ' range=':= _default_ * predSapphireSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.609 * _default_ * predSapphireSize ' range=':= _default_ * predSapphireSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -506,8 +506,8 @@
                             <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:1")'> <Replaces block='ProjRed|Exploration:projectred.exploration.ore:1' weight='1.0' /> </IfCondition>
-                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * predSapphireSize  * 0.5 ' range=':= _default_ * predSapphireSize  * 0.5 ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * predSapphireSize  * 0.5 ' range=':= _default_ * predSapphireSize  * 0.5 ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * predSapphireSize  * 0.5 ' range=':= _default_ * predSapphireSize  * 0.5 ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.609 * _default_ * predSapphireSize  * 0.5 ' range=':= _default_ * predSapphireSize  * 0.5 ' type='normal' />
                             <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
                         </Veins>
                     </IfCondition>
@@ -614,18 +614,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * predPeridotFreq ' range=':= _default_ * predPeridotFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * predPeridotSize ' range=':= _default_ * predPeridotSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * predPeridotSize ' range=':= _default_ * predPeridotSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 22 ' range=':= 6 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.371 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * predPeridotSize ' range=':= _default_ * predPeridotSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * predPeridotSize ' range=':= _default_ * predPeridotSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.609 * _default_ * predPeridotSize ' range=':= _default_ * predPeridotSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -635,8 +635,8 @@
                             <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:2")'> <Replaces block='ProjRed|Exploration:projectred.exploration.ore:2' weight='1.0' /> </IfCondition>
-                            <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * predPeridotSize  * 0.5 ' range=':= _default_ * predPeridotSize  * 0.5 ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * predPeridotSize  * 0.5 ' range=':= _default_ * predPeridotSize  * 0.5 ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * predPeridotSize  * 0.5 ' range=':= _default_ * predPeridotSize  * 0.5 ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.609 * _default_ * predPeridotSize  * 0.5 ' range=':= _default_ * predPeridotSize  * 0.5 ' type='normal' />
                             <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
                         </Veins>
                     </IfCondition>
@@ -743,18 +743,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.948 * _default_ * predCopperFreq ' range=':= _default_ * predCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.982 * _default_ * predCopperSize ' range=':= _default_ * predCopperSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.991 * _default_ * predCopperSize ' range=':= _default_ * predCopperSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 35 ' range=':= 29 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.982 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.973 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * predCopperSize ' range=':= _default_ * predCopperSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.982 * _default_ * predCopperSize ' range=':= _default_ * predCopperSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.987 * _default_ * predCopperSize ' range=':= _default_ * predCopperSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -862,18 +862,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.749 * _default_ * predTinFreq ' range=':= _default_ * predTinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.908 * _default_ * predTinSize ' range=':= _default_ * predTinSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.953 * _default_ * predTinSize ' range=':= _default_ * predTinSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 27 ' range=':= 21 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.908 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.866 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * predTinSize ' range=':= _default_ * predTinSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.908 * _default_ * predTinSize ' range=':= _default_ * predTinSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.930 * _default_ * predTinSize ' range=':= _default_ * predTinSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -981,18 +981,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.237 * _default_ * predSilverFreq ' range=':= _default_ * predSilverFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.619 * _default_ * predSilverSize ' range=':= _default_ * predSilverSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.787 * _default_ * predSilverSize ' range=':= _default_ * predSilverSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.619 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.487 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * predSilverSize ' range=':= _default_ * predSilverSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.619 * _default_ * predSilverSize ' range=':= _default_ * predSilverSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.698 * _default_ * predSilverSize ' range=':= _default_ * predSilverSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1100,18 +1100,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.878 * _default_ * predElectrotineFreq ' range=':= _default_ * predElectrotineFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.958 * _default_ * predElectrotineSize ' range=':= _default_ * predElectrotineSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * predElectrotineSize ' range=':= _default_ * predElectrotineSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 11 ' range=':= 5 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= -_default_ ' range=':= -_default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.958 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.937 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * predElectrotineSize ' range=':= _default_ * predElectrotineSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.958 * _default_ * predElectrotineSize ' range=':= _default_ * predElectrotineSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.968 * _default_ * predElectrotineSize ' range=':= _default_ * predElectrotineSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1219,18 +1219,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.474 * _default_ * predMarbleFreq ' range=':= _default_ * predMarbleFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.780 * _default_ * predMarbleSize ' range=':= _default_ * predMarbleSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.883 * _default_ * predMarbleSize ' range=':= _default_ * predMarbleSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 48 ' range=':= 16 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.780 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.688 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * predMarbleSize ' range=':= _default_ * predMarbleSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.780 * _default_ * predMarbleSize ' range=':= _default_ * predMarbleSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.830 * _default_ * predMarbleSize ' range=':= _default_ * predMarbleSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>

--- a/src/main/resources/config/modules/RailCraft.xml
+++ b/src/main/resources/config/modules/RailCraft.xml
@@ -492,18 +492,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 7.921 * _default_ * rlcrPoorIronFreq ' range=':= _default_ * rlcrPoorIronFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.993 * _default_ * rlcrPoorIronSize ' range=':= _default_ * rlcrPoorIronSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * rlcrPoorIronSize ' range=':= _default_ * rlcrPoorIronSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 40 ' range=':= 4 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.993 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 2.814 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * rlcrPoorIronSize ' range=':= _default_ * rlcrPoorIronSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.993 * _default_ * rlcrPoorIronSize ' range=':= _default_ * rlcrPoorIronSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.678 * _default_ * rlcrPoorIronSize ' range=':= _default_ * rlcrPoorIronSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -618,18 +618,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.980 * _default_ * rlcrPoorGoldFreq ' range=':= _default_ * rlcrPoorGoldFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.256 * _default_ * rlcrPoorGoldSize ' range=':= _default_ * rlcrPoorGoldSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * _default_ * rlcrPoorGoldSize ' range=':= _default_ * rlcrPoorGoldSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 15 ' range=':= 1 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.256 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.407 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * rlcrPoorGoldSize ' range=':= _default_ * rlcrPoorGoldSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.256 * _default_ * rlcrPoorGoldSize ' range=':= _default_ * rlcrPoorGoldSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.186 * _default_ * rlcrPoorGoldSize ' range=':= _default_ * rlcrPoorGoldSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -744,18 +744,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 5.601 * _default_ * rlcrPoorCopperFreq ' range=':= _default_ * rlcrPoorCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.776 * _default_ * rlcrPoorCopperSize ' range=':= _default_ * rlcrPoorCopperSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * _default_ * rlcrPoorCopperSize ' range=':= _default_ * rlcrPoorCopperSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 60 ' range=':= 3 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.776 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 2.367 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * rlcrPoorCopperSize ' range=':= _default_ * rlcrPoorCopperSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.776 * _default_ * rlcrPoorCopperSize ' range=':= _default_ * rlcrPoorCopperSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.538 * _default_ * rlcrPoorCopperSize ' range=':= _default_ * rlcrPoorCopperSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -870,18 +870,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.801 * _default_ * rlcrPoorTinFreq ' range=':= _default_ * rlcrPoorTinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.410 * _default_ * rlcrPoorTinSize ' range=':= _default_ * rlcrPoorTinSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * _default_ * rlcrPoorTinSize ' range=':= _default_ * rlcrPoorTinSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 50 ' range=':= 2 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.410 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.673 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * rlcrPoorTinSize ' range=':= _default_ * rlcrPoorTinSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.410 * _default_ * rlcrPoorTinSize ' range=':= _default_ * rlcrPoorTinSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.294 * _default_ * rlcrPoorTinSize ' range=':= _default_ * rlcrPoorTinSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -996,18 +996,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 4.851 * _default_ * rlcrPoorLeadFreq ' range=':= _default_ * rlcrPoorLeadFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.693 * _default_ * rlcrPoorLeadSize ' range=':= _default_ * rlcrPoorLeadSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * _default_ * rlcrPoorLeadSize ' range=':= _default_ * rlcrPoorLeadSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 30 ' range=':= 3 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.693 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 2.202 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * rlcrPoorLeadSize ' range=':= _default_ * rlcrPoorLeadSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.693 * _default_ * rlcrPoorLeadSize ' range=':= _default_ * rlcrPoorLeadSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.484 * _default_ * rlcrPoorLeadSize ' range=':= _default_ * rlcrPoorLeadSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1123,18 +1123,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
                             <BiomeType name='Desert'  minRainfall='0' maxRainfall='0.1' minTemperature='1.5' maxTemperature='2.0' />
                             <Setting name='MotherlodeFrequency' avg=':= 2.801 * _default_ * rlcrSaltpeterFreq ' range=':= _default_ * rlcrSaltpeterFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.410 * _default_ * rlcrSaltpeterSize ' range=':= _default_ * rlcrSaltpeterSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * _default_ * rlcrSaltpeterSize ' range=':= _default_ * rlcrSaltpeterSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 75 ' range=':= 25 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.410 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= 0 ' range=':= 0 ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.673 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * rlcrSaltpeterSize ' range=':= _default_ * rlcrSaltpeterSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.410 * _default_ * rlcrSaltpeterSize ' range=':= _default_ * rlcrSaltpeterSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.294 * _default_ * rlcrSaltpeterSize ' range=':= _default_ * rlcrSaltpeterSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1244,18 +1244,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.872 * _default_ * rlcrSulfurFreq ' range=':= _default_ * rlcrSulfurFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.956 * _default_ * rlcrSulfurSize ' range=':= _default_ * rlcrSulfurSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * _default_ * rlcrSulfurSize ' range=':= _default_ * rlcrSulfurSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 11 ' range=':= 5 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.956 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.934 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * rlcrSulfurSize ' range=':= _default_ * rlcrSulfurSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.956 * _default_ * rlcrSulfurSize ' range=':= _default_ * rlcrSulfurSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.966 * _default_ * rlcrSulfurSize ' range=':= _default_ * rlcrSulfurSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1265,8 +1265,8 @@
                             <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("Railcraft:ore")'> <Replaces block='Railcraft:ore' weight='1.0' /> </IfCondition>
-                            <Setting name='MotherlodeSize' avg=':= 0.956 * _default_ * rlcrSulfurSize  * 0.5 ' range=':= _default_ * rlcrSulfurSize  * 0.5 ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.956 * _default_ * rlcrSulfurSize  * 0.5 ' range=':= _default_ * rlcrSulfurSize  * 0.5 ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * _default_ * rlcrSulfurSize  * 0.5 ' range=':= _default_ * rlcrSulfurSize  * 0.5 ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.966 * _default_ * rlcrSulfurSize  * 0.5 ' range=':= _default_ * rlcrSulfurSize  * 0.5 ' type='normal' />
                             <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
                         </Veins>
                     </IfCondition>
@@ -1407,18 +1407,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.191 * _default_ * rlcrFirestoneFreq ' range=':= _default_ * rlcrFirestoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.576 * _default_ * rlcrFirestoneSize ' range=':= _default_ * rlcrFirestoneSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.191 * _default_ * rlcrFirestoneSize ' range=':= _default_ * rlcrFirestoneSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 16 ' range=':= 15 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.576 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * rlcrFirestoneSize ' range=':= _default_ * rlcrFirestoneSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.576 * _default_ * rlcrFirestoneSize ' range=':= _default_ * rlcrFirestoneSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= _default_ * rlcrFirestoneSize ' range=':= _default_ * rlcrFirestoneSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>

--- a/src/main/resources/config/modules/ReactorCraft.xml
+++ b/src/main/resources/config/modules/ReactorCraft.xml
@@ -681,18 +681,18 @@
                             <BiomeType name='Ocean'  />
                             <BiomeType name='River'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.425 * _default_ * recrPitchblendeFreq ' range=':= 1 * _default_ * recrPitchblendeFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.344 * _default_ * recrPitchblendeSize ' range=':= 1 * _default_ * recrPitchblendeSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * recrPitchblendeSize ' range=':= 1 * _default_ * recrPitchblendeSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 16 ' range=':= 8 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.344 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.557 * _default_ ' range=':= 1 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * recrPitchblendeSize ' range=':= _default_ * recrPitchblendeSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.344 * _default_ * recrPitchblendeSize ' range=':= 1 * _default_ * recrPitchblendeSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.248 * _default_ * recrPitchblendeSize ' range=':= 1 * _default_ * recrPitchblendeSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -804,18 +804,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.615 * _default_ * recrCadmiumFreq ' range=':= 1 * _default_ * recrCadmiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.851 * _default_ * recrCadmiumSize ' range=':= 1 * _default_ * recrCadmiumSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * recrCadmiumSize ' range=':= 1 * _default_ * recrCadmiumSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 22 ' range=':= 10 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.851 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.785 * _default_ ' range=':= 1 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * recrCadmiumSize ' range=':= _default_ * recrCadmiumSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.851 * _default_ * recrCadmiumSize ' range=':= 1 * _default_ * recrCadmiumSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.886 * _default_ * recrCadmiumSize ' range=':= 1 * _default_ * recrCadmiumSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -923,18 +923,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.443 * _default_ * recrIndiumFreq ' range=':= 1 * _default_ * recrIndiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.762 * _default_ * recrIndiumSize ' range=':= 1 * _default_ * recrIndiumSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.873 * _default_ * recrIndiumSize ' range=':= 1 * _default_ * recrIndiumSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 11 ' range=':= 16 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.762 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.666 * _default_ ' range=':= 1 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * recrIndiumSize ' range=':= _default_ * recrIndiumSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.762 * _default_ * recrIndiumSize ' range=':= 1 * _default_ * recrIndiumSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.709 * _default_ * recrIndiumSize ' range=':= 1 * _default_ * recrIndiumSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1042,18 +1042,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.503 * _default_ * recrSilverFreq ' range=':= 1 * _default_ * recrSilverFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.795 * _default_ * recrSilverSize ' range=':= 1 * _default_ * recrSilverSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.892 * _default_ * recrSilverSize ' range=':= 1 * _default_ * recrSilverSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 28 ' range=':= 12 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.795 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.709 * _default_ ' range=':= 1 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * recrSilverSize ' range=':= _default_ * recrSilverSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.795 * _default_ * recrSilverSize ' range=':= 1 * _default_ * recrSilverSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.842 * _default_ * recrSilverSize ' range=':= 1 * _default_ * recrSilverSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1168,18 +1168,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.425 * _default_ * recrCalciteFreq ' range=':= 1 * _default_ * recrCalciteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.344 * _default_ * recrCalciteSize ' range=':= 1 * _default_ * recrCalciteSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * recrCalciteSize ' range=':= 1 * _default_ * recrCalciteSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.344 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.557 * _default_ ' range=':= 1 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * recrCalciteSize ' range=':= _default_ * recrCalciteSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.344 * _default_ * recrCalciteSize ' range=':= 1 * _default_ * recrCalciteSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.248 * _default_ * recrCalciteSize ' range=':= 1 * _default_ * recrCalciteSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1294,18 +1294,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 3.705 * _default_ * recrMagnetiteFreq ' range=':= 1 * _default_ * recrMagnetiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.547 * _default_ * recrMagnetiteSize ' range=':= 1 * _default_ * recrMagnetiteSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * recrMagnetiteSize ' range=':= 1 * _default_ * recrMagnetiteSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 94 ' range=':= 34 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.547 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.925 * _default_ ' range=':= 1 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * recrMagnetiteSize ' range=':= _default_ * recrMagnetiteSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.547 * _default_ * recrMagnetiteSize ' range=':= 1 * _default_ * recrMagnetiteSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.387 * _default_ * recrMagnetiteSize ' range=':= 1 * _default_ * recrMagnetiteSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1413,18 +1413,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.410 * _default_ * recrBlueFluoriteFreq ' range=':= 1 * _default_ * recrBlueFluoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.743 * _default_ * recrBlueFluoriteSize ' range=':= 1 * _default_ * recrBlueFluoriteSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.862 * _default_ * recrBlueFluoriteSize ' range=':= 1 * _default_ * recrBlueFluoriteSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.743 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.641 * _default_ ' range=':= 1 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * recrBlueFluoriteSize ' range=':= _default_ * recrBlueFluoriteSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.743 * _default_ * recrBlueFluoriteSize ' range=':= 1 * _default_ * recrBlueFluoriteSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.800 * _default_ * recrBlueFluoriteSize ' range=':= 1 * _default_ * recrBlueFluoriteSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1533,18 +1533,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.410 * _default_ * recrPinkFluoriteFreq ' range=':= 1 * _default_ * recrPinkFluoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.743 * _default_ * recrPinkFluoriteSize ' range=':= 1 * _default_ * recrPinkFluoriteSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.862 * _default_ * recrPinkFluoriteSize ' range=':= 1 * _default_ * recrPinkFluoriteSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.743 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.641 * _default_ ' range=':= 1 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * recrPinkFluoriteSize ' range=':= _default_ * recrPinkFluoriteSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.743 * _default_ * recrPinkFluoriteSize ' range=':= 1 * _default_ * recrPinkFluoriteSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.800 * _default_ * recrPinkFluoriteSize ' range=':= 1 * _default_ * recrPinkFluoriteSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1653,18 +1653,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.410 * _default_ * recrOrangeFluoriteFreq ' range=':= 1 * _default_ * recrOrangeFluoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.743 * _default_ * recrOrangeFluoriteSize ' range=':= 1 * _default_ * recrOrangeFluoriteSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.862 * _default_ * recrOrangeFluoriteSize ' range=':= 1 * _default_ * recrOrangeFluoriteSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.743 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.641 * _default_ ' range=':= 1 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * recrOrangeFluoriteSize ' range=':= _default_ * recrOrangeFluoriteSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.743 * _default_ * recrOrangeFluoriteSize ' range=':= 1 * _default_ * recrOrangeFluoriteSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.800 * _default_ * recrOrangeFluoriteSize ' range=':= 1 * _default_ * recrOrangeFluoriteSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1774,18 +1774,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.410 * _default_ * recrMagentaFluoriteFreq ' range=':= 1 * _default_ * recrMagentaFluoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.743 * _default_ * recrMagentaFluoriteSize ' range=':= 1 * _default_ * recrMagentaFluoriteSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.862 * _default_ * recrMagentaFluoriteSize ' range=':= 1 * _default_ * recrMagentaFluoriteSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.743 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.641 * _default_ ' range=':= 1 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * recrMagentaFluoriteSize ' range=':= _default_ * recrMagentaFluoriteSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.743 * _default_ * recrMagentaFluoriteSize ' range=':= 1 * _default_ * recrMagentaFluoriteSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.800 * _default_ * recrMagentaFluoriteSize ' range=':= 1 * _default_ * recrMagentaFluoriteSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1894,18 +1894,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.410 * _default_ * recrGreenFluoriteFreq ' range=':= 1 * _default_ * recrGreenFluoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.743 * _default_ * recrGreenFluoriteSize ' range=':= 1 * _default_ * recrGreenFluoriteSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.862 * _default_ * recrGreenFluoriteSize ' range=':= 1 * _default_ * recrGreenFluoriteSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.743 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.641 * _default_ ' range=':= 1 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * recrGreenFluoriteSize ' range=':= _default_ * recrGreenFluoriteSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.743 * _default_ * recrGreenFluoriteSize ' range=':= 1 * _default_ * recrGreenFluoriteSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.800 * _default_ * recrGreenFluoriteSize ' range=':= 1 * _default_ * recrGreenFluoriteSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -2014,18 +2014,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.410 * _default_ * recrRedFluoriteFreq ' range=':= 1 * _default_ * recrRedFluoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.743 * _default_ * recrRedFluoriteSize ' range=':= 1 * _default_ * recrRedFluoriteSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.862 * _default_ * recrRedFluoriteSize ' range=':= 1 * _default_ * recrRedFluoriteSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.743 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.641 * _default_ ' range=':= 1 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * recrRedFluoriteSize ' range=':= _default_ * recrRedFluoriteSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.743 * _default_ * recrRedFluoriteSize ' range=':= 1 * _default_ * recrRedFluoriteSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.800 * _default_ * recrRedFluoriteSize ' range=':= 1 * _default_ * recrRedFluoriteSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -2133,18 +2133,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.410 * _default_ * recrWhiteFluoriteFreq ' range=':= 1 * _default_ * recrWhiteFluoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.743 * _default_ * recrWhiteFluoriteSize ' range=':= 1 * _default_ * recrWhiteFluoriteSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.862 * _default_ * recrWhiteFluoriteSize ' range=':= 1 * _default_ * recrWhiteFluoriteSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.743 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.641 * _default_ ' range=':= 1 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * recrWhiteFluoriteSize ' range=':= _default_ * recrWhiteFluoriteSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.743 * _default_ * recrWhiteFluoriteSize ' range=':= 1 * _default_ * recrWhiteFluoriteSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.800 * _default_ * recrWhiteFluoriteSize ' range=':= 1 * _default_ * recrWhiteFluoriteSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -2253,18 +2253,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.410 * _default_ * recrYellowFluoriteFreq ' range=':= 1 * _default_ * recrYellowFluoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.743 * _default_ * recrYellowFluoriteSize ' range=':= 1 * _default_ * recrYellowFluoriteSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.862 * _default_ * recrYellowFluoriteSize ' range=':= 1 * _default_ * recrYellowFluoriteSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.743 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.641 * _default_ ' range=':= 1 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * recrYellowFluoriteSize ' range=':= _default_ * recrYellowFluoriteSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.743 * _default_ * recrYellowFluoriteSize ' range=':= 1 * _default_ * recrYellowFluoriteSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.800 * _default_ * recrYellowFluoriteSize ' range=':= 1 * _default_ * recrYellowFluoriteSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -2414,18 +2414,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.425 * _default_ * recrAmmoniumChlorideFreq ' range=':= 1 * _default_ * recrAmmoniumChlorideFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.344 * _default_ * recrAmmoniumChlorideSize ' range=':= 1 * _default_ * recrAmmoniumChlorideSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * recrAmmoniumChlorideSize ' range=':= 1 * _default_ * recrAmmoniumChlorideSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 32 ' range=':= 0 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.344 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.557 * _default_ ' range=':= 1 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * recrAmmoniumChlorideSize ' range=':= _default_ * recrAmmoniumChlorideSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.344 * _default_ * recrAmmoniumChlorideSize ' range=':= 1 * _default_ * recrAmmoniumChlorideSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.248 * _default_ * recrAmmoniumChlorideSize ' range=':= 1 * _default_ * recrAmmoniumChlorideSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -2534,18 +2534,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.715 * _default_ * recrThoriteFreq ' range=':= 1 * _default_ * recrThoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.197 * _default_ * recrThoriteSize ' range=':= 1 * _default_ * recrThoriteSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * recrThoriteSize ' range=':= 1 * _default_ * recrThoriteSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 18.5 ' range=':= 13.5 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.197 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.310 * _default_ ' range=':= 1 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * recrThoriteSize ' range=':= _default_ * recrThoriteSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.197 * _default_ * recrThoriteSize ' range=':= 1 * _default_ * recrThoriteSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.144 * _default_ * recrThoriteSize ' range=':= 1 * _default_ * recrThoriteSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -2692,18 +2692,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 3.430 * _default_ * recrEndPitchblendeFreq ' range=':= 1 * _default_ * recrEndPitchblendeFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.508 * _default_ * recrEndPitchblendeSize ' range=':= 1 * _default_ * recrEndPitchblendeSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * recrEndPitchblendeSize ' range=':= 1 * _default_ * recrEndPitchblendeSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 34.5 ' range=':= 29.5 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.508 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.852 * _default_ ' range=':= 1 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * recrEndPitchblendeSize ' range=':= _default_ * recrEndPitchblendeSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.508 * _default_ * recrEndPitchblendeSize ' range=':= 1 * _default_ * recrEndPitchblendeSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.361 * _default_ * recrEndPitchblendeSize ' range=':= 1 * _default_ * recrEndPitchblendeSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>

--- a/src/main/resources/config/modules/SimpleOres.xml
+++ b/src/main/resources/config/modules/SimpleOres.xml
@@ -251,18 +251,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.854 * _default_ * smpoCopperFreq ' range=':= _default_ * smpoCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.228 * _default_ * smpoCopperSize ' range=':= _default_ * smpoCopperSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 1.108 * _default_ * smpoCopperSize ' range=':= _default_ * smpoCopperSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 48 ' range=':= 42 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.228 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.362 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * smpoCopperSize ' range=':= _default_ * smpoCopperSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.228 * _default_ * smpoCopperSize ' range=':= _default_ * smpoCopperSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.167 * _default_ * smpoCopperSize ' range=':= _default_ * smpoCopperSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -370,18 +370,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.716 * _default_ * smpoTinFreq ' range=':= _default_ * smpoTinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.197 * _default_ * smpoTinSize ' range=':= _default_ * smpoTinSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 1.094 * _default_ * smpoTinSize ' range=':= _default_ * smpoTinSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 48 ' range=':= 42 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.197 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.310 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * smpoTinSize ' range=':= _default_ * smpoTinSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.197 * _default_ * smpoTinSize ' range=':= _default_ * smpoTinSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.145 * _default_ * smpoTinSize ' range=':= _default_ * smpoTinSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -489,18 +489,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.670 * _default_ * smpoMythrilFreq ' range=':= _default_ * smpoMythrilFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.875 * _default_ * smpoMythrilSize ' range=':= _default_ * smpoMythrilSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.935 * _default_ * smpoMythrilSize ' range=':= _default_ * smpoMythrilSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 20 ' range=':= 15 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.875 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.819 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * smpoMythrilSize ' range=':= _default_ * smpoMythrilSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.875 * _default_ * smpoMythrilSize ' range=':= _default_ * smpoMythrilSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.905 * _default_ * smpoMythrilSize ' range=':= _default_ * smpoMythrilSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -608,18 +608,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.474 * _default_ * smpoAdamantiumFreq ' range=':= _default_ * smpoAdamantiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.780 * _default_ * smpoAdamantiumSize ' range=':= _default_ * smpoAdamantiumSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.883 * _default_ * smpoAdamantiumSize ' range=':= _default_ * smpoAdamantiumSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 13 ' range=':= 7 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.780 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.688 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * smpoAdamantiumSize ' range=':= _default_ * smpoAdamantiumSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.780 * _default_ * smpoAdamantiumSize ' range=':= _default_ * smpoAdamantiumSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.830 * _default_ * smpoAdamantiumSize ' range=':= _default_ * smpoAdamantiumSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -759,18 +759,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.474 * _default_ * smpoOnyxFreq ' range=':= _default_ * smpoOnyxFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.780 * _default_ * smpoOnyxSize ' range=':= _default_ * smpoOnyxSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * smpoOnyxSize ' range=':= _default_ * smpoOnyxSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 72 ' range=':= 56 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.780 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.903 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * smpoOnyxSize ' range=':= _default_ * smpoOnyxSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.780 * _default_ * smpoOnyxSize ' range=':= _default_ * smpoOnyxSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.950 * _default_ * smpoOnyxSize ' range=':= _default_ * smpoOnyxSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -780,8 +780,8 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <OreBlock block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("simpleores:onyx_ore")'> <Replaces block='simpleores:onyx_ore' weight='1.0' /> </IfCondition>
-                            <Setting name='MotherlodeSize' avg=':= 0.780 * _default_ * smpoOnyxSize  * 0.5 ' range=':= _default_ * smpoOnyxSize  * 0.5 ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.780 * _default_ * smpoOnyxSize  * 0.5 ' range=':= _default_ * smpoOnyxSize  * 0.5 ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * smpoOnyxSize  * 0.5 ' range=':= _default_ * smpoOnyxSize  * 0.5 ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.950 * _default_ * smpoOnyxSize  * 0.5 ' range=':= _default_ * smpoOnyxSize  * 0.5 ' type='normal' />
                             <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
                         </Veins>
                     </IfCondition>

--- a/src/main/resources/config/modules/Thaumcraft4.xml
+++ b/src/main/resources/config/modules/Thaumcraft4.xml
@@ -364,18 +364,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.990 * _default_ * thm4AmberFreq ' range=':= _default_ * thm4AmberFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.997 * _default_ * thm4AmberSize ' range=':= _default_ * thm4AmberSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * thm4AmberSize ' range=':= _default_ * thm4AmberSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 50 ' range=':= 16 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.997 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.995 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * thm4AmberSize ' range=':= _default_ * thm4AmberSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.997 * _default_ * thm4AmberSize ' range=':= _default_ * thm4AmberSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.998 * _default_ * thm4AmberSize ' range=':= _default_ * thm4AmberSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -490,18 +490,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.213 * _default_ * thm4CinnabarFreq ' range=':= _default_ * thm4CinnabarFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.066 * _default_ * thm4CinnabarSize ' range=':= _default_ * thm4CinnabarSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * thm4CinnabarSize ' range=':= _default_ * thm4CinnabarSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.066 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.101 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * thm4CinnabarSize ' range=':= _default_ * thm4CinnabarSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.066 * _default_ * thm4CinnabarSize ' range=':= _default_ * thm4CinnabarSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.049 * _default_ * thm4CinnabarSize ' range=':= _default_ * thm4CinnabarSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -617,18 +617,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.783 * _default_ * thm4AirInfusedStoneFreq ' range=':= _default_ * thm4AirInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * thm4AirInfusedStoneSize ' range=':= _default_ * thm4AirInfusedStoneSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * thm4AirInfusedStoneSize ' range=':= _default_ * thm4AirInfusedStoneSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.922 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.885 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * thm4AirInfusedStoneSize ' range=':= _default_ * thm4AirInfusedStoneSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.922 * _default_ * thm4AirInfusedStoneSize ' range=':= _default_ * thm4AirInfusedStoneSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.941 * _default_ * thm4AirInfusedStoneSize ' range=':= _default_ * thm4AirInfusedStoneSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -643,18 +643,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <BiomeType name='Plains'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.783 * _default_ * thm4AirInfusedStoneFreq ' range=':= _default_ * thm4AirInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * thm4AirInfusedStoneSize ' range=':= _default_ * thm4AirInfusedStoneSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * thm4AirInfusedStoneSize ' range=':= _default_ * thm4AirInfusedStoneSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.922 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.885 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * thm4AirInfusedStoneSize ' range=':= _default_ * thm4AirInfusedStoneSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.922 * _default_ * thm4AirInfusedStoneSize ' range=':= _default_ * thm4AirInfusedStoneSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.941 * _default_ * thm4AirInfusedStoneSize ' range=':= _default_ * thm4AirInfusedStoneSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -805,18 +805,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.783 * _default_ * thm4FireInfusedStoneFreq ' range=':= _default_ * thm4FireInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * thm4FireInfusedStoneSize ' range=':= _default_ * thm4FireInfusedStoneSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * thm4FireInfusedStoneSize ' range=':= _default_ * thm4FireInfusedStoneSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.922 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.885 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * thm4FireInfusedStoneSize ' range=':= _default_ * thm4FireInfusedStoneSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.922 * _default_ * thm4FireInfusedStoneSize ' range=':= _default_ * thm4FireInfusedStoneSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.941 * _default_ * thm4FireInfusedStoneSize ' range=':= _default_ * thm4FireInfusedStoneSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -831,18 +831,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <BiomeType name='Desert'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.783 * _default_ * thm4FireInfusedStoneFreq ' range=':= _default_ * thm4FireInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * thm4FireInfusedStoneSize ' range=':= _default_ * thm4FireInfusedStoneSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * thm4FireInfusedStoneSize ' range=':= _default_ * thm4FireInfusedStoneSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.922 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.885 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * thm4FireInfusedStoneSize ' range=':= _default_ * thm4FireInfusedStoneSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.922 * _default_ * thm4FireInfusedStoneSize ' range=':= _default_ * thm4FireInfusedStoneSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.941 * _default_ * thm4FireInfusedStoneSize ' range=':= _default_ * thm4FireInfusedStoneSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -994,18 +994,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.783 * _default_ * thm4WaterInfusedStoneFreq ' range=':= _default_ * thm4WaterInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * thm4WaterInfusedStoneSize ' range=':= _default_ * thm4WaterInfusedStoneSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * thm4WaterInfusedStoneSize ' range=':= _default_ * thm4WaterInfusedStoneSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.922 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.885 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * thm4WaterInfusedStoneSize ' range=':= _default_ * thm4WaterInfusedStoneSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.922 * _default_ * thm4WaterInfusedStoneSize ' range=':= _default_ * thm4WaterInfusedStoneSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.941 * _default_ * thm4WaterInfusedStoneSize ' range=':= _default_ * thm4WaterInfusedStoneSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1021,18 +1021,18 @@
                             <BiomeType name='Water'  />
                             <BiomeType name='Swamp'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.783 * _default_ * thm4WaterInfusedStoneFreq ' range=':= _default_ * thm4WaterInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * thm4WaterInfusedStoneSize ' range=':= _default_ * thm4WaterInfusedStoneSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * thm4WaterInfusedStoneSize ' range=':= _default_ * thm4WaterInfusedStoneSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.922 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.885 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * thm4WaterInfusedStoneSize ' range=':= _default_ * thm4WaterInfusedStoneSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.922 * _default_ * thm4WaterInfusedStoneSize ' range=':= _default_ * thm4WaterInfusedStoneSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.941 * _default_ * thm4WaterInfusedStoneSize ' range=':= _default_ * thm4WaterInfusedStoneSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1185,18 +1185,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.783 * _default_ * thm4EarthInfusedStoneFreq ' range=':= _default_ * thm4EarthInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * thm4EarthInfusedStoneSize ' range=':= _default_ * thm4EarthInfusedStoneSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * thm4EarthInfusedStoneSize ' range=':= _default_ * thm4EarthInfusedStoneSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.922 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.885 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * thm4EarthInfusedStoneSize ' range=':= _default_ * thm4EarthInfusedStoneSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.922 * _default_ * thm4EarthInfusedStoneSize ' range=':= _default_ * thm4EarthInfusedStoneSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.941 * _default_ * thm4EarthInfusedStoneSize ' range=':= _default_ * thm4EarthInfusedStoneSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1211,18 +1211,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <BiomeType name='Forest'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.783 * _default_ * thm4EarthInfusedStoneFreq ' range=':= _default_ * thm4EarthInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * thm4EarthInfusedStoneSize ' range=':= _default_ * thm4EarthInfusedStoneSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * thm4EarthInfusedStoneSize ' range=':= _default_ * thm4EarthInfusedStoneSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.922 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.885 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * thm4EarthInfusedStoneSize ' range=':= _default_ * thm4EarthInfusedStoneSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.922 * _default_ * thm4EarthInfusedStoneSize ' range=':= _default_ * thm4EarthInfusedStoneSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.941 * _default_ * thm4EarthInfusedStoneSize ' range=':= _default_ * thm4EarthInfusedStoneSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1374,18 +1374,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.783 * _default_ * thm4OrderInfusedStoneFreq ' range=':= _default_ * thm4OrderInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * thm4OrderInfusedStoneSize ' range=':= _default_ * thm4OrderInfusedStoneSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * thm4OrderInfusedStoneSize ' range=':= _default_ * thm4OrderInfusedStoneSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.922 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.885 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * thm4OrderInfusedStoneSize ' range=':= _default_ * thm4OrderInfusedStoneSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.922 * _default_ * thm4OrderInfusedStoneSize ' range=':= _default_ * thm4OrderInfusedStoneSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.941 * _default_ * thm4OrderInfusedStoneSize ' range=':= _default_ * thm4OrderInfusedStoneSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1402,18 +1402,18 @@
                             <BiomeType name='Mountain'  />
                             <BiomeType name='Magical'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.783 * _default_ * thm4OrderInfusedStoneFreq ' range=':= _default_ * thm4OrderInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * thm4OrderInfusedStoneSize ' range=':= _default_ * thm4OrderInfusedStoneSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * thm4OrderInfusedStoneSize ' range=':= _default_ * thm4OrderInfusedStoneSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.922 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.885 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * thm4OrderInfusedStoneSize ' range=':= _default_ * thm4OrderInfusedStoneSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.922 * _default_ * thm4OrderInfusedStoneSize ' range=':= _default_ * thm4OrderInfusedStoneSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.941 * _default_ * thm4OrderInfusedStoneSize ' range=':= _default_ * thm4OrderInfusedStoneSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1567,18 +1567,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.783 * _default_ * thm4EntropyInfusedStoneFreq ' range=':= _default_ * thm4EntropyInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * thm4EntropyInfusedStoneSize ' range=':= _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * thm4EntropyInfusedStoneSize ' range=':= _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.922 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.885 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * thm4EntropyInfusedStoneSize ' range=':= _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.922 * _default_ * thm4EntropyInfusedStoneSize ' range=':= _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.941 * _default_ * thm4EntropyInfusedStoneSize ' range=':= _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1594,18 +1594,18 @@
                             <BiomeType name='Swamp'  />
                             <BiomeType name='Wasteland'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.783 * _default_ * thm4EntropyInfusedStoneFreq ' range=':= _default_ * thm4EntropyInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * thm4EntropyInfusedStoneSize ' range=':= _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * thm4EntropyInfusedStoneSize ' range=':= _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.922 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.885 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * thm4EntropyInfusedStoneSize ' range=':= _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.922 * _default_ * thm4EntropyInfusedStoneSize ' range=':= _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.941 * _default_ * thm4EntropyInfusedStoneSize ' range=':= _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>

--- a/src/main/resources/config/modules/ThermalFoundation.xml
+++ b/src/main/resources/config/modules/ThermalFoundation.xml
@@ -289,18 +289,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.059 * _default_ * thfoCopperFreq ' range=':= _default_ * thfoCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.019 * _default_ * thfoCopperSize ' range=':= _default_ * thfoCopperSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 1.010 * _default_ * thfoCopperSize ' range=':= _default_ * thfoCopperSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 40 ' range=':= 20 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.019 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.029 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * thfoCopperSize ' range=':= _default_ * thfoCopperSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.019 * _default_ * thfoCopperSize ' range=':= _default_ * thfoCopperSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.15 * _default_ * thfoCopperSize ' range=':= _default_ * thfoCopperSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -408,18 +408,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.948 * _default_ * thfoTinFreq ' range=':= _default_ * thfoTinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.982 * _default_ * thfoTinSize ' range=':= _default_ * thfoTinSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.991 * _default_ * thfoTinSize ' range=':= _default_ * thfoTinSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 40 ' range=':= 20 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.982 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.973 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * thfoTinSize ' range=':= _default_ * thfoTinSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.982 * _default_ * thfoTinSize ' range=':= _default_ * thfoTinSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.987 * _default_ * thfoTinSize ' range=':= _default_ * thfoTinSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -527,18 +527,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.821 * _default_ * thfoSilverFreq ' range=':= _default_ * thfoSilverFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.936 * _default_ * thfoSilverSize ' range=':= _default_ * thfoSilverSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.968 * _default_ * thfoSilverSize ' range=':= _default_ * thfoSilverSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 40 ' range=':= 20 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.936 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.906 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * thfoSilverSize ' range=':= _default_ * thfoSilverSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.936 * _default_ * thfoSilverSize ' range=':= _default_ * thfoSilverSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.952 * _default_ * thfoSilverSize ' range=':= _default_ * thfoSilverSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -646,18 +646,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.948 * _default_ * thfoLeadFreq ' range=':= _default_ * thfoLeadFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.982 * _default_ * thfoLeadSize ' range=':= _default_ * thfoLeadSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.991 * _default_ * thfoLeadSize ' range=':= _default_ * thfoLeadSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 40 ' range=':= 20 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.982 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.973 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * thfoLeadSize ' range=':= _default_ * thfoLeadSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.982 * _default_ * thfoLeadSize ' range=':= _default_ * thfoLeadSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.987 * _default_ * thfoLeadSize ' range=':= _default_ * thfoLeadSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -765,18 +765,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.410 * _default_ * thfoFerrousFreq ' range=':= _default_ * thfoFerrousFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.743 * _default_ * thfoFerrousSize ' range=':= _default_ * thfoFerrousSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.862 * _default_ * thfoFerrousSize ' range=':= _default_ * thfoFerrousSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 40 ' range=':= 20 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.743 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.641 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * thfoFerrousSize ' range=':= _default_ * thfoFerrousSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.743 * _default_ * thfoFerrousSize ' range=':= _default_ * thfoFerrousSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.800 * _default_ * thfoFerrousSize ' range=':= _default_ * thfoFerrousSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -884,18 +884,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.205 * _default_ * thfoShinyFreq ' range=':= _default_ * thfoShinyFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.590 * _default_ * thfoShinySize ' range=':= _default_ * thfoShinySize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.768 * _default_ * thfoShinySize ' range=':= _default_ * thfoShinySize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 40 ' range=':= 20 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.590 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.453 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * thfoShinySize ' range=':= _default_ * thfoShinySize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.590 * _default_ * thfoShinySize ' range=':= _default_ * thfoShinySize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.673 * _default_ * thfoShinySize ' range=':= _default_ * thfoShinySize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>

--- a/src/main/resources/config/modules/TinkersConstruct.xml
+++ b/src/main/resources/config/modules/TinkersConstruct.xml
@@ -1,8 +1,8 @@
 <!-- =================================================================
      Custom Ore Generation "Tinkers Construct" Module: This
-     configuration covers copper, tin, aluminum, iron gravel, gold
-     gravel, copper gravel, tin gravel, aluminum gravel, cobalt,
-     ardite, and nether cobalt gravel.
+     configuration covers copper, tin, aluminum, cobalt, ardite, iron
+     gravel, gold gravel, copper gravel, tin gravel, aluminum gravel,
+     and nether cobalt gravel.
      ================================================================= -->
 
 
@@ -136,6 +136,74 @@
                 </OptionNumeric>
             </ConfigSection>
             <!-- Aluminum Configuration UI Complete -->
+
+
+            <!-- Cobalt Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='ticoCobaltDist'  displayState=':= if(?enableTinkersConstruct, "shown", "hidden")' displayGroup='groupTinkersConstruct'>
+                    <Description> Controls how Cobalt is generated </Description>
+                    <DisplayName>Tinkers Construct Cobalt</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                        <Description>
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Cobalt is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='ticoCobaltFreq' default='1'  min='0' max='5' displayState=':= if(?enableTinkersConstruct, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupTinkersConstruct'>
+                    <Description> Frequency multiplier for Tinkers Construct Cobalt distributions </Description>
+                    <DisplayName>Tinkers Construct Cobalt Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='ticoCobaltSize' default='1'  min='0' max='5' displayState=':= if(?enableTinkersConstruct, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupTinkersConstruct'>
+                    <Description> Size multiplier for Tinkers Construct Cobalt distributions </Description>
+                    <DisplayName>Tinkers Construct Cobalt Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Cobalt Configuration UI Complete -->
+
+
+            <!-- Ardite Configuration UI Starting -->
+            <ConfigSection>
+                <OptionChoice name='ticoArditeDist'  displayState=':= if(?enableTinkersConstruct, "shown", "hidden")' displayGroup='groupTinkersConstruct'>
+                    <Description> Controls how Ardite is generated </Description>
+                    <DisplayName>Tinkers Construct Ardite</DisplayName>
+                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                        <Description>
+                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                        </Description>
+                    </Choice>
+                    <Choice value='Cloud' displayValue='Strategic Cloud'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Ardite is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='ticoArditeFreq' default='1'  min='0' max='5' displayState=':= if(?enableTinkersConstruct, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupTinkersConstruct'>
+                    <Description> Frequency multiplier for Tinkers Construct Ardite distributions </Description>
+                    <DisplayName>Tinkers Construct Ardite Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='ticoArditeSize' default='1'  min='0' max='5' displayState=':= if(?enableTinkersConstruct, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupTinkersConstruct'>
+                    <Description> Size multiplier for Tinkers Construct Ardite distributions </Description>
+                    <DisplayName>Tinkers Construct Ardite Size</DisplayName>
+                </OptionNumeric>
+            </ConfigSection>
+            <!-- Ardite Configuration UI Complete -->
 
 
             <!-- Iron Gravel Configuration UI Starting -->
@@ -308,74 +376,6 @@
             <!-- Aluminum Gravel Configuration UI Complete -->
 
 
-            <!-- Cobalt Configuration UI Starting -->
-            <ConfigSection>
-                <OptionChoice name='ticoCobaltDist'  displayState=':= if(?enableTinkersConstruct, "shown", "hidden")' displayGroup='groupTinkersConstruct'>
-                    <Description> Controls how Cobalt is generated </Description>
-                    <DisplayName>Tinkers Construct Cobalt</DisplayName>
-                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
-                        </Description>
-                    </Choice>
-                    <Choice value='Cloud' displayValue='Strategic Cloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with ore.
-                        </Description>
-                    </Choice>
-                    <Choice value='Vanilla' displayValue='Vanilla'>
-                        <Description>
-                            Simulates Vanilla Minecraft.
-                        </Description>
-                    </Choice>
-                    <Choice value='none' displayValue='None' description='Cobalt is not generated in the world.'/>
-                </OptionChoice>
-                <OptionNumeric name='ticoCobaltFreq' default='1'  min='0' max='5' displayState=':= if(?enableTinkersConstruct, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupTinkersConstruct'>
-                    <Description> Frequency multiplier for Tinkers Construct Cobalt distributions </Description>
-                    <DisplayName>Tinkers Construct Cobalt Freq.</DisplayName>
-                </OptionNumeric>
-                <OptionNumeric name='ticoCobaltSize' default='1'  min='0' max='5' displayState=':= if(?enableTinkersConstruct, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupTinkersConstruct'>
-                    <Description> Size multiplier for Tinkers Construct Cobalt distributions </Description>
-                    <DisplayName>Tinkers Construct Cobalt Size</DisplayName>
-                </OptionNumeric>
-            </ConfigSection>
-            <!-- Cobalt Configuration UI Complete -->
-
-
-            <!-- Ardite Configuration UI Starting -->
-            <ConfigSection>
-                <OptionChoice name='ticoArditeDist'  displayState=':= if(?enableTinkersConstruct, "shown", "hidden")' displayGroup='groupTinkersConstruct'>
-                    <Description> Controls how Ardite is generated </Description>
-                    <DisplayName>Tinkers Construct Ardite</DisplayName>
-                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
-                        </Description>
-                    </Choice>
-                    <Choice value='Cloud' displayValue='Strategic Cloud'>
-                        <Description>
-                            Large irregular clouds filled lightly with ore.
-                        </Description>
-                    </Choice>
-                    <Choice value='Vanilla' displayValue='Vanilla'>
-                        <Description>
-                            Simulates Vanilla Minecraft.
-                        </Description>
-                    </Choice>
-                    <Choice value='none' displayValue='None' description='Ardite is not generated in the world.'/>
-                </OptionChoice>
-                <OptionNumeric name='ticoArditeFreq' default='1'  min='0' max='5' displayState=':= if(?enableTinkersConstruct, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupTinkersConstruct'>
-                    <Description> Frequency multiplier for Tinkers Construct Ardite distributions </Description>
-                    <DisplayName>Tinkers Construct Ardite Freq.</DisplayName>
-                </OptionNumeric>
-                <OptionNumeric name='ticoArditeSize' default='1'  min='0' max='5' displayState=':= if(?enableTinkersConstruct, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupTinkersConstruct'>
-                    <Description> Size multiplier for Tinkers Construct Ardite distributions </Description>
-                    <DisplayName>Tinkers Construct Ardite Size</DisplayName>
-                </OptionNumeric>
-            </ConfigSection>
-            <!-- Ardite Configuration UI Complete -->
-
-
             <!-- Nether Cobalt Gravel Configuration UI Starting -->
             <ConfigSection>
                 <OptionChoice name='ticoNetherCobaltGravelDist'  displayState=':= if(?enableTinkersConstruct, "shown", "hidden")' displayGroup='groupTinkersConstruct'>
@@ -476,18 +476,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.474 * _default_ * ticoCopperFreq ' range=':= _default_ * ticoCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.780 * _default_ * ticoCopperSize ' range=':= _default_ * ticoCopperSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.883 * _default_ * ticoCopperSize ' range=':= _default_ * ticoCopperSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 40 ' range=':= 20 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.780 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.688 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * ticoCopperSize ' range=':= _default_ * ticoCopperSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.780 * _default_ * ticoCopperSize ' range=':= _default_ * ticoCopperSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.830 * _default_ * ticoCopperSize ' range=':= _default_ * ticoCopperSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -595,18 +595,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.474 * _default_ * ticoTinFreq ' range=':= _default_ * ticoTinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.780 * _default_ * ticoTinSize ' range=':= _default_ * ticoTinSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.883 * _default_ * ticoTinSize ' range=':= _default_ * ticoTinSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 23 ' range=':= 17 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.780 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.688 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * ticoTinSize ' range=':= _default_ * ticoTinSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.780 * _default_ * ticoTinSize ' range=':= _default_ * ticoTinSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.830 * _default_ * ticoTinSize ' range=':= _default_ * ticoTinSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -714,18 +714,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.503 * _default_ * ticoAluminumFreq ' range=':= _default_ * ticoAluminumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.795 * _default_ * ticoAluminumSize ' range=':= _default_ * ticoAluminumSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.892 * _default_ * ticoAluminumSize ' range=':= _default_ * ticoAluminumSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 35 ' range=':= 29 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.795 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.709 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * ticoAluminumSize ' range=':= _default_ * ticoAluminumSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.795 * _default_ * ticoAluminumSize ' range=':= _default_ * ticoAluminumSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.842 * _default_ * ticoAluminumSize ' range=':= _default_ * ticoAluminumSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -832,19 +832,19 @@
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre")'> <OreBlock block='TConstruct:GravelOre' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.498 * _default_ * ticoIronGravelFreq ' range=':= 1 * _default_ * ticoIronGravelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.144 * _default_ * ticoIronGravelSize ' range=':= 1 * _default_ * ticoIronGravelSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.498 * _default_ * ticoIronGravelFreq ' range=':= _default_ * ticoIronGravelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.070 * _default_ * ticoIronGravelSize ' range=':= _default_ * ticoIronGravelSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 36 ' range=':= 31 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.144 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.224 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * ticoIronGravelSize ' range=':= _default_ * ticoIronGravelSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.144 * _default_ * ticoIronGravelSize ' range=':= 1 * _default_ * ticoIronGravelSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.106 * _default_ * ticoIronGravelSize ' range=':= _default_ * ticoIronGravelSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -951,19 +951,19 @@
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:1")'> <OreBlock block='TConstruct:GravelOre:1' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.474 * _default_ * ticoGoldGravelFreq ' range=':= 1 * _default_ * ticoGoldGravelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.780 * _default_ * ticoGoldGravelSize ' range=':= 1 * _default_ * ticoGoldGravelSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 17 ' range=':= 12 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.474 * _default_ * ticoGoldGravelFreq ' range=':= _default_ * ticoGoldGravelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.883 * _default_ * ticoGoldGravelSize ' range=':= _default_ * ticoGoldGravelSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 19 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.780 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.688 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * ticoGoldGravelSize ' range=':= _default_ * ticoGoldGravelSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.780 * _default_ * ticoGoldGravelSize ' range=':= 1 * _default_ * ticoGoldGravelSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.830 * _default_ * ticoGoldGravelSize ' range=':= _default_ * ticoGoldGravelSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -996,7 +996,7 @@
                             <Setting name='CloudRadius' avg=':= 0.973 * _default_ * ticoGoldGravelSize ' range=':= _default_ * ticoGoldGravelSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.973 * _default_ * ticoGoldGravelSize ' range=':= _default_ * ticoGoldGravelSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * ticoGoldGravelFreq ' range=':= _default_ * ticoGoldGravelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 17 ' range=':= 12 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 19 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1047,7 +1047,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 8 * ticoGoldGravelSize ' range=':= _default_ * ticoGoldGravelSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 2 * ticoGoldGravelFreq ' range=':= _default_ * ticoGoldGravelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 17 ' range=':= 12 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 19 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1070,19 +1070,19 @@
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:2")'> <OreBlock block='TConstruct:GravelOre:2' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.474 * _default_ * ticoCopperGravelFreq ' range=':= _default_ * ticoCopperGravelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.780 * _default_ * ticoCopperGravelSize ' range=':= _default_ * ticoCopperGravelSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 40 ' range=':= 20 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.059 * _default_ * ticoCopperGravelFreq ' range=':= _default_ * ticoCopperGravelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.010 * _default_ * ticoCopperGravelSize ' range=':= _default_ * ticoCopperGravelSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 68 ' range=':= 28 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.780 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.029 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * ticoCopperGravelSize ' range=':= _default_ * ticoCopperGravelSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.780 * _default_ * ticoCopperGravelSize ' range=':= _default_ * ticoCopperGravelSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.015 * _default_ * ticoCopperGravelSize ' range=':= _default_ * ticoCopperGravelSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1113,10 +1113,10 @@
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:2")'> <OreBlock block='TConstruct:GravelOre:2' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.973 * _default_ * ticoCopperGravelSize ' range=':= _default_ * ticoCopperGravelSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.973 * _default_ * ticoCopperGravelSize ' range=':= _default_ * ticoCopperGravelSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * ticoCopperGravelFreq ' range=':= _default_ * ticoCopperGravelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 40 ' range=':= 20 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 1.454 * _default_ * ticoCopperGravelSize ' range=':= _default_ * ticoCopperGravelSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.454 * _default_ * ticoCopperGravelSize ' range=':= _default_ * ticoCopperGravelSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 2.115  * _default_ * ticoCopperGravelFreq ' range=':= _default_ * ticoCopperGravelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 68 ' range=':= 28 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1166,8 +1166,8 @@
                             <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 8 * ticoCopperGravelSize ' range=':= _default_ * ticoCopperGravelSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2 * ticoCopperGravelFreq ' range=':= _default_ * ticoCopperGravelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 40 ' range=':= 20 ' type='normal' scaleTo='base' />
+                            <Setting name='Frequency' avg=':= 10 * ticoCopperGravelFreq ' range=':= _default_ * ticoCopperGravelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 68 ' range=':= 28 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1190,19 +1190,19 @@
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:3")'> <OreBlock block='TConstruct:GravelOre:3' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.474 * _default_ * ticoTinGravelFreq ' range=':= _default_ * ticoTinGravelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.780 * _default_ * ticoTinGravelSize ' range=':= _default_ * ticoTinGravelSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 23 ' range=':= 17 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.948 * _default_ * ticoTinGravelFreq ' range=':= _default_ * ticoTinGravelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.991 * _default_ * ticoTinGravelSize ' range=':= _default_ * ticoTinGravelSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 38 ' range=':= 17 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.780 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.973 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * ticoTinGravelSize ' range=':= _default_ * ticoTinGravelSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.780 * _default_ * ticoTinGravelSize ' range=':= _default_ * ticoTinGravelSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.987 * _default_ * ticoTinGravelSize ' range=':= _default_ * ticoTinGravelSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1232,10 +1232,10 @@
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:3")'> <OreBlock block='TConstruct:GravelOre:3' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.973 * _default_ * ticoTinGravelSize ' range=':= _default_ * ticoTinGravelSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.973 * _default_ * ticoTinGravelSize ' range=':= _default_ * ticoTinGravelSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.946  * _default_ * ticoTinGravelFreq ' range=':= _default_ * ticoTinGravelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 23 ' range=':= 17 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 1.375 * _default_ * ticoTinGravelSize ' range=':= _default_ * ticoTinGravelSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.375 * _default_ * ticoTinGravelSize ' range=':= _default_ * ticoTinGravelSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.892  * _default_ * ticoTinGravelFreq ' range=':= _default_ * ticoTinGravelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 38 ' range=':= 17 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1285,8 +1285,8 @@
                             <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 8 * ticoTinGravelSize ' range=':= _default_ * ticoTinGravelSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2 * ticoTinGravelFreq ' range=':= _default_ * ticoTinGravelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 23 ' range=':= 17 ' type='normal' scaleTo='base' />
+                            <Setting name='Frequency' avg=':= 8 * ticoTinGravelFreq ' range=':= _default_ * ticoTinGravelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 38 ' range=':= 17 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1310,18 +1310,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.503 * _default_ * ticoAluminumGravelFreq ' range=':= _default_ * ticoAluminumGravelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.795 * _default_ * ticoAluminumGravelSize ' range=':= _default_ * ticoAluminumGravelSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.892 * _default_ * ticoAluminumGravelSize ' range=':= _default_ * ticoAluminumGravelSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 35 ' range=':= 29 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.795 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.709 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * ticoAluminumGravelSize ' range=':= _default_ * ticoAluminumGravelSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.795 * _default_ * ticoAluminumGravelSize ' range=':= _default_ * ticoAluminumGravelSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.842 * _default_ * ticoAluminumGravelSize ' range=':= _default_ * ticoAluminumGravelSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1478,18 +1478,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.580 * _default_ * ticoCobaltFreq ' range=':= _default_ * ticoCobaltFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.834 * _default_ * ticoCobaltSize ' range=':= _default_ * ticoCobaltSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.913 * _default_ * ticoCobaltSize ' range=':= _default_ * ticoCobaltSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 64 ' range=':= 64 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.834 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.762 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * ticoCobaltSize ' range=':= _default_ * ticoCobaltSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.834 * _default_ * ticoCobaltSize ' range=':= _default_ * ticoCobaltSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.873 * _default_ * ticoCobaltSize ' range=':= _default_ * ticoCobaltSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1572,7 +1572,7 @@
                             <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3 * ticoCobaltSize ' range=':= _default_ * ticoCobaltSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2 * ticoCobaltFreq ' range=':= _default_ * ticoCobaltFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Frequency' avg=':= 8 * ticoCobaltFreq ' range=':= _default_ * ticoCobaltFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 64 ' range=':= 64 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -1597,18 +1597,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.580 * _default_ * ticoArditeFreq ' range=':= _default_ * ticoArditeFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.834 * _default_ * ticoArditeSize ' range=':= _default_ * ticoArditeSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.913 * _default_ * ticoArditeSize ' range=':= _default_ * ticoArditeSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 64 ' range=':= 64 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.834 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.762 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * ticoArditeSize ' range=':= _default_ * ticoArditeSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.834 * _default_ * ticoArditeSize ' range=':= _default_ * ticoArditeSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.873 * _default_ * ticoArditeSize ' range=':= _default_ * ticoArditeSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1691,7 +1691,7 @@
                             <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3 * ticoArditeSize ' range=':= _default_ * ticoArditeSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2 * ticoArditeFreq ' range=':= _default_ * ticoArditeFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Frequency' avg=':= 8 * ticoArditeFreq ' range=':= _default_ * ticoArditeFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 64 ' range=':= 64 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -1717,18 +1717,18 @@
                             <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.580 * _default_ * ticoNetherCobaltGravelFreq ' range=':= _default_ * ticoNetherCobaltGravelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.834 * _default_ * ticoNetherCobaltGravelSize ' range=':= _default_ * ticoNetherCobaltGravelSize ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0.913 * _default_ * ticoNetherCobaltGravelSize ' range=':= _default_ * ticoNetherCobaltGravelSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 64 ' range=':= 64 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.834 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.762 * _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * ticoNetherCobaltGravelSize ' range=':= _default_ * ticoNetherCobaltGravelSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.834 * _default_ * ticoNetherCobaltGravelSize ' range=':= _default_ * ticoNetherCobaltGravelSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.873 * _default_ * ticoNetherCobaltGravelSize ' range=':= _default_ * ticoNetherCobaltGravelSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1813,7 +1813,7 @@
                             <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3 * ticoNetherCobaltGravelSize ' range=':= _default_ * ticoNetherCobaltGravelSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2 * ticoNetherCobaltGravelFreq ' range=':= _default_ * ticoNetherCobaltGravelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Frequency' avg=':= 8 * ticoNetherCobaltGravelFreq ' range=':= _default_ * ticoNetherCobaltGravelFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 64 ' range=':= 64 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>

--- a/src/main/resources/config/modules/TinkersSteelworks.xml
+++ b/src/main/resources/config/modules/TinkersSteelworks.xml
@@ -1,113 +1,138 @@
+<!-- =================================================================
+     Custom Ore Generation "Tinkers Steelworks" Module: This
+     configuration covers limestone.
+     ================================================================= -->
 
-<!-- ================================================================ 
 
-Custom Ore Generation:   Tinkers Steelworks Module
 
-Generates: 
-Limestone
 
-================================================================ -->
 
-    <!-- Mod detection -->
-    <IfModInstalled name="TSteelworks">
-        
-        <!-- Starting Custom Ore Gen Configuration. -->
+
+<!-- Is the "Tinkers Steelworks" mod on the system?  Let's find out! -->
+<IfModInstalled name="TSteelworks">
+
+    <!-- Starting Configuration for Custom Ore Generation. -->
+    <ConfigSection>
+
+
+
+
+
+        <!-- Setup Screen Configuration -->
         <ConfigSection>
-        
-            
-            <!-- Setup Screen Configuration -->
+            <OptionDisplayGroup name='groupTinkersSteelworks' displayName='Tinkers Steelworks' displayState='shown'>
+                <Description>
+                    Distribution options for Tinkers Steelworks Ores.
+                </Description>
+            </OptionDisplayGroup>
+            <OptionChoice name='enableTinkersSteelworks' displayName='Handle Tinkers Steelworks Setup?' default='true' displayState='shown_dynamic' displayGroup='groupTinkersSteelworks'>
+                <Description> Should Custom Ore Generation handle Tinkers Steelworks ore generation? </Description>
+                <Choice value=':= ?true' displayValue='Yes' description='Use Custom Ore Generation to handle Tinkers Steelworks ores.'/>
+                <Choice value=':= ?false' displayValue='No' description='Tinkers Steelworks ores will be handled by the mod itself.'/>
+            </OptionChoice>
+
+            <!-- Limestone Configuration UI Starting -->
             <ConfigSection>
-                <OptionDisplayGroup name='groupTinkersSteelworks' displayName='Tinkers Steelworks' displayState='shown'> 
-                    <Description>
-                        Distribution options for Tinkers Steelworks Ores.
-                    </Description>
-                </OptionDisplayGroup>
-                
-                <!-- Limestone Configuration UI Starting -->
-                <ConfigSection>
-                    <OptionChoice name='tiswLimestoneDist'  displayState='shown' displayGroup='groupTinkersSteelworks'> 
-                        <Description> Controls how Limestone is generated </Description> 
-                        <DisplayName>Tinkers Steelworks Limestone</DisplayName>
-                        <Choice value='layeredVeins' displayValue='Layered Veins'>
-                            <Description>
-                                Layered Veins.
-                            </Description>
-                        </Choice>
-                        <Choice value='none' displayValue='None' description='Limestone is not generated in the world.'/>
-                    </OptionChoice>
-                    <OptionNumeric name='tiswLimestoneFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupTinkersSteelworks'>
-                        <Description> Frequency multiplier for Tinkers Steelworks Limestone distributions </Description>
-                        <DisplayName>Tinkers Steelworks Limestone Freq.</DisplayName>
-                    </OptionNumeric>
-                    <OptionNumeric name='tiswLimestoneSize' default='1'  min='0' max='5' displayState=':= if(?advOptions,"shown","hidden")' displayGroup='groupTinkersSteelworks'>
-                        <Description> Size multiplier for Tinkers Steelworks Limestone distributions </Description>
-                        <DisplayName>Tinkers Steelworks Limestone Size</DisplayName>
-                    </OptionNumeric>
-                </ConfigSection> 
-                <!-- Limestone Configuration UI Complete -->
-                
+                <OptionChoice name='tiswLimestoneDist'  displayState=':= if(?enableTinkersSteelworks, "shown", "hidden")' displayGroup='groupTinkersSteelworks'>
+                    <Description> Controls how Limestone is generated </Description>
+                    <DisplayName>Tinkers Steelworks Limestone</DisplayName>
+                    <Choice value='Vanilla' displayValue='Vanilla'>
+                        <Description>
+                            Simulates Vanilla Minecraft.
+                        </Description>
+                    </Choice>
+                    <Choice value='none' displayValue='None' description='Limestone is not generated in the world.'/>
+                </OptionChoice>
+                <OptionNumeric name='tiswLimestoneFreq' default='1'  min='0' max='5' displayState=':= if(?enableTinkersSteelworks, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupTinkersSteelworks'>
+                    <Description> Frequency multiplier for Tinkers Steelworks Limestone distributions </Description>
+                    <DisplayName>Tinkers Steelworks Limestone Freq.</DisplayName>
+                </OptionNumeric>
+                <OptionNumeric name='tiswLimestoneSize' default='1'  min='0' max='5' displayState=':= if(?enableTinkersSteelworks, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupTinkersSteelworks'>
+                    <Description> Size multiplier for Tinkers Steelworks Limestone distributions </Description>
+                    <DisplayName>Tinkers Steelworks Limestone Size</DisplayName>
+                </OptionNumeric>
             </ConfigSection>
-            <!-- Setup Screen Complete -->
+            <!-- Limestone Configuration UI Complete -->
+
+        </ConfigSection>
+        <!-- Setup Screen Complete -->
+
+        <IfCondition condition=':= ?enableTinkersSteelworks'>
 
 
-            <!-- Setup Overworld -->
+
+
+            <!-- Overworld Setup Beginning -->
+
             <IfCondition condition=':= ?COGActive'>
-                
-                <!-- Starting Original Overworld Ore Removal -->
-                <!-- Original Overworld Ore Removal Complete -->
-                
-                <!-- Adding ores --> 
-                
-                <!-- Begin Limestone Generation --> 
-                
-                <!-- Begin Layered Veins distribution of Limestone -->
-                <IfCondition condition=':= tiswLimestoneDist = "layeredVeins"'>
-                
-                    <Veins name='tiswLimestoneBaseVeins' block='TSteelworks:Limestone' inherits='PresetLayeredVeins'>
-                        <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60CD3AC4</WireframeColor>
-                        <Setting name='MotherlodeSize' avg=':= 1 * 1 * tiswLimestoneSize * _default_' range=':= 1 * 1 * tiswLimestoneSize * _default_'/>
-                        <Setting name='MotherlodeHeight' avg=':= 128' range=':= 128' type='uniform' scaleTo='SeaLevel'/> 
-                        <Setting name='SegmentRadius' avg=':= 1 * 1 * tiswLimestoneSize * _default_' range=':= 1 * 1 * tiswLimestoneSize * _default_'/>
-                        <Setting name='OreDensity' avg=':= 1 * 1 * _default_' range=':= _default_'/>
-                        <Setting name='MotherlodeFrequency' avg=':= 3 * 1 * tiswLimestoneFreq * _default_'/>
-                        <Replaces block='minecraft:stone'/>
-                    </Veins>
-                    
-                    <!-- Begin Preferred Biome Distribution (Limestone Layered Veins) Settings -->
-                    <Veins name='tiswLimestonePrefersVeins' block='TSteelworks:Limestone' inherits='tiswLimestoneBaseVeins'>
-                        <Description>
-                            Spawns 2 more times in preferred biomes.
-                        </Description>
-                        <DrawWireframe>:=drawWireframes</DrawWireframe>
-                        <WireframeColor>0x60CD3AC4</WireframeColor>
-                        <Setting name='MotherlodeFrequency' avg=':= 2 * _default_'/>
-                        <BiomeType name='swamp'/>
-                    </Veins>
-                    <!-- End Preferred Biome Distribution (Limestone Layered Veins) Settings -->
-                
-                </IfCondition>
-                <!-- End Layered Veins distribution of Limestone -->
-                
-                <!-- End Limestone Generation --> 
 
-                <!-- Done adding ores -->
-            
+                <!-- Starting Original "Overworld" Block Removal -->
+
+                <IfCondition condition=':= ?blockExists("minecraft:stone")'>
+                    <Substitute name='tiswOverworldBlockSubstitute0' block='minecraft:stone'>
+                        <Description>
+                            Replace vanilla-generated ore clusters.
+                        </Description>
+                        <Comment>
+                            The global option  deferredPopulationRange
+                            must be large  enough to catch all ore
+                            clusters (>=  32).
+                        </Comment>
+                        <IfCondition condition=':= ?blockExists("TSteelworks:Limestone")'> <Replaces block='TSteelworks:Limestone' weight='1.0' /> </IfCondition>
+                    </Substitute>
+                </IfCondition>
+
+                <!-- Original "Overworld" Block Removal Complete -->
+
+                <!-- Adding blocks -->
+
+                <!-- Begin Limestone Generation -->
+
+                <!-- Starting Vanilla Preset for Limestone. -->
+                <ConfigSection>
+                    <IfCondition condition=':= tiswLimestoneDist = "Vanilla"'>
+                        <StandardGen name='tiswLimestoneStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60C5CCA9' drawBoundBox='false' boundBoxColor='0x60C5CCA9'>
+                            <Description>
+                                A master preset for standardgen  ore
+                                distributions.
+                            </Description>
+                            <IfCondition condition=':= ?blockExists("TSteelworks:Limestone")'> <OreBlock block='TSteelworks:Limestone' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <Biome name='.*'  />
+                            <Setting name='Size' avg=':= 3 * tiswLimestoneSize ' range=':= _default_ * tiswLimestoneSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 8 * tiswLimestoneFreq ' range=':= _default_ * tiswLimestoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64 ' range=':= 64 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                        </StandardGen>
+                    </IfCondition>
+                </ConfigSection>
+                <!-- Vanilla Preset for Limestone is complete. -->
+
+                <!-- End Limestone Generation -->
+
+                <!-- Finished adding blocks -->
+
             </IfCondition>
             <!-- Overworld Setup Complete -->
 
 
- 
- 
-        
-        </ConfigSection>
-        <!-- Custom Ore Gen Configuration Complete! -->
-    
-    </IfModInstalled> 
- 
+
+        </IfCondition>
+
+    </ConfigSection>
+    <!-- Configuration for Custom Ore Generation Complete! -->
+
+</IfModInstalled>
+<!-- The "Tinkers Steelworks" mod is now configured. -->
 
 
-<!-- This file was made using the Sprocket Configuration Generator. -->
+
+
+
+<!-- =================================================================
+     This file was made using the Sprocket Configuration Generator.
+     If you wish to make your own configurations for a mod not
+     currently supported by Custom Ore Generation, and you don't want
+     the hassle of writing XML, you can find the generator script at
+     its GitHub page: http://https://github.com/reteo/Sprocket
+     ================================================================= -->

--- a/src/main/resources/config/modules/VanillaMinecraft.xml
+++ b/src/main/resources/config/modules/VanillaMinecraft.xml
@@ -394,9 +394,9 @@
                     <Biome name='Ocean'  weight='-1' />
                     <Biome name='Desert'  weight='-1' />
                     <Biome name='Mountain'  weight='-1' />
-                    <Setting name='MotherlodeFrequency' avg=':= 0.5 * _default_ * vnlaClayFreq ' range=':= 0.5 * _default_ * vnlaClayFreq ' type='uniform' scaleTo='base' />
-                    <Setting name='MotherlodeSize' avg=':= 2 * _default_ * vnlaClaySize ' range=':= 2 * _default_ * vnlaClaySize ' type='normal' />
-                    <Setting name='MotherlodeHeight' avg=':= 60 ' range=':= 4 ' type='normal' scaleTo='base' />
+                    <Setting name='MotherlodeFrequency' avg=':= 0.765 * _default_ * vnlaClayFreq ' range=':= 1 * _default_ * vnlaClayFreq ' type='normal' scaleTo='base' />
+                    <Setting name='MotherlodeSize' avg=':= 0.956 * _default_ * vnlaClaySize ' range=':= 1 * _default_ * vnlaClaySize ' type='normal' />
+                    <Setting name='MotherlodeHeight' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                     <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -427,9 +427,9 @@
                     <Biome name='Ocean'  weight='-1' />
                     <Biome name='Desert'  weight='-1' />
                     <Biome name='Mountain'  weight='-1' />
-                    <Setting name='MotherlodeFrequency' avg=':= 0.5 * _default_ * vnlaClayFreq ' range=':= 0.5 * _default_ * vnlaClayFreq ' type='uniform' scaleTo='base' />
-                    <Setting name='MotherlodeSize' avg=':= 2 * _default_ * vnlaClaySize ' range=':= 2 * _default_ * vnlaClaySize ' type='normal' />
-                    <Setting name='MotherlodeHeight' avg=':= 60 ' range=':= 4 ' type='normal' scaleTo='base' />
+                    <Setting name='MotherlodeFrequency' avg=':= 0.765 * _default_ * vnlaClayFreq ' range=':= 1 * _default_ * vnlaClayFreq ' type='normal' scaleTo='base' />
+                    <Setting name='MotherlodeSize' avg=':= 0.956 * _default_ * vnlaClaySize ' range=':= 1 * _default_ * vnlaClaySize ' type='normal' />
+                    <Setting name='MotherlodeHeight' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                     <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -472,18 +472,18 @@
                     <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                     <Biome name='.*'  />
                     <Setting name='MotherlodeFrequency' avg=':= 6.262 * _default_ * vnlaCoalFreq ' range=':= 1 * _default_ * vnlaCoalFreq ' type='normal' scaleTo='base' />
-                    <Setting name='MotherlodeSize' avg=':= 1.843 * _default_ * vnlaCoalSize ' range=':= 1 * _default_ * vnlaCoalSize ' type='normal' />
+                    <Setting name='MotherlodeSize' avg=':= 0 * _default_ * vnlaCoalSize ' range=':= 1 * _default_ * vnlaCoalSize ' type='normal' />
                     <Setting name='MotherlodeHeight' avg=':= 68 ' range=':= 63 ' type='uniform' scaleTo='base' />
                     <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                    <Setting name='BranchLength' avg=':= 1.843 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                    <Setting name='BranchLength' avg=':= 2.502 * _default_ ' range=':= 1 * _default_ ' type='normal' />
                     <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                     <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='SegmentLength' avg=':= _default_ * vnlaCoalSize ' range=':= _default_ * vnlaCoalSize ' type='normal' />
                     <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                    <Setting name='SegmentRadius' avg=':= 1.843 * _default_ * vnlaCoalSize ' range=':= 1 * _default_ * vnlaCoalSize ' type='normal' />
+                    <Setting name='SegmentRadius' avg=':= 1.582 * _default_ * vnlaCoalSize ' range=':= 1 * _default_ * vnlaCoalSize ' type='normal' />
                     <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                 </Veins>
@@ -643,18 +643,18 @@
                     <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                     <Biome name='.*'  />
                     <Setting name='MotherlodeFrequency' avg=':= 1.498 * _default_ * vnlaIronFreq ' range=':= 1 * _default_ * vnlaIronFreq ' type='normal' scaleTo='base' />
-                    <Setting name='MotherlodeSize' avg=':= 1.144 * _default_ * vnlaIronSize ' range=':= 1 * _default_ * vnlaIronSize ' type='normal' />
+                    <Setting name='MotherlodeSize' avg=':= 1.070 * _default_ * vnlaIronSize ' range=':= 1 * _default_ * vnlaIronSize ' type='normal' />
                     <Setting name='MotherlodeHeight' avg=':= 36 ' range=':= 31 ' type='normal' scaleTo='base' />
                     <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                    <Setting name='BranchLength' avg=':= 1.144 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                    <Setting name='BranchLength' avg=':= 1.224 * _default_ ' range=':= 1 * _default_ ' type='normal' />
                     <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                     <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='SegmentLength' avg=':= _default_ * vnlaIronSize ' range=':= _default_ * vnlaIronSize ' type='normal' />
                     <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                    <Setting name='SegmentRadius' avg=':= 1.144 * _default_ * vnlaIronSize ' range=':= 1 * _default_ * vnlaIronSize ' type='normal' />
+                    <Setting name='SegmentRadius' avg=':= 1.106 * _default_ * vnlaIronSize ' range=':= 1 * _default_ * vnlaIronSize ' type='normal' />
                     <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                 </Veins>
@@ -757,18 +757,18 @@
                     <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                     <Biome name='.*'  />
                     <Setting name='MotherlodeFrequency' avg=':= 0.474 * _default_ * vnlaGoldFreq ' range=':= 1 * _default_ * vnlaGoldFreq ' type='normal' scaleTo='base' />
-                    <Setting name='MotherlodeSize' avg=':= 0.780 * _default_ * vnlaGoldSize ' range=':= 1 * _default_ * vnlaGoldSize ' type='normal' />
+                    <Setting name='MotherlodeSize' avg=':= 0.883 * _default_ * vnlaGoldSize ' range=':= 1 * _default_ * vnlaGoldSize ' type='normal' />
                     <Setting name='MotherlodeHeight' avg=':= 17 ' range=':= 12 ' type='normal' scaleTo='base' />
                     <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                    <Setting name='BranchLength' avg=':= 0.780 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                    <Setting name='BranchLength' avg=':= 0.688 * _default_ ' range=':= 1 * _default_ ' type='normal' />
                     <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                     <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='SegmentLength' avg=':= _default_ * vnlaGoldSize ' range=':= _default_ * vnlaGoldSize ' type='normal' />
                     <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                    <Setting name='SegmentRadius' avg=':= 0.780 * _default_ * vnlaGoldSize ' range=':= 1 * _default_ * vnlaGoldSize ' type='normal' />
+                    <Setting name='SegmentRadius' avg=':= 0.830 * _default_ * vnlaGoldSize ' range=':= 1 * _default_ * vnlaGoldSize ' type='normal' />
                     <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                 </Veins>
@@ -871,18 +871,18 @@
                     <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                     <Biome name='.*'  />
                     <Setting name='MotherlodeFrequency' avg=':= 1.642 * _default_ * vnlaRedstoneFreq ' range=':= 1 * _default_ * vnlaRedstoneFreq ' type='normal' scaleTo='base' />
-                    <Setting name='MotherlodeSize' avg=':= 1.180 * _default_ * vnlaRedstoneSize ' range=':= 1 * _default_ * vnlaRedstoneSize ' type='normal' />
+                    <Setting name='MotherlodeSize' avg=':= 0 * _default_ * vnlaRedstoneSize ' range=':= 1 * _default_ * vnlaRedstoneSize ' type='normal' />
                     <Setting name='MotherlodeHeight' avg=':= 10 ' range=':= 5 ' type='normal' scaleTo='base' />
                     <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='BranchInclination' avg=':= -_default_ ' range=':= -_default_ ' type='normal' />
-                    <Setting name='BranchLength' avg=':= 1.180 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                    <Setting name='BranchLength' avg=':= 1.282 * _default_ ' range=':= 1 * _default_ ' type='normal' />
                     <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                     <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='SegmentLength' avg=':= _default_ * vnlaRedstoneSize ' range=':= _default_ * vnlaRedstoneSize ' type='normal' />
                     <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                    <Setting name='SegmentRadius' avg=':= 1.180 * _default_ * vnlaRedstoneSize ' range=':= 1 * _default_ * vnlaRedstoneSize ' type='normal' />
+                    <Setting name='SegmentRadius' avg=':= 1.132 * _default_ * vnlaRedstoneSize ' range=':= 1 * _default_ * vnlaRedstoneSize ' type='normal' />
                     <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                 </Veins>
@@ -897,18 +897,18 @@
                     <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                     <BiomeType name='Desert'  />
                     <Setting name='MotherlodeFrequency' avg=':= 1.642 * _default_ * vnlaRedstoneFreq ' range=':= 1 * _default_ * vnlaRedstoneFreq ' type='normal' scaleTo='base' />
-                    <Setting name='MotherlodeSize' avg=':= 1.180 * _default_ * vnlaRedstoneSize ' range=':= 1 * _default_ * vnlaRedstoneSize ' type='normal' />
+                    <Setting name='MotherlodeSize' avg=':= 0 * _default_ * vnlaRedstoneSize ' range=':= 1 * _default_ * vnlaRedstoneSize ' type='normal' />
                     <Setting name='MotherlodeHeight' avg=':= 10 ' range=':= 5 ' type='normal' scaleTo='base' />
                     <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='BranchInclination' avg=':= -_default_ ' range=':= -_default_ ' type='normal' />
-                    <Setting name='BranchLength' avg=':= 1.180 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                    <Setting name='BranchLength' avg=':= 1.282 * _default_ ' range=':= 1 * _default_ ' type='normal' />
                     <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                     <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='SegmentLength' avg=':= _default_ * vnlaRedstoneSize ' range=':= _default_ * vnlaRedstoneSize ' type='normal' />
                     <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                    <Setting name='SegmentRadius' avg=':= 1.180 * _default_ * vnlaRedstoneSize ' range=':= 1 * _default_ * vnlaRedstoneSize ' type='normal' />
+                    <Setting name='SegmentRadius' avg=':= 1.132 * _default_ * vnlaRedstoneSize ' range=':= 1 * _default_ * vnlaRedstoneSize ' type='normal' />
                     <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                 </Veins>
@@ -1045,18 +1045,18 @@
                     <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                     <Biome name='.*'  />
                     <Setting name='MotherlodeFrequency' avg=':= 0.365 * _default_ * vnlaDiamondFreq ' range=':= 1 * _default_ * vnlaDiamondFreq ' type='normal' scaleTo='base' />
-                    <Setting name='MotherlodeSize' avg=':= 0.715 * _default_ * vnlaDiamondSize ' range=':= 1 * _default_ * vnlaDiamondSize ' type='normal' />
+                    <Setting name='MotherlodeSize' avg=':= 0 * _default_ * vnlaDiamondSize ' range=':= 1 * _default_ * vnlaDiamondSize ' type='normal' />
                     <Setting name='MotherlodeHeight' avg=':= 10 ' range=':= 5 ' type='normal' scaleTo='base' />
                     <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                    <Setting name='BranchLength' avg=':= 0.715 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                    <Setting name='BranchLength' avg=':= 0.604 * _default_ ' range=':= 1 * _default_ ' type='normal' />
                     <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                     <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='SegmentLength' avg=':= _default_ * vnlaDiamondSize ' range=':= _default_ * vnlaDiamondSize ' type='normal' />
                     <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                    <Setting name='SegmentRadius' avg=':= 0.715 * _default_ * vnlaDiamondSize ' range=':= 1 * _default_ * vnlaDiamondSize ' type='normal' />
+                    <Setting name='SegmentRadius' avg=':= 0.777 * _default_ * vnlaDiamondSize ' range=':= 1 * _default_ * vnlaDiamondSize ' type='normal' />
                     <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                 </Veins>
@@ -1066,8 +1066,8 @@
                     <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
                     <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                     <IfCondition condition=':= ?blockExists("minecraft:diamond_ore")'> <Replaces block='minecraft:diamond_ore' weight='1.0' /> </IfCondition>
-                    <Setting name='MotherlodeSize' avg=':= 0.715 * _default_ * vnlaDiamondSize  * 0.5 ' range=':= 1 * _default_ * vnlaDiamondSize  * 0.5 ' type='normal' />
-                    <Setting name='SegmentRadius' avg=':= 0.715 * _default_ * vnlaDiamondSize  * 0.5 ' range=':= 1 * _default_ * vnlaDiamondSize  * 0.5 ' type='normal' />
+                    <Setting name='MotherlodeSize' avg=':= 0 * _default_ * vnlaDiamondSize  * 0.5 ' range=':= 1 * _default_ * vnlaDiamondSize  * 0.5 ' type='normal' />
+                    <Setting name='SegmentRadius' avg=':= 0.777 * _default_ * vnlaDiamondSize  * 0.5 ' range=':= 1 * _default_ * vnlaDiamondSize  * 0.5 ' type='normal' />
                     <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
                 </Veins>
             </IfCondition>
@@ -1169,18 +1169,18 @@
                     <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                     <Biome name='.*'  />
                     <Setting name='MotherlodeFrequency' avg=':= 0.538 * _default_ * vnlaLapisLazuliFreq ' range=':= 1 * _default_ * vnlaLapisLazuliFreq ' type='normal' scaleTo='base' />
-                    <Setting name='MotherlodeSize' avg=':= 0.813 * _default_ * vnlaLapisLazuliSize ' range=':= 1 * _default_ * vnlaLapisLazuliSize ' type='normal' />
+                    <Setting name='MotherlodeSize' avg=':= 0 * _default_ * vnlaLapisLazuliSize ' range=':= 1 * _default_ * vnlaLapisLazuliSize ' type='normal' />
                     <Setting name='MotherlodeHeight' avg=':= 19 ' range=':= 14 ' type='normal' scaleTo='base' />
                     <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='BranchInclination' avg=':= -_default_ ' range=':= -_default_ ' type='normal' />
-                    <Setting name='BranchLength' avg=':= 0.813 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                    <Setting name='BranchLength' avg=':= 0.733 * _default_ ' range=':= 1 * _default_ ' type='normal' />
                     <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                     <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='SegmentLength' avg=':= _default_ * vnlaLapisLazuliSize ' range=':= _default_ * vnlaLapisLazuliSize ' type='normal' />
                     <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                    <Setting name='SegmentRadius' avg=':= 0.813 * _default_ * vnlaLapisLazuliSize ' range=':= 1 * _default_ * vnlaLapisLazuliSize ' type='normal' />
+                    <Setting name='SegmentRadius' avg=':= 0.856 * _default_ * vnlaLapisLazuliSize ' range=':= 1 * _default_ * vnlaLapisLazuliSize ' type='normal' />
                     <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                 </Veins>
@@ -1195,18 +1195,18 @@
                     <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                     <BiomeType name='Ocean'  />
                     <Setting name='MotherlodeFrequency' avg=':= 0.538 * _default_ * vnlaLapisLazuliFreq ' range=':= 1 * _default_ * vnlaLapisLazuliFreq ' type='normal' scaleTo='base' />
-                    <Setting name='MotherlodeSize' avg=':= 0.813 * _default_ * vnlaLapisLazuliSize ' range=':= 1 * _default_ * vnlaLapisLazuliSize ' type='normal' />
+                    <Setting name='MotherlodeSize' avg=':= 0 * _default_ * vnlaLapisLazuliSize ' range=':= 1 * _default_ * vnlaLapisLazuliSize ' type='normal' />
                     <Setting name='MotherlodeHeight' avg=':= 19 ' range=':= 14 ' type='normal' scaleTo='base' />
                     <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='BranchInclination' avg=':= -_default_ ' range=':= -_default_ ' type='normal' />
-                    <Setting name='BranchLength' avg=':= 0.813 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                    <Setting name='BranchLength' avg=':= 0.733 * _default_ ' range=':= 1 * _default_ ' type='normal' />
                     <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                     <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='SegmentLength' avg=':= _default_ * vnlaLapisLazuliSize ' range=':= _default_ * vnlaLapisLazuliSize ' type='normal' />
                     <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                    <Setting name='SegmentRadius' avg=':= 0.813 * _default_ * vnlaLapisLazuliSize ' range=':= 1 * _default_ * vnlaLapisLazuliSize ' type='normal' />
+                    <Setting name='SegmentRadius' avg=':= 0.856 * _default_ * vnlaLapisLazuliSize ' range=':= 1 * _default_ * vnlaLapisLazuliSize ' type='normal' />
                     <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                 </Veins>
@@ -1343,18 +1343,18 @@
                     <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                     <BiomeType name='Mountain'  />
                     <Setting name='MotherlodeFrequency' avg=':= 0.138 * _default_ * vnlaEmeraldFreq ' range=':= 1 * _default_ * vnlaEmeraldFreq ' type='normal' scaleTo='base' />
-                    <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * vnlaEmeraldSize ' range=':= 1 * _default_ * vnlaEmeraldSize ' type='normal' />
+                    <Setting name='MotherlodeSize' avg=':= 0 * _default_ * vnlaEmeraldSize ' range=':= 1 * _default_ * vnlaEmeraldSize ' type='normal' />
                     <Setting name='MotherlodeHeight' avg=':= 37 ' range=':= 14 ' type='normal' scaleTo='base' />
                     <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                    <Setting name='BranchLength' avg=':= 0.517 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                    <Setting name='BranchLength' avg=':= 0.371 * _default_ ' range=':= 1 * _default_ ' type='normal' />
                     <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                     <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='SegmentLength' avg=':= _default_ * vnlaEmeraldSize ' range=':= _default_ * vnlaEmeraldSize ' type='normal' />
                     <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                    <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * vnlaEmeraldSize ' range=':= 1 * _default_ * vnlaEmeraldSize ' type='normal' />
+                    <Setting name='SegmentRadius' avg=':= 0.609 * _default_ * vnlaEmeraldSize ' range=':= 1 * _default_ * vnlaEmeraldSize ' type='normal' />
                     <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                 </Veins>
@@ -1364,8 +1364,8 @@
                     <IfCondition condition=':= ?blockExists("minecraft:monster_egg")'> <OreBlock block='minecraft:monster_egg' weight='1.0' /> </IfCondition>
                     <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
                     <IfCondition condition=':= ?blockExists("minecraft:emerald_ore")'> <Replaces block='minecraft:emerald_ore' weight='1.0' /> </IfCondition>
-                    <Setting name='MotherlodeSize' avg=':= 0.517 * _default_ * vnlaEmeraldSize  * 0.5 ' range=':= 1 * _default_ * vnlaEmeraldSize  * 0.5 ' type='normal' />
-                    <Setting name='SegmentRadius' avg=':= 0.517 * _default_ * vnlaEmeraldSize  * 0.5 ' range=':= 1 * _default_ * vnlaEmeraldSize  * 0.5 ' type='normal' />
+                    <Setting name='MotherlodeSize' avg=':= 0 * _default_ * vnlaEmeraldSize  * 0.5 ' range=':= 1 * _default_ * vnlaEmeraldSize  * 0.5 ' type='normal' />
+                    <Setting name='SegmentRadius' avg=':= 0.609 * _default_ * vnlaEmeraldSize  * 0.5 ' range=':= 1 * _default_ * vnlaEmeraldSize  * 0.5 ' type='normal' />
                     <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
                 </Veins>
             </IfCondition>
@@ -1498,18 +1498,18 @@
                     <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
                     <Biome name='.*'  />
                     <Setting name='MotherlodeFrequency' avg=':= 5.049 * _default_ * vnlaNetherQuartzFreq ' range=':= 1 * _default_ * vnlaNetherQuartzFreq ' type='normal' scaleTo='base' />
-                    <Setting name='MotherlodeSize' avg=':= 1.716 * _default_ * vnlaNetherQuartzSize ' range=':= 1 * _default_ * vnlaNetherQuartzSize ' type='normal' />
+                    <Setting name='MotherlodeSize' avg=':= 0 * _default_ * vnlaNetherQuartzSize ' range=':= 1 * _default_ * vnlaNetherQuartzSize ' type='normal' />
                     <Setting name='MotherlodeHeight' avg=':= 68 ' range=':= 52 ' type='uniform' scaleTo='base' />
                     <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                    <Setting name='BranchLength' avg=':= 1.716 * _default_ ' range=':= 1 * _default_ ' type='normal' />
+                    <Setting name='BranchLength' avg=':= 2.247 * _default_ ' range=':= 1 * _default_ ' type='normal' />
                     <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                     <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='SegmentLength' avg=':= _default_ * vnlaNetherQuartzSize ' range=':= _default_ * vnlaNetherQuartzSize ' type='normal' />
                     <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                    <Setting name='SegmentRadius' avg=':= 1.716 * _default_ * vnlaNetherQuartzSize ' range=':= 1 * _default_ * vnlaNetherQuartzSize ' type='normal' />
+                    <Setting name='SegmentRadius' avg=':= 1.499 * _default_ * vnlaNetherQuartzSize ' range=':= 1 * _default_ * vnlaNetherQuartzSize ' type='normal' />
                     <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                 </Veins>


### PR DESCRIPTION
Thanks to some mathematical help from Keybounce, I've figured out how to make the distributions respect the square-cube law.  The Railcraft poor ores, in particular, are now actually under control for the first time.  The configurations generated by Sprocket are now closer to an accurate representation of the vanilla commonness.

Also overhauled configurations for Netherrocks and Tinker's Steelworks.