### PR TITLE
Uniform y>64 avg, TiC Ores fixed

### DIFF
--- a/src/main/resources/config/modules/Chisel2.xml
+++ b/src/main/resources/config/modules/Chisel2.xml
@@ -228,7 +228,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.002 * _default_ * chslAndesiteFreq ' range=':= 2.002 * _default_ * chslAndesiteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.123 * _default_ * chslAndesiteSize ' range=':= 1.123 * _default_ * chslAndesiteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -271,7 +271,7 @@
                             <Setting name='CloudRadius' avg=':= 1.323 * _default_ * chslAndesiteSize ' range=':= 1.323 * _default_ * chslAndesiteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.323 * _default_ * chslAndesiteSize ' range=':= 1.323 * _default_ * chslAndesiteSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.752 * _default_ * chslAndesiteFreq ' range=':= 1.752 * _default_ * chslAndesiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -326,7 +326,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.002 * _default_ * chslDioriteFreq ' range=':= 2.002 * _default_ * chslDioriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.123 * _default_ * chslDioriteSize ' range=':= 1.123 * _default_ * chslDioriteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -369,7 +369,7 @@
                             <Setting name='CloudRadius' avg=':= 1.323 * _default_ * chslDioriteSize ' range=':= 1.323 * _default_ * chslDioriteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.323 * _default_ * chslDioriteSize ' range=':= 1.323 * _default_ * chslDioriteSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.752 * _default_ * chslDioriteFreq ' range=':= 1.752 * _default_ * chslDioriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -424,7 +424,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.002 * _default_ * chslGraniteFreq ' range=':= 2.002 * _default_ * chslGraniteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.123 * _default_ * chslGraniteSize ' range=':= 1.123 * _default_ * chslGraniteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -467,7 +467,7 @@
                             <Setting name='CloudRadius' avg=':= 1.323 * _default_ * chslGraniteSize ' range=':= 1.323 * _default_ * chslGraniteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.323 * _default_ * chslGraniteSize ' range=':= 1.323 * _default_ * chslGraniteSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.752 * _default_ * chslGraniteFreq ' range=':= 1.752 * _default_ * chslGraniteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -522,7 +522,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.348 * _default_ * chslLimestoneFreq ' range=':= 2.348 * _default_ * chslLimestoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.153 * _default_ * chslLimestoneSize ' range=':= 1.153 * _default_ * chslLimestoneSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -565,7 +565,7 @@
                             <Setting name='CloudRadius' avg=':= 1.433 * _default_ * chslLimestoneSize ' range=':= 1.433 * _default_ * chslLimestoneSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.433 * _default_ * chslLimestoneSize ' range=':= 1.433 * _default_ * chslLimestoneSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 2.054 * _default_ * chslLimestoneFreq ' range=':= 2.054 * _default_ * chslLimestoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -620,7 +620,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.196 * _default_ * chslMarbleFreq ' range=':= 2.196 * _default_ * chslMarbleFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.140 * _default_ * chslMarbleSize ' range=':= 1.140 * _default_ * chslMarbleSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -663,7 +663,7 @@
                             <Setting name='CloudRadius' avg=':= 1.386 * _default_ * chslMarbleSize ' range=':= 1.386 * _default_ * chslMarbleSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.386 * _default_ * chslMarbleSize ' range=':= 1.386 * _default_ * chslMarbleSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.921 * _default_ * chslMarbleFreq ' range=':= 1.921 * _default_ * chslMarbleFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />

--- a/src/main/resources/config/modules/ElectriCraft.xml
+++ b/src/main/resources/config/modules/ElectriCraft.xml
@@ -765,7 +765,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.583 * _default_ * elcrAluminumFreq ' range=':= 1.583 * _default_ * elcrAluminumFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.080 * _default_ * elcrAluminumSize ' range=':= 1.080 * _default_ * elcrAluminumSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 94 ' range=':= 34 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 94 ' range=':= 34 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -797,7 +797,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 8.000 * elcrAluminumSize ' range=':= _default_ * elcrAluminumSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 10.000 * elcrAluminumFreq ' range=':= _default_ * elcrAluminumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 94 ' range=':= 34 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 94 ' range=':= 34 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -829,7 +829,7 @@
                             <Setting name='CloudRadius' avg=':= 1.177 * _default_ * elcrAluminumSize ' range=':= 1.177 * _default_ * elcrAluminumSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.177 * _default_ * elcrAluminumSize ' range=':= 1.177 * _default_ * elcrAluminumSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.385 * _default_ * elcrAluminumFreq ' range=':= 1.385 * _default_ * elcrAluminumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 94 ' range=':= 34 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 94 ' range=':= 34 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />

--- a/src/main/resources/config/modules/Forestry.xml
+++ b/src/main/resources/config/modules/Forestry.xml
@@ -188,7 +188,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.599 * _default_ * frstApatiteFreq ' range=':= 2.599 * _default_ * frstApatiteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * frstApatiteSize ' range=':= 0 * _default_ * frstApatiteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 120 ' range=':= 64 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 120 ' range=':= 64 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -231,7 +231,7 @@
                             <Setting name='CloudRadius' avg=':= 0.964 * _default_ * frstApatiteSize ' range=':= 0.964 * _default_ * frstApatiteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.964 * _default_ * frstApatiteSize ' range=':= 0.964 * _default_ * frstApatiteSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.929 * _default_ * frstApatiteFreq ' range=':= 0.929 * _default_ * frstApatiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 120 ' range=':= 64 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 120 ' range=':= 64 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -282,7 +282,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 36.000 * frstApatiteSize ' range=':= _default_ * frstApatiteSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 1.000 * frstApatiteFreq ' range=':= _default_ * frstApatiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 120 ' range=':= 64 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 120 ' range=':= 64 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -307,7 +307,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.938 * _default_ * frstCopperFreq ' range=':= 1.938 * _default_ * frstCopperFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.117 * _default_ * frstCopperSize ' range=':= 1.117 * _default_ * frstCopperSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 106 ' range=':= 74 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 106 ' range=':= 74 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -350,7 +350,7 @@
                             <Setting name='CloudRadius' avg=':= 1.302 * _default_ * frstCopperSize ' range=':= 1.302 * _default_ * frstCopperSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.302 * _default_ * frstCopperSize ' range=':= 1.302 * _default_ * frstCopperSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.696 * _default_ * frstCopperFreq ' range=':= 1.696 * _default_ * frstCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 106 ' range=':= 74 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 106 ' range=':= 74 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -401,7 +401,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 6.000 * frstCopperSize ' range=':= _default_ * frstCopperSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 20.000 * frstCopperFreq ' range=':= _default_ * frstCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 106 ' range=':= 74 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 106 ' range=':= 74 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -426,7 +426,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.839 * _default_ * frstTinFreq ' range=':= 1.839 * _default_ * frstTinFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.107 * _default_ * frstTinSize ' range=':= 1.107 * _default_ * frstTinSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 98 ' range=':= 82 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 98 ' range=':= 82 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -469,7 +469,7 @@
                             <Setting name='CloudRadius' avg=':= 1.268 * _default_ * frstTinSize ' range=':= 1.268 * _default_ * frstTinSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.268 * _default_ * frstTinSize ' range=':= 1.268 * _default_ * frstTinSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.609 * _default_ * frstTinFreq ' range=':= 1.609 * _default_ * frstTinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 98 ' range=':= 82 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 98 ' range=':= 82 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -520,7 +520,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 6.000 * frstTinSize ' range=':= _default_ * frstTinSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 18.000 * frstTinFreq ' range=':= _default_ * frstTinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 98 ' range=':= 82 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 98 ' range=':= 82 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>

--- a/src/main/resources/config/modules/GeoStrata.xml
+++ b/src/main/resources/config/modules/GeoStrata.xml
@@ -792,7 +792,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 4.904 * _default_ * gstaSandstoneFreq ' range=':= 4.904 * _default_ * gstaSandstoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.303 * _default_ * gstaSandstoneSize ' range=':= 1.303 * _default_ * gstaSandstoneSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 88 ' range=':= 40 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 88 ' range=':= 40 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -835,7 +835,7 @@
                             <Setting name='CloudRadius' avg=':= 2.071 * _default_ * gstaSandstoneSize ' range=':= 2.071 * _default_ * gstaSandstoneSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 2.071 * _default_ * gstaSandstoneSize ' range=':= 2.071 * _default_ * gstaSandstoneSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 4.291 * _default_ * gstaSandstoneFreq ' range=':= 4.291 * _default_ * gstaSandstoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 88 ' range=':= 40 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 88 ' range=':= 40 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -886,7 +886,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 32 * gstaSandstoneSize ' range=':= _default_ * gstaSandstoneSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 24.000 * gstaSandstoneFreq ' range=':= _default_ * gstaSandstoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 88 ' range=':= 40 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 88 ' range=':= 40 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -911,7 +911,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 4.904 * _default_ * gstaLimestoneFreq ' range=':= 4.904 * _default_ * gstaLimestoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.303 * _default_ * gstaLimestoneSize ' range=':= 1.303 * _default_ * gstaLimestoneSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 88 ' range=':= 40 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 88 ' range=':= 40 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -954,7 +954,7 @@
                             <Setting name='CloudRadius' avg=':= 2.071 * _default_ * gstaLimestoneSize ' range=':= 2.071 * _default_ * gstaLimestoneSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 2.071 * _default_ * gstaLimestoneSize ' range=':= 2.071 * _default_ * gstaLimestoneSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 4.291 * _default_ * gstaLimestoneFreq ' range=':= 4.291 * _default_ * gstaLimestoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 88 ' range=':= 40 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 88 ' range=':= 40 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1005,7 +1005,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 32 * gstaLimestoneSize ' range=':= _default_ * gstaLimestoneSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 24.000 * gstaLimestoneFreq ' range=':= _default_ * gstaLimestoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 88 ' range=':= 40 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 88 ' range=':= 40 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1982,7 +1982,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 4.904 * _default_ * gstaBasaltFreq ' range=':= 4.904 * _default_ * gstaBasaltFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.303 * _default_ * gstaBasaltSize ' range=':= 1.303 * _default_ * gstaBasaltSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 88 ' range=':= 40 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 88 ' range=':= 40 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2025,7 +2025,7 @@
                             <Setting name='CloudRadius' avg=':= 2.071 * _default_ * gstaBasaltSize ' range=':= 2.071 * _default_ * gstaBasaltSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 2.071 * _default_ * gstaBasaltSize ' range=':= 2.071 * _default_ * gstaBasaltSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 4.291 * _default_ * gstaBasaltFreq ' range=':= 4.291 * _default_ * gstaBasaltFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 88 ' range=':= 40 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 88 ' range=':= 40 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2076,7 +2076,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 32 * gstaBasaltSize ' range=':= _default_ * gstaBasaltSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 24.000 * gstaBasaltFreq ' range=':= _default_ * gstaBasaltFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 88 ' range=':= 40 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 88 ' range=':= 40 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>

--- a/src/main/resources/config/modules/Metallurgy4.xml
+++ b/src/main/resources/config/modules/Metallurgy4.xml
@@ -1304,7 +1304,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.733 * _default_ * mtlgSulfurFreq ' range=':= 1.733 * _default_ * mtlgSulfurFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * mtlgSulfurSize ' range=':= 0 * _default_ * mtlgSulfurSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1347,7 +1347,7 @@
                             <Setting name='CloudRadius' avg=':= 0.787 * _default_ * mtlgSulfurSize ' range=':= 0.787 * _default_ * mtlgSulfurSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.787 * _default_ * mtlgSulfurSize ' range=':= 0.787 * _default_ * mtlgSulfurSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.619 * _default_ * mtlgSulfurFreq ' range=':= 0.619 * _default_ * mtlgSulfurFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1398,7 +1398,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * mtlgSulfurSize ' range=':= _default_ * mtlgSulfurSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 4.000 * mtlgSulfurFreq ' range=':= _default_ * mtlgSulfurFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1430,7 +1430,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.733 * _default_ * mtlgPhosphoriteFreq ' range=':= 1.733 * _default_ * mtlgPhosphoriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * mtlgPhosphoriteSize ' range=':= 0 * _default_ * mtlgPhosphoriteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1473,7 +1473,7 @@
                             <Setting name='CloudRadius' avg=':= 0.787 * _default_ * mtlgPhosphoriteSize ' range=':= 0.787 * _default_ * mtlgPhosphoriteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.787 * _default_ * mtlgPhosphoriteSize ' range=':= 0.787 * _default_ * mtlgPhosphoriteSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.619 * _default_ * mtlgPhosphoriteFreq ' range=':= 0.619 * _default_ * mtlgPhosphoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1524,7 +1524,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * mtlgPhosphoriteSize ' range=':= _default_ * mtlgPhosphoriteSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 4.000 * mtlgPhosphoriteFreq ' range=':= _default_ * mtlgPhosphoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1556,7 +1556,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.733 * _default_ * mtlgSaltpeterFreq ' range=':= 1.733 * _default_ * mtlgSaltpeterFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * mtlgSaltpeterSize ' range=':= 0 * _default_ * mtlgSaltpeterSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1599,7 +1599,7 @@
                             <Setting name='CloudRadius' avg=':= 0.787 * _default_ * mtlgSaltpeterSize ' range=':= 0.787 * _default_ * mtlgSaltpeterSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.787 * _default_ * mtlgSaltpeterSize ' range=':= 0.787 * _default_ * mtlgSaltpeterSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.619 * _default_ * mtlgSaltpeterFreq ' range=':= 0.619 * _default_ * mtlgSaltpeterFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1650,7 +1650,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * mtlgSaltpeterSize ' range=':= _default_ * mtlgSaltpeterSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 4.000 * mtlgSaltpeterFreq ' range=':= _default_ * mtlgSaltpeterFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1682,7 +1682,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.733 * _default_ * mtlgMagnesiumFreq ' range=':= 1.733 * _default_ * mtlgMagnesiumFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * mtlgMagnesiumSize ' range=':= 0 * _default_ * mtlgMagnesiumSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1725,7 +1725,7 @@
                             <Setting name='CloudRadius' avg=':= 0.787 * _default_ * mtlgMagnesiumSize ' range=':= 0.787 * _default_ * mtlgMagnesiumSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.787 * _default_ * mtlgMagnesiumSize ' range=':= 0.787 * _default_ * mtlgMagnesiumSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.619 * _default_ * mtlgMagnesiumFreq ' range=':= 0.619 * _default_ * mtlgMagnesiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1776,7 +1776,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * mtlgMagnesiumSize ' range=':= _default_ * mtlgMagnesiumSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 4.000 * mtlgMagnesiumFreq ' range=':= _default_ * mtlgMagnesiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1808,7 +1808,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.733 * _default_ * mtlgBitumenFreq ' range=':= 1.733 * _default_ * mtlgBitumenFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * mtlgBitumenSize ' range=':= 0 * _default_ * mtlgBitumenSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1851,7 +1851,7 @@
                             <Setting name='CloudRadius' avg=':= 0.787 * _default_ * mtlgBitumenSize ' range=':= 0.787 * _default_ * mtlgBitumenSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.787 * _default_ * mtlgBitumenSize ' range=':= 0.787 * _default_ * mtlgBitumenSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.619 * _default_ * mtlgBitumenFreq ' range=':= 0.619 * _default_ * mtlgBitumenFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1902,7 +1902,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * mtlgBitumenSize ' range=':= _default_ * mtlgBitumenSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 4.000 * mtlgBitumenFreq ' range=':= _default_ * mtlgBitumenFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1934,7 +1934,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.733 * _default_ * mtlgPotashFreq ' range=':= 1.733 * _default_ * mtlgPotashFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * mtlgPotashSize ' range=':= 0 * _default_ * mtlgPotashSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1977,7 +1977,7 @@
                             <Setting name='CloudRadius' avg=':= 0.787 * _default_ * mtlgPotashSize ' range=':= 0.787 * _default_ * mtlgPotashSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.787 * _default_ * mtlgPotashSize ' range=':= 0.787 * _default_ * mtlgPotashSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.619 * _default_ * mtlgPotashFreq ' range=':= 0.619 * _default_ * mtlgPotashFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2028,7 +2028,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * mtlgPotashSize ' range=':= _default_ * mtlgPotashSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 4.000 * mtlgPotashFreq ' range=':= _default_ * mtlgPotashFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -2053,7 +2053,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.501 * _default_ * mtlgCopperFreq ' range=':= 1.501 * _default_ * mtlgCopperFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.070 * _default_ * mtlgCopperSize ' range=':= 1.070 * _default_ * mtlgCopperSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2096,7 +2096,7 @@
                             <Setting name='CloudRadius' avg=':= 1.146 * _default_ * mtlgCopperSize ' range=':= 1.146 * _default_ * mtlgCopperSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.146 * _default_ * mtlgCopperSize ' range=':= 1.146 * _default_ * mtlgCopperSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.314 * _default_ * mtlgCopperFreq ' range=':= 1.314 * _default_ * mtlgCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2147,7 +2147,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 6.000 * mtlgCopperSize ' range=':= _default_ * mtlgCopperSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 12.000 * mtlgCopperFreq ' range=':= _default_ * mtlgCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -2172,7 +2172,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.480 * _default_ * mtlgTinFreq ' range=':= 1.480 * _default_ * mtlgTinFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.068 * _default_ * mtlgTinSize ' range=':= 1.068 * _default_ * mtlgTinSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2215,7 +2215,7 @@
                             <Setting name='CloudRadius' avg=':= 1.138 * _default_ * mtlgTinSize ' range=':= 1.138 * _default_ * mtlgTinSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.138 * _default_ * mtlgTinSize ' range=':= 1.138 * _default_ * mtlgTinSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.295 * _default_ * mtlgTinFreq ' range=':= 1.295 * _default_ * mtlgTinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2266,7 +2266,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 10.000 * mtlgTinSize ' range=':= _default_ * mtlgTinSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 7.000 * mtlgTinFreq ' range=':= _default_ * mtlgTinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -2291,7 +2291,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.791 * _default_ * mtlgManganeseFreq ' range=':= 0.791 * _default_ * mtlgManganeseFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.962 * _default_ * mtlgManganeseSize ' range=':= 0.962 * _default_ * mtlgManganeseSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2334,7 +2334,7 @@
                             <Setting name='CloudRadius' avg=':= 0.832 * _default_ * mtlgManganeseSize ' range=':= 0.832 * _default_ * mtlgManganeseSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.832 * _default_ * mtlgManganeseSize ' range=':= 0.832 * _default_ * mtlgManganeseSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.692 * _default_ * mtlgManganeseFreq ' range=':= 0.692 * _default_ * mtlgManganeseFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2385,7 +2385,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * mtlgManganeseSize ' range=':= _default_ * mtlgManganeseSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 5.000 * mtlgManganeseFreq ' range=':= _default_ * mtlgManganeseFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -2410,7 +2410,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * mtlgZincFreq ' range=':= 0.969 * _default_ * mtlgZincFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.995 * _default_ * mtlgZincSize ' range=':= 0.995 * _default_ * mtlgZincSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2453,7 +2453,7 @@
                             <Setting name='CloudRadius' avg=':= 0.921 * _default_ * mtlgZincSize ' range=':= 0.921 * _default_ * mtlgZincSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.921 * _default_ * mtlgZincSize ' range=':= 0.921 * _default_ * mtlgZincSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.848 * _default_ * mtlgZincFreq ' range=':= 0.848 * _default_ * mtlgZincFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2504,7 +2504,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 5.000 * mtlgZincSize ' range=':= _default_ * mtlgZincSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 6.000 * mtlgZincFreq ' range=':= _default_ * mtlgZincFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -2529,7 +2529,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * mtlgSilverFreq ' range=':= 0.969 * _default_ * mtlgSilverFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.995 * _default_ * mtlgSilverSize ' range=':= 0.995 * _default_ * mtlgSilverSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2572,7 +2572,7 @@
                             <Setting name='CloudRadius' avg=':= 0.921 * _default_ * mtlgSilverSize ' range=':= 0.921 * _default_ * mtlgSilverSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.921 * _default_ * mtlgSilverSize ' range=':= 0.921 * _default_ * mtlgSilverSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.848 * _default_ * mtlgSilverFreq ' range=':= 0.848 * _default_ * mtlgSilverFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2623,7 +2623,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 5.000 * mtlgSilverSize ' range=':= _default_ * mtlgSilverSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 6.000 * mtlgSilverFreq ' range=':= _default_ * mtlgSilverFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -2648,7 +2648,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.531 * _default_ * mtlgPlatinumFreq ' range=':= 0.531 * _default_ * mtlgPlatinumFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.900 * _default_ * mtlgPlatinumSize ' range=':= 0.900 * _default_ * mtlgPlatinumSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2691,7 +2691,7 @@
                             <Setting name='CloudRadius' avg=':= 0.682 * _default_ * mtlgPlatinumSize ' range=':= 0.682 * _default_ * mtlgPlatinumSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.682 * _default_ * mtlgPlatinumSize ' range=':= 0.682 * _default_ * mtlgPlatinumSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.464 * _default_ * mtlgPlatinumFreq ' range=':= 0.464 * _default_ * mtlgPlatinumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2742,7 +2742,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.000 * mtlgPlatinumSize ' range=':= _default_ * mtlgPlatinumSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 3.000 * mtlgPlatinumFreq ' range=':= _default_ * mtlgPlatinumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -2767,7 +2767,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * mtlgPromethiumFreq ' range=':= 0.969 * _default_ * mtlgPromethiumFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.995 * _default_ * mtlgPromethiumSize ' range=':= 0.995 * _default_ * mtlgPromethiumSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2810,7 +2810,7 @@
                             <Setting name='CloudRadius' avg=':= 0.921 * _default_ * mtlgPromethiumSize ' range=':= 0.921 * _default_ * mtlgPromethiumSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.921 * _default_ * mtlgPromethiumSize ' range=':= 0.921 * _default_ * mtlgPromethiumSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.848 * _default_ * mtlgPromethiumFreq ' range=':= 0.848 * _default_ * mtlgPromethiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2861,7 +2861,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 6.000 * mtlgPromethiumSize ' range=':= _default_ * mtlgPromethiumSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 5.000 * mtlgPromethiumFreq ' range=':= _default_ * mtlgPromethiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -2886,7 +2886,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.791 * _default_ * mtlgDeepIronFreq ' range=':= 0.791 * _default_ * mtlgDeepIronFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.962 * _default_ * mtlgDeepIronSize ' range=':= 0.962 * _default_ * mtlgDeepIronSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2929,7 +2929,7 @@
                             <Setting name='CloudRadius' avg=':= 0.832 * _default_ * mtlgDeepIronSize ' range=':= 0.832 * _default_ * mtlgDeepIronSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.832 * _default_ * mtlgDeepIronSize ' range=':= 0.832 * _default_ * mtlgDeepIronSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.692 * _default_ * mtlgDeepIronFreq ' range=':= 0.692 * _default_ * mtlgDeepIronFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2980,7 +2980,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * mtlgDeepIronSize ' range=':= _default_ * mtlgDeepIronSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 5.000 * mtlgDeepIronFreq ' range=':= _default_ * mtlgDeepIronFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -3005,7 +3005,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.791 * _default_ * mtlgInfuscoliumFreq ' range=':= 0.791 * _default_ * mtlgInfuscoliumFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.962 * _default_ * mtlgInfuscoliumSize ' range=':= 0.962 * _default_ * mtlgInfuscoliumSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3048,7 +3048,7 @@
                             <Setting name='CloudRadius' avg=':= 0.832 * _default_ * mtlgInfuscoliumSize ' range=':= 0.832 * _default_ * mtlgInfuscoliumSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.832 * _default_ * mtlgInfuscoliumSize ' range=':= 0.832 * _default_ * mtlgInfuscoliumSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.692 * _default_ * mtlgInfuscoliumFreq ' range=':= 0.692 * _default_ * mtlgInfuscoliumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3099,7 +3099,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * mtlgInfuscoliumSize ' range=':= _default_ * mtlgInfuscoliumSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 5.000 * mtlgInfuscoliumFreq ' range=':= _default_ * mtlgInfuscoliumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -3124,7 +3124,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.613 * _default_ * mtlgOureclaseFreq ' range=':= 0.613 * _default_ * mtlgOureclaseFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * mtlgOureclaseSize ' range=':= 0.922 * _default_ * mtlgOureclaseSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3167,7 +3167,7 @@
                             <Setting name='CloudRadius' avg=':= 0.732 * _default_ * mtlgOureclaseSize ' range=':= 0.732 * _default_ * mtlgOureclaseSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.732 * _default_ * mtlgOureclaseSize ' range=':= 0.732 * _default_ * mtlgOureclaseSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.536 * _default_ * mtlgOureclaseFreq ' range=':= 0.536 * _default_ * mtlgOureclaseFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3218,7 +3218,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.000 * mtlgOureclaseSize ' range=':= _default_ * mtlgOureclaseSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 4.000 * mtlgOureclaseFreq ' range=':= _default_ * mtlgOureclaseFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -3243,7 +3243,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.613 * _default_ * mtlgAstralSilverFreq ' range=':= 0.613 * _default_ * mtlgAstralSilverFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * mtlgAstralSilverSize ' range=':= 0.922 * _default_ * mtlgAstralSilverSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3287,7 +3287,7 @@
                             <Setting name='CloudRadius' avg=':= 0.732 * _default_ * mtlgAstralSilverSize ' range=':= 0.732 * _default_ * mtlgAstralSilverSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.732 * _default_ * mtlgAstralSilverSize ' range=':= 0.732 * _default_ * mtlgAstralSilverSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.536 * _default_ * mtlgAstralSilverFreq ' range=':= 0.536 * _default_ * mtlgAstralSilverFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3338,7 +3338,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.000 * mtlgAstralSilverSize ' range=':= _default_ * mtlgAstralSilverSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 4.000 * mtlgAstralSilverFreq ' range=':= _default_ * mtlgAstralSilverFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -3363,7 +3363,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.531 * _default_ * mtlgCarmotFreq ' range=':= 0.531 * _default_ * mtlgCarmotFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.900 * _default_ * mtlgCarmotSize ' range=':= 0.900 * _default_ * mtlgCarmotSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3406,7 +3406,7 @@
                             <Setting name='CloudRadius' avg=':= 0.682 * _default_ * mtlgCarmotSize ' range=':= 0.682 * _default_ * mtlgCarmotSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.682 * _default_ * mtlgCarmotSize ' range=':= 0.682 * _default_ * mtlgCarmotSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.464 * _default_ * mtlgCarmotFreq ' range=':= 0.464 * _default_ * mtlgCarmotFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3457,7 +3457,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.000 * mtlgCarmotSize ' range=':= _default_ * mtlgCarmotSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 3.000 * mtlgCarmotFreq ' range=':= _default_ * mtlgCarmotFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -3482,7 +3482,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.531 * _default_ * mtlgMithrilFreq ' range=':= 0.531 * _default_ * mtlgMithrilFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.900 * _default_ * mtlgMithrilSize ' range=':= 0.900 * _default_ * mtlgMithrilSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3525,7 +3525,7 @@
                             <Setting name='CloudRadius' avg=':= 0.682 * _default_ * mtlgMithrilSize ' range=':= 0.682 * _default_ * mtlgMithrilSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.682 * _default_ * mtlgMithrilSize ' range=':= 0.682 * _default_ * mtlgMithrilSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.464 * _default_ * mtlgMithrilFreq ' range=':= 0.464 * _default_ * mtlgMithrilFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3576,7 +3576,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.000 * mtlgMithrilSize ' range=':= _default_ * mtlgMithrilSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 3.000 * mtlgMithrilFreq ' range=':= _default_ * mtlgMithrilFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -3601,7 +3601,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.433 * _default_ * mtlgRubraciumFreq ' range=':= 0.433 * _default_ * mtlgRubraciumFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.870 * _default_ * mtlgRubraciumSize ' range=':= 0.870 * _default_ * mtlgRubraciumSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3644,7 +3644,7 @@
                             <Setting name='CloudRadius' avg=':= 0.616 * _default_ * mtlgRubraciumSize ' range=':= 0.616 * _default_ * mtlgRubraciumSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.616 * _default_ * mtlgRubraciumSize ' range=':= 0.616 * _default_ * mtlgRubraciumSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.379 * _default_ * mtlgRubraciumFreq ' range=':= 0.379 * _default_ * mtlgRubraciumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3695,7 +3695,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.000 * mtlgRubraciumSize ' range=':= _default_ * mtlgRubraciumSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 2.000 * mtlgRubraciumFreq ' range=':= _default_ * mtlgRubraciumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -3720,7 +3720,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.500 * _default_ * mtlgOrichalcumFreq ' range=':= 0.500 * _default_ * mtlgOrichalcumFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.891 * _default_ * mtlgOrichalcumSize ' range=':= 0.891 * _default_ * mtlgOrichalcumSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3763,7 +3763,7 @@
                             <Setting name='CloudRadius' avg=':= 0.662 * _default_ * mtlgOrichalcumSize ' range=':= 0.662 * _default_ * mtlgOrichalcumSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.662 * _default_ * mtlgOrichalcumSize ' range=':= 0.662 * _default_ * mtlgOrichalcumSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.438 * _default_ * mtlgOrichalcumFreq ' range=':= 0.438 * _default_ * mtlgOrichalcumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3814,7 +3814,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * mtlgOrichalcumSize ' range=':= _default_ * mtlgOrichalcumSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 2.000 * mtlgOrichalcumFreq ' range=':= _default_ * mtlgOrichalcumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -3839,7 +3839,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.433 * _default_ * mtlgAdamantineFreq ' range=':= 0.433 * _default_ * mtlgAdamantineFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.870 * _default_ * mtlgAdamantineSize ' range=':= 0.870 * _default_ * mtlgAdamantineSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3882,7 +3882,7 @@
                             <Setting name='CloudRadius' avg=':= 0.616 * _default_ * mtlgAdamantineSize ' range=':= 0.616 * _default_ * mtlgAdamantineSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.616 * _default_ * mtlgAdamantineSize ' range=':= 0.616 * _default_ * mtlgAdamantineSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.379 * _default_ * mtlgAdamantineFreq ' range=':= 0.379 * _default_ * mtlgAdamantineFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3933,7 +3933,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.000 * mtlgAdamantineSize ' range=':= _default_ * mtlgAdamantineSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 2.000 * mtlgAdamantineFreq ' range=':= _default_ * mtlgAdamantineFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -3958,7 +3958,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.433 * _default_ * mtlgAtlarusFreq ' range=':= 0.433 * _default_ * mtlgAtlarusFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.870 * _default_ * mtlgAtlarusSize ' range=':= 0.870 * _default_ * mtlgAtlarusSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4001,7 +4001,7 @@
                             <Setting name='CloudRadius' avg=':= 0.616 * _default_ * mtlgAtlarusSize ' range=':= 0.616 * _default_ * mtlgAtlarusSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.616 * _default_ * mtlgAtlarusSize ' range=':= 0.616 * _default_ * mtlgAtlarusSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.379 * _default_ * mtlgAtlarusFreq ' range=':= 0.379 * _default_ * mtlgAtlarusFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4052,7 +4052,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.000 * mtlgAtlarusSize ' range=':= _default_ * mtlgAtlarusSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 2.000 * mtlgAtlarusFreq ' range=':= _default_ * mtlgAtlarusFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -4118,7 +4118,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.300 * _default_ * mtlgIgnatiusFreq ' range=':= 1.300 * _default_ * mtlgIgnatiusFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.045 * _default_ * mtlgIgnatiusSize ' range=':= 1.045 * _default_ * mtlgIgnatiusSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4161,7 +4161,7 @@
                             <Setting name='CloudRadius' avg=':= 1.067 * _default_ * mtlgIgnatiusSize ' range=':= 1.067 * _default_ * mtlgIgnatiusSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.067 * _default_ * mtlgIgnatiusSize ' range=':= 1.067 * _default_ * mtlgIgnatiusSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.138 * _default_ * mtlgIgnatiusFreq ' range=':= 1.138 * _default_ * mtlgIgnatiusFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4212,7 +4212,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 6.000 * mtlgIgnatiusSize ' range=':= _default_ * mtlgIgnatiusSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 9.000 * mtlgIgnatiusFreq ' range=':= _default_ * mtlgIgnatiusFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -4237,7 +4237,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.147 * _default_ * mtlgShadowIronFreq ' range=':= 1.147 * _default_ * mtlgShadowIronFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.023 * _default_ * mtlgShadowIronSize ' range=':= 1.023 * _default_ * mtlgShadowIronSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4280,7 +4280,7 @@
                             <Setting name='CloudRadius' avg=':= 1.002 * _default_ * mtlgShadowIronSize ' range=':= 1.002 * _default_ * mtlgShadowIronSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.002 * _default_ * mtlgShadowIronSize ' range=':= 1.002 * _default_ * mtlgShadowIronSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.003 * _default_ * mtlgShadowIronFreq ' range=':= 1.003 * _default_ * mtlgShadowIronFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4331,7 +4331,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 6.000 * mtlgShadowIronSize ' range=':= _default_ * mtlgShadowIronSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 7.000 * mtlgShadowIronFreq ' range=':= _default_ * mtlgShadowIronFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -4356,7 +4356,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.062 * _default_ * mtlgLemuriteFreq ' range=':= 1.062 * _default_ * mtlgLemuriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.010 * _default_ * mtlgLemuriteSize ' range=':= 1.010 * _default_ * mtlgLemuriteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4399,7 +4399,7 @@
                             <Setting name='CloudRadius' avg=':= 0.964 * _default_ * mtlgLemuriteSize ' range=':= 0.964 * _default_ * mtlgLemuriteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.964 * _default_ * mtlgLemuriteSize ' range=':= 0.964 * _default_ * mtlgLemuriteSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.929 * _default_ * mtlgLemuriteFreq ' range=':= 0.929 * _default_ * mtlgLemuriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4450,7 +4450,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 6.000 * mtlgLemuriteSize ' range=':= _default_ * mtlgLemuriteSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 6.000 * mtlgLemuriteFreq ' range=':= _default_ * mtlgLemuriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -4475,7 +4475,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * mtlgMidasiumFreq ' range=':= 0.969 * _default_ * mtlgMidasiumFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.995 * _default_ * mtlgMidasiumSize ' range=':= 0.995 * _default_ * mtlgMidasiumSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4518,7 +4518,7 @@
                             <Setting name='CloudRadius' avg=':= 0.921 * _default_ * mtlgMidasiumSize ' range=':= 0.921 * _default_ * mtlgMidasiumSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.921 * _default_ * mtlgMidasiumSize ' range=':= 0.921 * _default_ * mtlgMidasiumSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.848 * _default_ * mtlgMidasiumFreq ' range=':= 0.848 * _default_ * mtlgMidasiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4569,7 +4569,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 6.000 * mtlgMidasiumSize ' range=':= _default_ * mtlgMidasiumSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 5.000 * mtlgMidasiumFreq ' range=':= _default_ * mtlgMidasiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -4594,7 +4594,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.936 * _default_ * mtlgVyroxeresFreq ' range=':= 0.936 * _default_ * mtlgVyroxeresFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.989 * _default_ * mtlgVyroxeresSize ' range=':= 0.989 * _default_ * mtlgVyroxeresSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4637,7 +4637,7 @@
                             <Setting name='CloudRadius' avg=':= 0.905 * _default_ * mtlgVyroxeresSize ' range=':= 0.905 * _default_ * mtlgVyroxeresSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.905 * _default_ * mtlgVyroxeresSize ' range=':= 0.905 * _default_ * mtlgVyroxeresSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.819 * _default_ * mtlgVyroxeresFreq ' range=':= 0.819 * _default_ * mtlgVyroxeresFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4688,7 +4688,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 7.000 * mtlgVyroxeresSize ' range=':= _default_ * mtlgVyroxeresSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 4.000 * mtlgVyroxeresFreq ' range=':= _default_ * mtlgVyroxeresFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -4713,7 +4713,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.708 * _default_ * mtlgCeruclaseFreq ' range=':= 0.708 * _default_ * mtlgCeruclaseFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.944 * _default_ * mtlgCeruclaseSize ' range=':= 0.944 * _default_ * mtlgCeruclaseSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4756,7 +4756,7 @@
                             <Setting name='CloudRadius' avg=':= 0.787 * _default_ * mtlgCeruclaseSize ' range=':= 0.787 * _default_ * mtlgCeruclaseSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.787 * _default_ * mtlgCeruclaseSize ' range=':= 0.787 * _default_ * mtlgCeruclaseSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.619 * _default_ * mtlgCeruclaseFreq ' range=':= 0.619 * _default_ * mtlgCeruclaseFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4807,7 +4807,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * mtlgCeruclaseSize ' range=':= _default_ * mtlgCeruclaseSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 4.000 * mtlgCeruclaseFreq ' range=':= _default_ * mtlgCeruclaseFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -4832,7 +4832,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.613 * _default_ * mtlgAlduoriteFreq ' range=':= 0.613 * _default_ * mtlgAlduoriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * mtlgAlduoriteSize ' range=':= 0.922 * _default_ * mtlgAlduoriteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4875,7 +4875,7 @@
                             <Setting name='CloudRadius' avg=':= 0.732 * _default_ * mtlgAlduoriteSize ' range=':= 0.732 * _default_ * mtlgAlduoriteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.732 * _default_ * mtlgAlduoriteSize ' range=':= 0.732 * _default_ * mtlgAlduoriteSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.536 * _default_ * mtlgAlduoriteFreq ' range=':= 0.536 * _default_ * mtlgAlduoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4926,7 +4926,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * mtlgAlduoriteSize ' range=':= _default_ * mtlgAlduoriteSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 3.000 * mtlgAlduoriteFreq ' range=':= _default_ * mtlgAlduoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -4951,7 +4951,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.613 * _default_ * mtlgKalendriteFreq ' range=':= 0.613 * _default_ * mtlgKalendriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * mtlgKalendriteSize ' range=':= 0.922 * _default_ * mtlgKalendriteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4994,7 +4994,7 @@
                             <Setting name='CloudRadius' avg=':= 0.732 * _default_ * mtlgKalendriteSize ' range=':= 0.732 * _default_ * mtlgKalendriteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.732 * _default_ * mtlgKalendriteSize ' range=':= 0.732 * _default_ * mtlgKalendriteSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.536 * _default_ * mtlgKalendriteFreq ' range=':= 0.536 * _default_ * mtlgKalendriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -5045,7 +5045,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * mtlgKalendriteSize ' range=':= _default_ * mtlgKalendriteSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 3.000 * mtlgKalendriteFreq ' range=':= _default_ * mtlgKalendriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -5070,7 +5070,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.433 * _default_ * mtlgVulcaniteFreq ' range=':= 0.433 * _default_ * mtlgVulcaniteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.870 * _default_ * mtlgVulcaniteSize ' range=':= 0.870 * _default_ * mtlgVulcaniteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -5113,7 +5113,7 @@
                             <Setting name='CloudRadius' avg=':= 0.616 * _default_ * mtlgVulcaniteSize ' range=':= 0.616 * _default_ * mtlgVulcaniteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.616 * _default_ * mtlgVulcaniteSize ' range=':= 0.616 * _default_ * mtlgVulcaniteSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.379 * _default_ * mtlgVulcaniteFreq ' range=':= 0.379 * _default_ * mtlgVulcaniteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -5164,7 +5164,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.000 * mtlgVulcaniteSize ' range=':= _default_ * mtlgVulcaniteSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 2.000 * mtlgVulcaniteFreq ' range=':= _default_ * mtlgVulcaniteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -5189,7 +5189,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.433 * _default_ * mtlgSanguiniteFreq ' range=':= 0.433 * _default_ * mtlgSanguiniteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.870 * _default_ * mtlgSanguiniteSize ' range=':= 0.870 * _default_ * mtlgSanguiniteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -5232,7 +5232,7 @@
                             <Setting name='CloudRadius' avg=':= 0.616 * _default_ * mtlgSanguiniteSize ' range=':= 0.616 * _default_ * mtlgSanguiniteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.616 * _default_ * mtlgSanguiniteSize ' range=':= 0.616 * _default_ * mtlgSanguiniteSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.379 * _default_ * mtlgSanguiniteFreq ' range=':= 0.379 * _default_ * mtlgSanguiniteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -5283,7 +5283,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.000 * mtlgSanguiniteSize ' range=':= _default_ * mtlgSanguiniteSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 2.000 * mtlgSanguiniteFreq ' range=':= _default_ * mtlgSanguiniteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -5341,7 +5341,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.867 * _default_ * mtlgEximiteFreq ' range=':= 0.867 * _default_ * mtlgEximiteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.976 * _default_ * mtlgEximiteSize ' range=':= 0.976 * _default_ * mtlgEximiteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -5384,7 +5384,7 @@
                             <Setting name='CloudRadius' avg=':= 0.871 * _default_ * mtlgEximiteSize ' range=':= 0.871 * _default_ * mtlgEximiteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.871 * _default_ * mtlgEximiteSize ' range=':= 0.871 * _default_ * mtlgEximiteSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.758 * _default_ * mtlgEximiteFreq ' range=':= 0.758 * _default_ * mtlgEximiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -5435,7 +5435,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * mtlgEximiteSize ' range=':= _default_ * mtlgEximiteSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 6.000 * mtlgEximiteFreq ' range=':= _default_ * mtlgEximiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -5460,7 +5460,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.531 * _default_ * mtlgMeutoiteFreq ' range=':= 0.531 * _default_ * mtlgMeutoiteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.900 * _default_ * mtlgMeutoiteSize ' range=':= 0.900 * _default_ * mtlgMeutoiteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -5503,7 +5503,7 @@
                             <Setting name='CloudRadius' avg=':= 0.682 * _default_ * mtlgMeutoiteSize ' range=':= 0.682 * _default_ * mtlgMeutoiteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.682 * _default_ * mtlgMeutoiteSize ' range=':= 0.682 * _default_ * mtlgMeutoiteSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.464 * _default_ * mtlgMeutoiteFreq ' range=':= 0.464 * _default_ * mtlgMeutoiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -5554,7 +5554,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.000 * mtlgMeutoiteSize ' range=':= _default_ * mtlgMeutoiteSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 3.000 * mtlgMeutoiteFreq ' range=':= _default_ * mtlgMeutoiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>

--- a/src/main/resources/config/modules/NetherOres.xml
+++ b/src/main/resources/config/modules/NetherOres.xml
@@ -1208,7 +1208,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 4.900 * _default_ * nthoCoalFreq ' range=':= 4.900 * _default_ * nthoCoalFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoCoalSize ' range=':= 0 * _default_ * nthoCoalSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1251,7 +1251,7 @@
                             <Setting name='CloudRadius' avg=':= 1.323 * _default_ * nthoCoalSize ' range=':= 1.323 * _default_ * nthoCoalSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.323 * _default_ * nthoCoalSize ' range=':= 1.323 * _default_ * nthoCoalSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.752 * _default_ * nthoCoalFreq ' range=':= 1.752 * _default_ * nthoCoalFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1302,7 +1302,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 16.000 * nthoCoalSize ' range=':= _default_ * nthoCoalSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 8.000 * nthoCoalFreq ' range=':= _default_ * nthoCoalFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1327,7 +1327,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.935 * _default_ * nthoDiamondFreq ' range=':= 0.935 * _default_ * nthoDiamondFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoDiamondSize ' range=':= 0 * _default_ * nthoDiamondSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1380,7 +1380,7 @@
                             <Setting name='CloudRadius' avg=':= 0.732 * _default_ * nthoDiamondSize ' range=':= 0.732 * _default_ * nthoDiamondSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.732 * _default_ * nthoDiamondSize ' range=':= 0.732 * _default_ * nthoDiamondSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.536 * _default_ * nthoDiamondFreq ' range=':= 0.536 * _default_ * nthoDiamondFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1431,7 +1431,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.000 * nthoDiamondSize ' range=':= _default_ * nthoDiamondSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 4.000 * nthoDiamondFreq ' range=':= _default_ * nthoDiamondFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1456,7 +1456,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.226 * _default_ * nthoGoldFreq ' range=':= 1.226 * _default_ * nthoGoldFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.035 * _default_ * nthoGoldSize ' range=':= 1.035 * _default_ * nthoGoldSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1499,7 +1499,7 @@
                             <Setting name='CloudRadius' avg=':= 1.036 * _default_ * nthoGoldSize ' range=':= 1.036 * _default_ * nthoGoldSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.036 * _default_ * nthoGoldSize ' range=':= 1.036 * _default_ * nthoGoldSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.073 * _default_ * nthoGoldFreq ' range=':= 1.073 * _default_ * nthoGoldFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1550,7 +1550,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 6.000 * nthoGoldSize ' range=':= _default_ * nthoGoldSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 8.000 * nthoGoldFreq ' range=':= _default_ * nthoGoldFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1575,7 +1575,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.416 * _default_ * nthoIronFreq ' range=':= 1.416 * _default_ * nthoIronFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.060 * _default_ * nthoIronSize ' range=':= 1.060 * _default_ * nthoIronSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1618,7 +1618,7 @@
                             <Setting name='CloudRadius' avg=':= 1.113 * _default_ * nthoIronSize ' range=':= 1.113 * _default_ * nthoIronSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.113 * _default_ * nthoIronSize ' range=':= 1.113 * _default_ * nthoIronSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.239 * _default_ * nthoIronFreq ' range=':= 1.239 * _default_ * nthoIronFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1669,7 +1669,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 8.000 * nthoIronSize ' range=':= _default_ * nthoIronSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 8.000 * nthoIronFreq ' range=':= _default_ * nthoIronFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1694,7 +1694,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.929 * _default_ * nthoLapisLazuliFreq ' range=':= 1.929 * _default_ * nthoLapisLazuliFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoLapisLazuliSize ' range=':= 0 * _default_ * nthoLapisLazuliSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1738,7 +1738,7 @@
                             <Setting name='CloudRadius' avg=':= 0.964 * _default_ * nthoLapisLazuliSize ' range=':= 0.964 * _default_ * nthoLapisLazuliSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.964 * _default_ * nthoLapisLazuliSize ' range=':= 0.964 * _default_ * nthoLapisLazuliSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.929 * _default_ * nthoLapisLazuliFreq ' range=':= 0.929 * _default_ * nthoLapisLazuliFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1789,7 +1789,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 6.000 * nthoLapisLazuliSize ' range=':= _default_ * nthoLapisLazuliSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 6.000 * nthoLapisLazuliFreq ' range=':= _default_ * nthoLapisLazuliFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1814,7 +1814,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.227 * _default_ * nthoRedstoneFreq ' range=':= 2.227 * _default_ * nthoRedstoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoRedstoneSize ' range=':= 0 * _default_ * nthoRedstoneSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1857,7 +1857,7 @@
                             <Setting name='CloudRadius' avg=':= 1.036 * _default_ * nthoRedstoneSize ' range=':= 1.036 * _default_ * nthoRedstoneSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.036 * _default_ * nthoRedstoneSize ' range=':= 1.036 * _default_ * nthoRedstoneSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.073 * _default_ * nthoRedstoneFreq ' range=':= 1.073 * _default_ * nthoRedstoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1908,7 +1908,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 8.000 * nthoRedstoneSize ' range=':= _default_ * nthoRedstoneSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 6.000 * nthoRedstoneFreq ' range=':= _default_ * nthoRedstoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1933,7 +1933,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.416 * _default_ * nthoCopperFreq ' range=':= 1.416 * _default_ * nthoCopperFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.060 * _default_ * nthoCopperSize ' range=':= 1.060 * _default_ * nthoCopperSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1976,7 +1976,7 @@
                             <Setting name='CloudRadius' avg=':= 1.113 * _default_ * nthoCopperSize ' range=':= 1.113 * _default_ * nthoCopperSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.113 * _default_ * nthoCopperSize ' range=':= 1.113 * _default_ * nthoCopperSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.239 * _default_ * nthoCopperFreq ' range=':= 1.239 * _default_ * nthoCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2027,7 +2027,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 8.000 * nthoCopperSize ' range=':= _default_ * nthoCopperSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 8.000 * nthoCopperFreq ' range=':= _default_ * nthoCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -2052,7 +2052,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.416 * _default_ * nthoTinFreq ' range=':= 1.416 * _default_ * nthoTinFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.060 * _default_ * nthoTinSize ' range=':= 1.060 * _default_ * nthoTinSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2095,7 +2095,7 @@
                             <Setting name='CloudRadius' avg=':= 1.113 * _default_ * nthoTinSize ' range=':= 1.113 * _default_ * nthoTinSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.113 * _default_ * nthoTinSize ' range=':= 1.113 * _default_ * nthoTinSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.239 * _default_ * nthoTinFreq ' range=':= 1.239 * _default_ * nthoTinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2146,7 +2146,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 8.000 * nthoTinSize ' range=':= _default_ * nthoTinSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 8.000 * nthoTinFreq ' range=':= _default_ * nthoTinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -2171,7 +2171,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.661 * _default_ * nthoEmeraldFreq ' range=':= 0.661 * _default_ * nthoEmeraldFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoEmeraldSize ' range=':= 0 * _default_ * nthoEmeraldSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2224,7 +2224,7 @@
                             <Setting name='CloudRadius' avg=':= 0.616 * _default_ * nthoEmeraldSize ' range=':= 0.616 * _default_ * nthoEmeraldSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.616 * _default_ * nthoEmeraldSize ' range=':= 0.616 * _default_ * nthoEmeraldSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.379 * _default_ * nthoEmeraldFreq ' range=':= 0.379 * _default_ * nthoEmeraldFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2275,7 +2275,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 2.000 * nthoEmeraldSize ' range=':= _default_ * nthoEmeraldSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 3.000 * nthoEmeraldFreq ' range=':= _default_ * nthoEmeraldFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -2300,7 +2300,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.867 * _default_ * nthoSilverFreq ' range=':= 0.867 * _default_ * nthoSilverFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.976 * _default_ * nthoSilverSize ' range=':= 0.976 * _default_ * nthoSilverSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2343,7 +2343,7 @@
                             <Setting name='CloudRadius' avg=':= 0.871 * _default_ * nthoSilverSize ' range=':= 0.871 * _default_ * nthoSilverSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.871 * _default_ * nthoSilverSize ' range=':= 0.871 * _default_ * nthoSilverSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.758 * _default_ * nthoSilverFreq ' range=':= 0.758 * _default_ * nthoSilverFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2394,7 +2394,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * nthoSilverSize ' range=':= _default_ * nthoSilverSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 6.000 * nthoSilverFreq ' range=':= _default_ * nthoSilverFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -2419,7 +2419,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.062 * _default_ * nthoLeadFreq ' range=':= 1.062 * _default_ * nthoLeadFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.010 * _default_ * nthoLeadSize ' range=':= 1.010 * _default_ * nthoLeadSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2462,7 +2462,7 @@
                             <Setting name='CloudRadius' avg=':= 0.964 * _default_ * nthoLeadSize ' range=':= 0.964 * _default_ * nthoLeadSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.964 * _default_ * nthoLeadSize ' range=':= 0.964 * _default_ * nthoLeadSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.929 * _default_ * nthoLeadFreq ' range=':= 0.929 * _default_ * nthoLeadFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2513,7 +2513,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 6.000 * nthoLeadSize ' range=':= _default_ * nthoLeadSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 6.000 * nthoLeadFreq ' range=':= _default_ * nthoLeadFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -2545,7 +2545,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.061 * _default_ * nthoUraniumFreq ' range=':= 1.061 * _default_ * nthoUraniumFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoUraniumSize ' range=':= 0 * _default_ * nthoUraniumSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2588,7 +2588,7 @@
                             <Setting name='CloudRadius' avg=':= 0.616 * _default_ * nthoUraniumSize ' range=':= 0.616 * _default_ * nthoUraniumSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.616 * _default_ * nthoUraniumSize ' range=':= 0.616 * _default_ * nthoUraniumSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.379 * _default_ * nthoUraniumFreq ' range=':= 0.379 * _default_ * nthoUraniumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2639,7 +2639,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 2.000 * nthoUraniumSize ' range=':= _default_ * nthoUraniumSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 3.000 * nthoUraniumFreq ' range=':= _default_ * nthoUraniumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -2664,7 +2664,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.818 * _default_ * nthoNikoliteFreq ' range=':= 1.818 * _default_ * nthoNikoliteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoNikoliteSize ' range=':= 0 * _default_ * nthoNikoliteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2707,7 +2707,7 @@
                             <Setting name='CloudRadius' avg=':= 0.936 * _default_ * nthoNikoliteSize ' range=':= 0.936 * _default_ * nthoNikoliteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.936 * _default_ * nthoNikoliteSize ' range=':= 0.936 * _default_ * nthoNikoliteSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.876 * _default_ * nthoNikoliteFreq ' range=':= 0.876 * _default_ * nthoNikoliteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2758,7 +2758,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * nthoNikoliteSize ' range=':= _default_ * nthoNikoliteSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 8.000 * nthoNikoliteFreq ' range=':= _default_ * nthoNikoliteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -2783,7 +2783,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.145 * _default_ * nthoRubyFreq ' range=':= 1.145 * _default_ * nthoRubyFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoRubySize ' range=':= 0 * _default_ * nthoRubySize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2836,7 +2836,7 @@
                             <Setting name='CloudRadius' avg=':= 0.810 * _default_ * nthoRubySize ' range=':= 0.810 * _default_ * nthoRubySize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.810 * _default_ * nthoRubySize ' range=':= 0.810 * _default_ * nthoRubySize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.657 * _default_ * nthoRubyFreq ' range=':= 0.657 * _default_ * nthoRubyFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2887,7 +2887,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.000 * nthoRubySize ' range=':= _default_ * nthoRubySize ' type='normal' />
                             <Setting name='Frequency' avg=':= 6.000 * nthoRubyFreq ' range=':= _default_ * nthoRubyFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -2912,7 +2912,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.145 * _default_ * nthoPeridotFreq ' range=':= 1.145 * _default_ * nthoPeridotFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoPeridotSize ' range=':= 0 * _default_ * nthoPeridotSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2965,7 +2965,7 @@
                             <Setting name='CloudRadius' avg=':= 0.810 * _default_ * nthoPeridotSize ' range=':= 0.810 * _default_ * nthoPeridotSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.810 * _default_ * nthoPeridotSize ' range=':= 0.810 * _default_ * nthoPeridotSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.657 * _default_ * nthoPeridotFreq ' range=':= 0.657 * _default_ * nthoPeridotFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3016,7 +3016,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.000 * nthoPeridotSize ' range=':= _default_ * nthoPeridotSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 6.000 * nthoPeridotFreq ' range=':= _default_ * nthoPeridotFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -3041,7 +3041,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.145 * _default_ * nthoSapphireFreq ' range=':= 1.145 * _default_ * nthoSapphireFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoSapphireSize ' range=':= 0 * _default_ * nthoSapphireSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3094,7 +3094,7 @@
                             <Setting name='CloudRadius' avg=':= 0.810 * _default_ * nthoSapphireSize ' range=':= 0.810 * _default_ * nthoSapphireSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.810 * _default_ * nthoSapphireSize ' range=':= 0.810 * _default_ * nthoSapphireSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.657 * _default_ * nthoSapphireFreq ' range=':= 0.657 * _default_ * nthoSapphireFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3145,7 +3145,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.000 * nthoSapphireSize ' range=':= _default_ * nthoSapphireSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 6.000 * nthoSapphireFreq ' range=':= _default_ * nthoSapphireFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -3170,7 +3170,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.306 * _default_ * nthoPlatinumFreq ' range=':= 0.306 * _default_ * nthoPlatinumFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.821 * _default_ * nthoPlatinumSize ' range=':= 0.821 * _default_ * nthoPlatinumSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3213,7 +3213,7 @@
                             <Setting name='CloudRadius' avg=':= 0.518 * _default_ * nthoPlatinumSize ' range=':= 0.518 * _default_ * nthoPlatinumSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.518 * _default_ * nthoPlatinumSize ' range=':= 0.518 * _default_ * nthoPlatinumSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.268 * _default_ * nthoPlatinumFreq ' range=':= 0.268 * _default_ * nthoPlatinumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3264,7 +3264,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.000 * nthoPlatinumSize ' range=':= _default_ * nthoPlatinumSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 1.000 * nthoPlatinumFreq ' range=':= _default_ * nthoPlatinumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -3289,7 +3289,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.867 * _default_ * nthoNickelFreq ' range=':= 0.867 * _default_ * nthoNickelFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.976 * _default_ * nthoNickelSize ' range=':= 0.976 * _default_ * nthoNickelSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3332,7 +3332,7 @@
                             <Setting name='CloudRadius' avg=':= 0.871 * _default_ * nthoNickelSize ' range=':= 0.871 * _default_ * nthoNickelSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.871 * _default_ * nthoNickelSize ' range=':= 0.871 * _default_ * nthoNickelSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.758 * _default_ * nthoNickelFreq ' range=':= 0.758 * _default_ * nthoNickelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3383,7 +3383,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 6.000 * nthoNickelSize ' range=':= _default_ * nthoNickelSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 4.000 * nthoNickelFreq ' range=':= _default_ * nthoNickelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -3408,7 +3408,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.613 * _default_ * nthoSteelFreq ' range=':= 0.613 * _default_ * nthoSteelFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * nthoSteelSize ' range=':= 0.922 * _default_ * nthoSteelSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3451,7 +3451,7 @@
                             <Setting name='CloudRadius' avg=':= 0.732 * _default_ * nthoSteelSize ' range=':= 0.732 * _default_ * nthoSteelSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.732 * _default_ * nthoSteelSize ' range=':= 0.732 * _default_ * nthoSteelSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.536 * _default_ * nthoSteelFreq ' range=':= 0.536 * _default_ * nthoSteelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3502,7 +3502,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * nthoSteelSize ' range=':= _default_ * nthoSteelSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 3.000 * nthoSteelFreq ' range=':= _default_ * nthoSteelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -3529,7 +3529,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.313 * _default_ * nthoIridiumFreq ' range=':= 0.313 * _default_ * nthoIridiumFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.824 * _default_ * nthoIridiumSize ' range=':= 0.824 * _default_ * nthoIridiumSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3572,7 +3572,7 @@
                             <Setting name='CloudRadius' avg=':= 0.468 * _default_ * nthoIridiumSize ' range=':= 0.468 * _default_ * nthoIridiumSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.468 * _default_ * nthoIridiumSize ' range=':= 0.468 * _default_ * nthoIridiumSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.219 * _default_ * nthoIridiumFreq ' range=':= 0.219 * _default_ * nthoIridiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3623,7 +3623,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 2.000 * nthoIridiumSize ' range=':= _default_ * nthoIridiumSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 1.000 * nthoIridiumFreq ' range=':= _default_ * nthoIridiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -3648,7 +3648,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.324 * _default_ * nthoOsmiumFreq ' range=':= 1.324 * _default_ * nthoOsmiumFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.048 * _default_ * nthoOsmiumSize ' range=':= 1.048 * _default_ * nthoOsmiumSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3691,7 +3691,7 @@
                             <Setting name='CloudRadius' avg=':= 1.076 * _default_ * nthoOsmiumSize ' range=':= 1.076 * _default_ * nthoOsmiumSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.076 * _default_ * nthoOsmiumSize ' range=':= 1.076 * _default_ * nthoOsmiumSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.159 * _default_ * nthoOsmiumFreq ' range=':= 1.159 * _default_ * nthoOsmiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3742,7 +3742,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 7.000 * nthoOsmiumSize ' range=':= _default_ * nthoOsmiumSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 8.000 * nthoOsmiumFreq ' range=':= _default_ * nthoOsmiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -3767,7 +3767,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 3.240 * _default_ * nthoSulfurFreq ' range=':= 3.240 * _default_ * nthoSulfurFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoSulfurSize ' range=':= 0 * _default_ * nthoSulfurSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3820,7 +3820,7 @@
                             <Setting name='CloudRadius' avg=':= 1.363 * _default_ * nthoSulfurSize ' range=':= 1.363 * _default_ * nthoSulfurSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.363 * _default_ * nthoSulfurSize ' range=':= 1.363 * _default_ * nthoSulfurSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.858 * _default_ * nthoSulfurFreq ' range=':= 1.858 * _default_ * nthoSulfurFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3871,7 +3871,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 12.000 * nthoSulfurSize ' range=':= _default_ * nthoSulfurSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 12.000 * nthoSulfurFreq ' range=':= _default_ * nthoSulfurFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -3896,7 +3896,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.433 * _default_ * nthoTitaniumFreq ' range=':= 0.433 * _default_ * nthoTitaniumFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.870 * _default_ * nthoTitaniumSize ' range=':= 0.870 * _default_ * nthoTitaniumSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3939,7 +3939,7 @@
                             <Setting name='CloudRadius' avg=':= 0.616 * _default_ * nthoTitaniumSize ' range=':= 0.616 * _default_ * nthoTitaniumSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.616 * _default_ * nthoTitaniumSize ' range=':= 0.616 * _default_ * nthoTitaniumSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.379 * _default_ * nthoTitaniumFreq ' range=':= 0.379 * _default_ * nthoTitaniumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3990,7 +3990,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 2.000 * nthoTitaniumSize ' range=':= _default_ * nthoTitaniumSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 3.000 * nthoTitaniumFreq ' range=':= _default_ * nthoTitaniumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -4015,7 +4015,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.062 * _default_ * nthoMithrilFreq ' range=':= 1.062 * _default_ * nthoMithrilFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.010 * _default_ * nthoMithrilSize ' range=':= 1.010 * _default_ * nthoMithrilSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4058,7 +4058,7 @@
                             <Setting name='CloudRadius' avg=':= 0.964 * _default_ * nthoMithrilSize ' range=':= 0.964 * _default_ * nthoMithrilSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.964 * _default_ * nthoMithrilSize ' range=':= 0.964 * _default_ * nthoMithrilSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.929 * _default_ * nthoMithrilFreq ' range=':= 0.929 * _default_ * nthoMithrilFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4109,7 +4109,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 6.000 * nthoMithrilSize ' range=':= _default_ * nthoMithrilSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 6.000 * nthoMithrilFreq ' range=':= _default_ * nthoMithrilFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -4134,7 +4134,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.791 * _default_ * nthoAdamantiumFreq ' range=':= 0.791 * _default_ * nthoAdamantiumFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.962 * _default_ * nthoAdamantiumSize ' range=':= 0.962 * _default_ * nthoAdamantiumSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4177,7 +4177,7 @@
                             <Setting name='CloudRadius' avg=':= 0.832 * _default_ * nthoAdamantiumSize ' range=':= 0.832 * _default_ * nthoAdamantiumSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.832 * _default_ * nthoAdamantiumSize ' range=':= 0.832 * _default_ * nthoAdamantiumSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.692 * _default_ * nthoAdamantiumFreq ' range=':= 0.692 * _default_ * nthoAdamantiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4228,7 +4228,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * nthoAdamantiumSize ' range=':= _default_ * nthoAdamantiumSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 5.000 * nthoAdamantiumFreq ' range=':= _default_ * nthoAdamantiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -4253,7 +4253,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.613 * _default_ * nthoRutileFreq ' range=':= 0.613 * _default_ * nthoRutileFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * nthoRutileSize ' range=':= 0.922 * _default_ * nthoRutileSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4296,7 +4296,7 @@
                             <Setting name='CloudRadius' avg=':= 0.732 * _default_ * nthoRutileSize ' range=':= 0.732 * _default_ * nthoRutileSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.732 * _default_ * nthoRutileSize ' range=':= 0.732 * _default_ * nthoRutileSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.536 * _default_ * nthoRutileFreq ' range=':= 0.536 * _default_ * nthoRutileFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4347,7 +4347,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * nthoRutileSize ' range=':= _default_ * nthoRutileSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 3.000 * nthoRutileFreq ' range=':= _default_ * nthoRutileFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -4372,7 +4372,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.416 * _default_ * nthoTungstenFreq ' range=':= 1.416 * _default_ * nthoTungstenFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.060 * _default_ * nthoTungstenSize ' range=':= 1.060 * _default_ * nthoTungstenSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4415,7 +4415,7 @@
                             <Setting name='CloudRadius' avg=':= 1.113 * _default_ * nthoTungstenSize ' range=':= 1.113 * _default_ * nthoTungstenSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.113 * _default_ * nthoTungstenSize ' range=':= 1.113 * _default_ * nthoTungstenSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.239 * _default_ * nthoTungstenFreq ' range=':= 1.239 * _default_ * nthoTungstenFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4466,7 +4466,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 8.000 * nthoTungstenSize ' range=':= _default_ * nthoTungstenSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 8.000 * nthoTungstenFreq ' range=':= _default_ * nthoTungstenFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -4498,7 +4498,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.372 * _default_ * nthoAmberFreq ' range=':= 2.372 * _default_ * nthoAmberFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoAmberSize ' range=':= 0 * _default_ * nthoAmberSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4541,7 +4541,7 @@
                             <Setting name='CloudRadius' avg=':= 0.921 * _default_ * nthoAmberSize ' range=':= 0.921 * _default_ * nthoAmberSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.921 * _default_ * nthoAmberSize ' range=':= 0.921 * _default_ * nthoAmberSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.848 * _default_ * nthoAmberFreq ' range=':= 0.848 * _default_ * nthoAmberFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4592,7 +4592,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 6.000 * nthoAmberSize ' range=':= _default_ * nthoAmberSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 5.000 * nthoAmberFreq ' range=':= _default_ * nthoAmberFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -4617,7 +4617,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.416 * _default_ * nthoTennantiteFreq ' range=':= 1.416 * _default_ * nthoTennantiteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.060 * _default_ * nthoTennantiteSize ' range=':= 1.060 * _default_ * nthoTennantiteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4660,7 +4660,7 @@
                             <Setting name='CloudRadius' avg=':= 1.113 * _default_ * nthoTennantiteSize ' range=':= 1.113 * _default_ * nthoTennantiteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.113 * _default_ * nthoTennantiteSize ' range=':= 1.113 * _default_ * nthoTennantiteSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.239 * _default_ * nthoTennantiteFreq ' range=':= 1.239 * _default_ * nthoTennantiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4711,7 +4711,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 8.000 * nthoTennantiteSize ' range=':= _default_ * nthoTennantiteSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 8.000 * nthoTennantiteFreq ' range=':= _default_ * nthoTennantiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -4743,7 +4743,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.166 * _default_ * nthoSaltFreq ' range=':= 2.166 * _default_ * nthoSaltFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoSaltSize ' range=':= 0 * _default_ * nthoSaltSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4786,7 +4786,7 @@
                             <Setting name='CloudRadius' avg=':= 0.880 * _default_ * nthoSaltSize ' range=':= 0.880 * _default_ * nthoSaltSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.880 * _default_ * nthoSaltSize ' range=':= 0.880 * _default_ * nthoSaltSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.774 * _default_ * nthoSaltFreq ' range=':= 0.774 * _default_ * nthoSaltFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4837,7 +4837,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 5.000 * nthoSaltSize ' range=':= _default_ * nthoSaltSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 5.000 * nthoSaltFreq ' range=':= _default_ * nthoSaltFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -4869,7 +4869,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.122 * _default_ * nthoSaltpeterFreq ' range=':= 2.122 * _default_ * nthoSaltpeterFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoSaltpeterSize ' range=':= 0 * _default_ * nthoSaltpeterSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4912,7 +4912,7 @@
                             <Setting name='CloudRadius' avg=':= 0.871 * _default_ * nthoSaltpeterSize ' range=':= 0.871 * _default_ * nthoSaltpeterSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.871 * _default_ * nthoSaltpeterSize ' range=':= 0.871 * _default_ * nthoSaltpeterSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.758 * _default_ * nthoSaltpeterFreq ' range=':= 0.758 * _default_ * nthoSaltpeterFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4963,7 +4963,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * nthoSaltpeterSize ' range=':= _default_ * nthoSaltpeterSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 6.000 * nthoSaltpeterFreq ' range=':= _default_ * nthoSaltpeterFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -4995,7 +4995,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.937 * _default_ * nthoMagnesiumFreq ' range=':= 1.937 * _default_ * nthoMagnesiumFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoMagnesiumSize ' range=':= 0 * _default_ * nthoMagnesiumSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -5038,7 +5038,7 @@
                             <Setting name='CloudRadius' avg=':= 0.832 * _default_ * nthoMagnesiumSize ' range=':= 0.832 * _default_ * nthoMagnesiumSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.832 * _default_ * nthoMagnesiumSize ' range=':= 0.832 * _default_ * nthoMagnesiumSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.692 * _default_ * nthoMagnesiumFreq ' range=':= 0.692 * _default_ * nthoMagnesiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -5089,7 +5089,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 5.000 * nthoMagnesiumSize ' range=':= _default_ * nthoMagnesiumSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 4.000 * nthoMagnesiumFreq ' range=':= _default_ * nthoMagnesiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>

--- a/src/main/resources/config/modules/Netherrocks.xml
+++ b/src/main/resources/config/modules/Netherrocks.xml
@@ -292,7 +292,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.371 * _default_ * nthrFyriteFreq ' range=':= 1.371 * _default_ * nthrFyriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.054 * _default_ * nthrFyriteSize ' range=':= 1.054 * _default_ * nthrFyriteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64 ' range=':= 64 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -335,7 +335,7 @@
                             <Setting name='CloudRadius' avg=':= 1.095 * _default_ * nthrFyriteSize ' range=':= 1.095 * _default_ * nthrFyriteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.095 * _default_ * nthrFyriteSize ' range=':= 1.095 * _default_ * nthrFyriteSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.199 * _default_ * nthrFyriteFreq ' range=':= 1.199 * _default_ * nthrFyriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64 ' range=':= 64 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -386,7 +386,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 6.000 * nthrFyriteSize ' range=':= _default_ * nthrFyriteSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 10.000 * nthrFyriteFreq ' range=':= _default_ * nthrFyriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64 ' range=':= 64 ' type='uniform' scaleTo='base' />
+                            <Setting name='Height' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -411,7 +411,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.480 * _default_ * nthrMalachiteFreq ' range=':= 1.480 * _default_ * nthrMalachiteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.068 * _default_ * nthrMalachiteSize ' range=':= 1.068 * _default_ * nthrMalachiteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64 ' range=':= 64 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -454,7 +454,7 @@
                             <Setting name='CloudRadius' avg=':= 1.138 * _default_ * nthrMalachiteSize ' range=':= 1.138 * _default_ * nthrMalachiteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.138 * _default_ * nthrMalachiteSize ' range=':= 1.138 * _default_ * nthrMalachiteSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.295 * _default_ * nthrMalachiteFreq ' range=':= 1.295 * _default_ * nthrMalachiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64 ' range=':= 64 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -505,7 +505,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 7.000 * nthrMalachiteSize ' range=':= _default_ * nthrMalachiteSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 10.000 * nthrMalachiteFreq ' range=':= _default_ * nthrMalachiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64 ' range=':= 64 ' type='uniform' scaleTo='base' />
+                            <Setting name='Height' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -530,7 +530,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.251 * _default_ * nthrAshtoneFreq ' range=':= 1.251 * _default_ * nthrAshtoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.038 * _default_ * nthrAshtoneSize ' range=':= 1.038 * _default_ * nthrAshtoneSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64 ' range=':= 64 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -573,7 +573,7 @@
                             <Setting name='CloudRadius' avg=':= 1.046 * _default_ * nthrAshtoneSize ' range=':= 1.046 * _default_ * nthrAshtoneSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.046 * _default_ * nthrAshtoneSize ' range=':= 1.046 * _default_ * nthrAshtoneSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.095 * _default_ * nthrAshtoneFreq ' range=':= 1.095 * _default_ * nthrAshtoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64 ' range=':= 64 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -624,7 +624,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 5.000 * nthrAshtoneSize ' range=':= _default_ * nthrAshtoneSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 10.000 * nthrAshtoneFreq ' range=':= _default_ * nthrAshtoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64 ' range=':= 64 ' type='uniform' scaleTo='base' />
+                            <Setting name='Height' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -649,7 +649,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 15.000 * nthrIllumeniteSize ' range=':= _default_ * nthrIllumeniteSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 350.000 * nthrIllumeniteFreq ' range=':= _default_ * nthrIllumeniteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64 ' range=':= 64 ' type='uniform' scaleTo='base' />
+                            <Setting name='Height' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -674,7 +674,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * nthrDragonstoneFreq ' range=':= 0.969 * _default_ * nthrDragonstoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.995 * _default_ * nthrDragonstoneSize ' range=':= 0.995 * _default_ * nthrDragonstoneSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64 ' range=':= 64 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -717,7 +717,7 @@
                             <Setting name='CloudRadius' avg=':= 0.921 * _default_ * nthrDragonstoneSize ' range=':= 0.921 * _default_ * nthrDragonstoneSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.921 * _default_ * nthrDragonstoneSize ' range=':= 0.921 * _default_ * nthrDragonstoneSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.848 * _default_ * nthrDragonstoneFreq ' range=':= 0.848 * _default_ * nthrDragonstoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64 ' range=':= 64 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -768,7 +768,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 5.000 * nthrDragonstoneSize ' range=':= _default_ * nthrDragonstoneSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 6.000 * nthrDragonstoneFreq ' range=':= _default_ * nthrDragonstoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64 ' range=':= 64 ' type='uniform' scaleTo='base' />
+                            <Setting name='Height' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -793,7 +793,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.371 * _default_ * nthrArgoniteFreq ' range=':= 1.371 * _default_ * nthrArgoniteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.054 * _default_ * nthrArgoniteSize ' range=':= 1.054 * _default_ * nthrArgoniteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64 ' range=':= 64 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -836,7 +836,7 @@
                             <Setting name='CloudRadius' avg=':= 1.095 * _default_ * nthrArgoniteSize ' range=':= 1.095 * _default_ * nthrArgoniteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.095 * _default_ * nthrArgoniteSize ' range=':= 1.095 * _default_ * nthrArgoniteSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.199 * _default_ * nthrArgoniteFreq ' range=':= 1.199 * _default_ * nthrArgoniteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64 ' range=':= 64 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -887,7 +887,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 6.000 * nthrArgoniteSize ' range=':= _default_ * nthrArgoniteSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 10.000 * nthrArgoniteFreq ' range=':= _default_ * nthrArgoniteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64 ' range=':= 64 ' type='uniform' scaleTo='base' />
+                            <Setting name='Height' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>

--- a/src/main/resources/config/modules/PamsHarvestCraft.xml
+++ b/src/main/resources/config/modules/PamsHarvestCraft.xml
@@ -118,7 +118,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 5.305 * _default_ * hvstSaltFreq ' range=':= 5.305 * _default_ * hvstSaltFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * hvstSaltSize ' range=':= 0 * _default_ * hvstSaltSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -161,7 +161,7 @@
                             <Setting name='CloudRadius' avg=':= 1.377 * _default_ * hvstSaltSize ' range=':= 1.377 * _default_ * hvstSaltSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.377 * _default_ * hvstSaltSize ' range=':= 1.377 * _default_ * hvstSaltSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.896 * _default_ * hvstSaltFreq ' range=':= 1.896 * _default_ * hvstSaltFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -212,7 +212,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 5.000 * hvstSaltSize ' range=':= _default_ * hvstSaltSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 30.000 * hvstSaltFreq ' range=':= _default_ * hvstSaltFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>

--- a/src/main/resources/config/modules/ReactorCraft.xml
+++ b/src/main/resources/config/modules/ReactorCraft.xml
@@ -1295,7 +1295,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 4.584 * _default_ * recrMagnetiteFreq ' range=':= 4.584 * _default_ * recrMagnetiteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * recrMagnetiteSize ' range=':= 0 * _default_ * recrMagnetiteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 94 ' range=':= 34 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 94 ' range=':= 34 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1327,7 +1327,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 16.000 * recrMagnetiteSize ' range=':= _default_ * recrMagnetiteSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 7.000 * recrMagnetiteFreq ' range=':= _default_ * recrMagnetiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 94 ' range=':= 34 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 94 ' range=':= 34 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1359,7 +1359,7 @@
                             <Setting name='CloudRadius' avg=':= 1.280 * _default_ * recrMagnetiteSize ' range=':= 1.280 * _default_ * recrMagnetiteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.280 * _default_ * recrMagnetiteSize ' range=':= 1.280 * _default_ * recrMagnetiteSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.638 * _default_ * recrMagnetiteFreq ' range=':= 1.638 * _default_ * recrMagnetiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 94 ' range=':= 34 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 94 ' range=':= 34 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />

--- a/src/main/resources/config/modules/SimpleOres.xml
+++ b/src/main/resources/config/modules/SimpleOres.xml
@@ -760,7 +760,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.597 * _default_ * smpoOnyxFreq ' range=':= 1.597 * _default_ * smpoOnyxFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * smpoOnyxSize ' range=':= 0 * _default_ * smpoOnyxSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 72 ' range=':= 56 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 72 ' range=':= 56 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -813,7 +813,7 @@
                             <Setting name='CloudRadius' avg=':= 0.957 * _default_ * smpoOnyxSize ' range=':= 0.957 * _default_ * smpoOnyxSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.957 * _default_ * smpoOnyxSize ' range=':= 0.957 * _default_ * smpoOnyxSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.916 * _default_ * smpoOnyxFreq ' range=':= 0.916 * _default_ * smpoOnyxFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 72 ' range=':= 56 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 72 ' range=':= 56 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -864,7 +864,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 7.000 * smpoOnyxSize ' range=':= _default_ * smpoOnyxSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 5.000 * smpoOnyxFreq ' range=':= _default_ * smpoOnyxFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 72 ' range=':= 56 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 72 ' range=':= 56 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>

--- a/src/main/resources/config/modules/Thaumcraft4.xml
+++ b/src/main/resources/config/modules/Thaumcraft4.xml
@@ -494,7 +494,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.500 * _default_ * thm4CinnabarFreq ' range=':= 1.500 * _default_ * thm4CinnabarFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * thm4CinnabarSize ' range=':= 0 * _default_ * thm4CinnabarSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -537,7 +537,7 @@
                             <Setting name='CloudRadius' avg=':= 0.732 * _default_ * thm4CinnabarSize ' range=':= 0.732 * _default_ * thm4CinnabarSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.732 * _default_ * thm4CinnabarSize ' range=':= 0.732 * _default_ * thm4CinnabarSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.536 * _default_ * thm4CinnabarFreq ' range=':= 0.536 * _default_ * thm4CinnabarFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -588,7 +588,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 1.000 * thm4CinnabarSize ' range=':= _default_ * thm4CinnabarSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 12.000 * thm4CinnabarFreq ' range=':= _default_ * thm4CinnabarFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -621,7 +621,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * thm4AirInfusedStoneFreq ' range=':= 0.969 * _default_ * thm4AirInfusedStoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * thm4AirInfusedStoneSize ' range=':= 0 * _default_ * thm4AirInfusedStoneSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -647,7 +647,7 @@
                             <BiomeType name='Plains'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * thm4AirInfusedStoneFreq ' range=':= 0.969 * _default_ * thm4AirInfusedStoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * thm4AirInfusedStoneSize ' range=':= 0 * _default_ * thm4AirInfusedStoneSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -693,7 +693,7 @@
                             <Setting name='CloudRadius' avg=':= 0.588 * _default_ * thm4AirInfusedStoneSize ' range=':= 0.588 * _default_ * thm4AirInfusedStoneSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.588 * _default_ * thm4AirInfusedStoneSize ' range=':= 0.588 * _default_ * thm4AirInfusedStoneSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.346 * _default_ * thm4AirInfusedStoneFreq ' range=':= 0.346 * _default_ * thm4AirInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -739,7 +739,7 @@
                             <Setting name='CloudRadius' avg=':= 0.588 * _default_ * thm4AirInfusedStoneSize ' range=':= 0.588 * _default_ * thm4AirInfusedStoneSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.588 * _default_ * thm4AirInfusedStoneSize ' range=':= 0.588 * _default_ * thm4AirInfusedStoneSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.346 * _default_ * thm4AirInfusedStoneFreq ' range=':= 0.346 * _default_ * thm4AirInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -776,7 +776,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 5.000 * thm4AirInfusedStoneSize ' range=':= _default_ * thm4AirInfusedStoneSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 1.000 * thm4AirInfusedStoneFreq ' range=':= _default_ * thm4AirInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -809,7 +809,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * thm4FireInfusedStoneFreq ' range=':= 0.969 * _default_ * thm4FireInfusedStoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * thm4FireInfusedStoneSize ' range=':= 0 * _default_ * thm4FireInfusedStoneSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -835,7 +835,7 @@
                             <BiomeType name='Desert'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * thm4FireInfusedStoneFreq ' range=':= 0.969 * _default_ * thm4FireInfusedStoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * thm4FireInfusedStoneSize ' range=':= 0 * _default_ * thm4FireInfusedStoneSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -881,7 +881,7 @@
                             <Setting name='CloudRadius' avg=':= 0.588 * _default_ * thm4FireInfusedStoneSize ' range=':= 0.588 * _default_ * thm4FireInfusedStoneSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.588 * _default_ * thm4FireInfusedStoneSize ' range=':= 0.588 * _default_ * thm4FireInfusedStoneSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.346 * _default_ * thm4FireInfusedStoneFreq ' range=':= 0.346 * _default_ * thm4FireInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -927,7 +927,7 @@
                             <Setting name='CloudRadius' avg=':= 0.588 * _default_ * thm4FireInfusedStoneSize ' range=':= 0.588 * _default_ * thm4FireInfusedStoneSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.588 * _default_ * thm4FireInfusedStoneSize ' range=':= 0.588 * _default_ * thm4FireInfusedStoneSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.346 * _default_ * thm4FireInfusedStoneFreq ' range=':= 0.346 * _default_ * thm4FireInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -964,7 +964,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 5.000 * thm4FireInfusedStoneSize ' range=':= _default_ * thm4FireInfusedStoneSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 1.000 * thm4FireInfusedStoneFreq ' range=':= _default_ * thm4FireInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -998,7 +998,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * thm4WaterInfusedStoneFreq ' range=':= 0.969 * _default_ * thm4WaterInfusedStoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * thm4WaterInfusedStoneSize ' range=':= 0 * _default_ * thm4WaterInfusedStoneSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1025,7 +1025,7 @@
                             <BiomeType name='Swamp'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * thm4WaterInfusedStoneFreq ' range=':= 0.969 * _default_ * thm4WaterInfusedStoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * thm4WaterInfusedStoneSize ' range=':= 0 * _default_ * thm4WaterInfusedStoneSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1071,7 +1071,7 @@
                             <Setting name='CloudRadius' avg=':= 0.588 * _default_ * thm4WaterInfusedStoneSize ' range=':= 0.588 * _default_ * thm4WaterInfusedStoneSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.588 * _default_ * thm4WaterInfusedStoneSize ' range=':= 0.588 * _default_ * thm4WaterInfusedStoneSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.346 * _default_ * thm4WaterInfusedStoneFreq ' range=':= 0.346 * _default_ * thm4WaterInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1118,7 +1118,7 @@
                             <Setting name='CloudRadius' avg=':= 0.588 * _default_ * thm4WaterInfusedStoneSize ' range=':= 0.588 * _default_ * thm4WaterInfusedStoneSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.588 * _default_ * thm4WaterInfusedStoneSize ' range=':= 0.588 * _default_ * thm4WaterInfusedStoneSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.346 * _default_ * thm4WaterInfusedStoneFreq ' range=':= 0.346 * _default_ * thm4WaterInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1155,7 +1155,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 5.000 * thm4WaterInfusedStoneSize ' range=':= _default_ * thm4WaterInfusedStoneSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 1.000 * thm4WaterInfusedStoneFreq ' range=':= _default_ * thm4WaterInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1189,7 +1189,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * thm4EarthInfusedStoneFreq ' range=':= 0.969 * _default_ * thm4EarthInfusedStoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * thm4EarthInfusedStoneSize ' range=':= 0 * _default_ * thm4EarthInfusedStoneSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1215,7 +1215,7 @@
                             <BiomeType name='Forest'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * thm4EarthInfusedStoneFreq ' range=':= 0.969 * _default_ * thm4EarthInfusedStoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * thm4EarthInfusedStoneSize ' range=':= 0 * _default_ * thm4EarthInfusedStoneSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1261,7 +1261,7 @@
                             <Setting name='CloudRadius' avg=':= 0.588 * _default_ * thm4EarthInfusedStoneSize ' range=':= 0.588 * _default_ * thm4EarthInfusedStoneSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.588 * _default_ * thm4EarthInfusedStoneSize ' range=':= 0.588 * _default_ * thm4EarthInfusedStoneSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.346 * _default_ * thm4EarthInfusedStoneFreq ' range=':= 0.346 * _default_ * thm4EarthInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1307,7 +1307,7 @@
                             <Setting name='CloudRadius' avg=':= 0.588 * _default_ * thm4EarthInfusedStoneSize ' range=':= 0.588 * _default_ * thm4EarthInfusedStoneSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.588 * _default_ * thm4EarthInfusedStoneSize ' range=':= 0.588 * _default_ * thm4EarthInfusedStoneSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.346 * _default_ * thm4EarthInfusedStoneFreq ' range=':= 0.346 * _default_ * thm4EarthInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1344,7 +1344,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 5.000 * thm4EarthInfusedStoneSize ' range=':= _default_ * thm4EarthInfusedStoneSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 1.000 * thm4EarthInfusedStoneFreq ' range=':= _default_ * thm4EarthInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1378,7 +1378,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * thm4OrderInfusedStoneFreq ' range=':= 0.969 * _default_ * thm4OrderInfusedStoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * thm4OrderInfusedStoneSize ' range=':= 0 * _default_ * thm4OrderInfusedStoneSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1406,7 +1406,7 @@
                             <BiomeType name='Magical'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * thm4OrderInfusedStoneFreq ' range=':= 0.969 * _default_ * thm4OrderInfusedStoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * thm4OrderInfusedStoneSize ' range=':= 0 * _default_ * thm4OrderInfusedStoneSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1452,7 +1452,7 @@
                             <Setting name='CloudRadius' avg=':= 0.588 * _default_ * thm4OrderInfusedStoneSize ' range=':= 0.588 * _default_ * thm4OrderInfusedStoneSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.588 * _default_ * thm4OrderInfusedStoneSize ' range=':= 0.588 * _default_ * thm4OrderInfusedStoneSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.346 * _default_ * thm4OrderInfusedStoneFreq ' range=':= 0.346 * _default_ * thm4OrderInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1500,7 +1500,7 @@
                             <Setting name='CloudRadius' avg=':= 0.588 * _default_ * thm4OrderInfusedStoneSize ' range=':= 0.588 * _default_ * thm4OrderInfusedStoneSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.588 * _default_ * thm4OrderInfusedStoneSize ' range=':= 0.588 * _default_ * thm4OrderInfusedStoneSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.346 * _default_ * thm4OrderInfusedStoneFreq ' range=':= 0.346 * _default_ * thm4OrderInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1537,7 +1537,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 5.000 * thm4OrderInfusedStoneSize ' range=':= _default_ * thm4OrderInfusedStoneSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 1.000 * thm4OrderInfusedStoneFreq ' range=':= _default_ * thm4OrderInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1571,7 +1571,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * thm4EntropyInfusedStoneFreq ' range=':= 0.969 * _default_ * thm4EntropyInfusedStoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * thm4EntropyInfusedStoneSize ' range=':= 0 * _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1598,7 +1598,7 @@
                             <BiomeType name='Wasteland'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * thm4EntropyInfusedStoneFreq ' range=':= 0.969 * _default_ * thm4EntropyInfusedStoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * thm4EntropyInfusedStoneSize ' range=':= 0 * _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1644,7 +1644,7 @@
                             <Setting name='CloudRadius' avg=':= 0.588 * _default_ * thm4EntropyInfusedStoneSize ' range=':= 0.588 * _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.588 * _default_ * thm4EntropyInfusedStoneSize ' range=':= 0.588 * _default_ * thm4EntropyInfusedStoneSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.346 * _default_ * thm4EntropyInfusedStoneFreq ' range=':= 0.346 * _default_ * thm4EntropyInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1691,7 +1691,7 @@
                             <Setting name='CloudRadius' avg=':= 0.588 * _default_ * thm4EntropyInfusedStoneSize ' range=':= 0.588 * _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.588 * _default_ * thm4EntropyInfusedStoneSize ' range=':= 0.588 * _default_ * thm4EntropyInfusedStoneSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.346 * _default_ * thm4EntropyInfusedStoneFreq ' range=':= 0.346 * _default_ * thm4EntropyInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1730,7 +1730,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 5.000 * thm4EntropyInfusedStoneSize ' range=':= _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 1.000 * thm4EntropyInfusedStoneFreq ' range=':= _default_ * thm4EntropyInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>

--- a/src/main/resources/config/modules/ThermalFoundation.xml
+++ b/src/main/resources/config/modules/ThermalFoundation.xml
@@ -290,7 +290,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.583 * _default_ * thfoCopperFreq ' range=':= 1.583 * _default_ * thfoCopperFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.080 * _default_ * thfoCopperSize ' range=':= 1.080 * _default_ * thfoCopperSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 68 ' range=':= 28 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 68 ' range=':= 28 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -333,7 +333,7 @@
                             <Setting name='CloudRadius' avg=':= 1.177 * _default_ * thfoCopperSize ' range=':= 1.177 * _default_ * thfoCopperSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.177 * _default_ * thfoCopperSize ' range=':= 1.177 * _default_ * thfoCopperSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.385 * _default_ * thfoCopperFreq ' range=':= 1.385 * _default_ * thfoCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 68 ' range=':= 28 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 68 ' range=':= 28 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -384,7 +384,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 8.000 * thfoCopperSize ' range=':= _default_ * thfoCopperSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 10.000 * thfoCopperFreq ' range=':= _default_ * thfoCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 68 ' range=':= 28 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 68 ' range=':= 28 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>

--- a/src/main/resources/config/modules/TinkersConstruct.xml
+++ b/src/main/resources/config/modules/TinkersConstruct.xml
@@ -1485,13 +1485,13 @@
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.041 * _default_ ' range=':= 1.041 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0 * _default_ ' range=':= 0 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * ticoCobaltSize ' range=':= _default_ * ticoCobaltSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.020 * _default_ * ticoCobaltSize ' range=':= 1.020 * _default_ * ticoCobaltSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0 * _default_ * ticoCobaltSize ' range=':= 0 * _default_ * ticoCobaltSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1606,13 +1606,13 @@
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.041 * _default_ ' range=':= 1.041 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0 * _default_ ' range=':= 0 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * ticoArditeSize ' range=':= _default_ * ticoArditeSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.020 * _default_ * ticoArditeSize ' range=':= 1.020 * _default_ * ticoArditeSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0 * _default_ * ticoArditeSize ' range=':= 0 * _default_ * ticoArditeSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>

--- a/src/main/resources/config/modules/TinkersConstruct.xml
+++ b/src/main/resources/config/modules/TinkersConstruct.xml
@@ -143,9 +143,9 @@
                 <OptionChoice name='ticoCobaltDist'  displayState=':= if(?enableTinkersConstruct, "shown", "hidden")' displayGroup='groupTinkersConstruct'>
                     <Description> Controls how Cobalt is generated </Description>
                     <DisplayName>Tinkers Construct Cobalt</DisplayName>
-                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                    <Choice value='SmallDeposits' displayValue='Small Deposits'>
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small motherlodes without any branches.
                         </Description>
                     </Choice>
                     <Choice value='Cloud' displayValue='Strategic Cloud'>
@@ -177,9 +177,9 @@
                 <OptionChoice name='ticoArditeDist'  displayState=':= if(?enableTinkersConstruct, "shown", "hidden")' displayGroup='groupTinkersConstruct'>
                     <Description> Controls how Ardite is generated </Description>
                     <DisplayName>Tinkers Construct Ardite</DisplayName>
-                    <Choice value='LayeredVeins' displayValue='Layered Veins'>
+                    <Choice value='SmallDeposits' displayValue='Small Deposits'>
                         <Description>
-                            Small, fairly rare motherlodes with 2-4 horizontal veins each.
+                            Small motherlodes without any branches.
                         </Description>
                     </Choice>
                     <Choice value='Cloud' displayValue='Strategic Cloud'>
@@ -1072,7 +1072,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.583 * _default_ * ticoCopperGravelFreq ' range=':= 1.583 * _default_ * ticoCopperGravelFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.080 * _default_ * ticoCopperGravelSize ' range=':= 1.080 * _default_ * ticoCopperGravelSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 68 ' range=':= 28 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 40 ' range=':= 20 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1116,7 +1116,7 @@
                             <Setting name='CloudRadius' avg=':= 1.177 * _default_ * ticoCopperGravelSize ' range=':= 1.177 * _default_ * ticoCopperGravelSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.177 * _default_ * ticoCopperGravelSize ' range=':= 1.177 * _default_ * ticoCopperGravelSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.385 * _default_ * ticoCopperGravelFreq ' range=':= 1.385 * _default_ * ticoCopperGravelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 68 ' range=':= 28 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 40 ' range=':= 20 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1167,7 +1167,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 8.000 * ticoCopperGravelSize ' range=':= _default_ * ticoCopperGravelSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 10.000 * ticoCopperGravelFreq ' range=':= _default_ * ticoCopperGravelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 68 ' range=':= 28 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 40 ' range=':= 20 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1466,36 +1466,38 @@
 
                 <!-- Begin Cobalt Generation -->
 
-                <!-- Starting LayeredVeins Preset for Cobalt. -->
+                <!-- Starting SmallDeposits Preset for Cobalt. -->
                 <ConfigSection>
-                    <IfCondition condition=':= ticoCobaltDist = "LayeredVeins"'>
-                        <Veins name='ticoCobaltVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x601D62B8' drawBoundBox='false' boundBoxColor='0x601D62B8'>
+                    <IfCondition condition=':= ticoCobaltDist = "SmallDeposits"'>
+                        <Veins name='ticoCobaltVeins'  inherits='PresetSmallDeposits' drawWireframe='true' wireframeColor='0x601D62B8' drawBoundBox='false' boundBoxColor='0x601D62B8'>
                             <Description>
-                                Small, fairly rare motherlodes  with
-                                2-4 horizontal veins each.
+                                Small motherlodes without any
+                                branches.  Similar to the  deposits
+                                produced by StandardGen
+                                distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:1")'> <OreBlock block='TConstruct:SearedBrick:1' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.867 * _default_ * ticoCobaltFreq ' range=':= 0.867 * _default_ * ticoCobaltFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.976 * _default_ * ticoCobaltSize ' range=':= 0.976 * _default_ * ticoCobaltSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64 ' range=':= 64 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.084 * _default_ * ticoCobaltFreq ' range=':= 1.084 * _default_ * ticoCobaltFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.014 * _default_ * ticoCobaltSize ' range=':= 1.014 * _default_ * ticoCobaltSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 64 ' range=':= 64 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.931 * _default_ ' range=':= 0.931 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.041 * _default_ ' range=':= 1.041 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * ticoCobaltSize ' range=':= _default_ * ticoCobaltSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.965 * _default_ * ticoCobaltSize ' range=':= 0.965 * _default_ * ticoCobaltSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.020 * _default_ * ticoCobaltSize ' range=':= 1.020 * _default_ * ticoCobaltSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
-                <!-- LayeredVeins Preset for Cobalt is complete. -->
+                <!-- SmallDeposits Preset for Cobalt is complete. -->
 
 
                 <!-- Starting Cloud Preset for Cobalt. -->
@@ -1522,7 +1524,7 @@
                             <Setting name='CloudRadius' avg=':= 0.871 * _default_ * ticoCobaltSize ' range=':= 0.871 * _default_ * ticoCobaltSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.871 * _default_ * ticoCobaltSize ' range=':= 0.871 * _default_ * ticoCobaltSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.758 * _default_ * ticoCobaltFreq ' range=':= 0.758 * _default_ * ticoCobaltFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64 ' range=':= 64 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64 ' range=':= 64 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1573,7 +1575,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.000 * ticoCobaltSize ' range=':= _default_ * ticoCobaltSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 8.000 * ticoCobaltFreq ' range=':= _default_ * ticoCobaltFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64 ' range=':= 64 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64 ' range=':= 64 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1585,36 +1587,38 @@
 
                 <!-- Begin Ardite Generation -->
 
-                <!-- Starting LayeredVeins Preset for Ardite. -->
+                <!-- Starting SmallDeposits Preset for Ardite. -->
                 <ConfigSection>
-                    <IfCondition condition=':= ticoArditeDist = "LayeredVeins"'>
-                        <Veins name='ticoArditeVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x60F48A00' drawBoundBox='false' boundBoxColor='0x60F48A00'>
+                    <IfCondition condition=':= ticoArditeDist = "SmallDeposits"'>
+                        <Veins name='ticoArditeVeins'  inherits='PresetSmallDeposits' drawWireframe='true' wireframeColor='0x60F48A00' drawBoundBox='false' boundBoxColor='0x60F48A00'>
                             <Description>
-                                Small, fairly rare motherlodes  with
-                                2-4 horizontal veins each.
+                                Small motherlodes without any
+                                branches.  Similar to the  deposits
+                                produced by StandardGen
+                                distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:2")'> <OreBlock block='TConstruct:SearedBrick:2' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.867 * _default_ * ticoArditeFreq ' range=':= 0.867 * _default_ * ticoArditeFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.976 * _default_ * ticoArditeSize ' range=':= 0.976 * _default_ * ticoArditeSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64 ' range=':= 64 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.084 * _default_ * ticoArditeFreq ' range=':= 1.084 * _default_ * ticoArditeFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.014 * _default_ * ticoArditeSize ' range=':= 1.014 * _default_ * ticoArditeSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 64 ' range=':= 64 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.931 * _default_ ' range=':= 0.931 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.041 * _default_ ' range=':= 1.041 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * ticoArditeSize ' range=':= _default_ * ticoArditeSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.965 * _default_ * ticoArditeSize ' range=':= 0.965 * _default_ * ticoArditeSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.020 * _default_ * ticoArditeSize ' range=':= 1.020 * _default_ * ticoArditeSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
-                <!-- LayeredVeins Preset for Ardite is complete. -->
+                <!-- SmallDeposits Preset for Ardite is complete. -->
 
 
                 <!-- Starting Cloud Preset for Ardite. -->
@@ -1641,7 +1645,7 @@
                             <Setting name='CloudRadius' avg=':= 0.871 * _default_ * ticoArditeSize ' range=':= 0.871 * _default_ * ticoArditeSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.871 * _default_ * ticoArditeSize ' range=':= 0.871 * _default_ * ticoArditeSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.758 * _default_ * ticoArditeFreq ' range=':= 0.758 * _default_ * ticoArditeFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64 ' range=':= 64 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64 ' range=':= 64 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1692,7 +1696,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.000 * ticoArditeSize ' range=':= _default_ * ticoArditeSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 8.000 * ticoArditeFreq ' range=':= _default_ * ticoArditeFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64 ' range=':= 64 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64 ' range=':= 64 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>


### PR DESCRIPTION
All ores whose average y level is above 64 were changed from using a normal distribution to a uniform distribution, in order to ensure enough is below sea level (and actually in the ground) to actually make the oregen worthwhile.

Also, Changed Cobalt and Ardite from Layered Veins to Small Deposits.