### PR TITLE
Rearranged Gregtech to follow other configs.

### DIFF
--- a/src/main/resources/config/CustomOreGen_Config_Default.xml
+++ b/src/main/resources/config/CustomOreGen_Config_Default.xml
@@ -413,8 +413,6 @@
     <Import file='modules/default/FossilsandArchaeology.xml'/>
     <Import file='modules/default/Galacticraft.xml'/>
     <Import file='modules/default/GeoStrata.xml'/>
-    <Import file='modules/default/Gregtech6.xml'/>
-    <Import file='modules/default/Gregtech.xml'/>
     <Import file='modules/default/ImmersiveEngineering.xml'/>
     <Import file='modules/default/IndustrialCraft2.xml'/>
     <Import file='modules/default/Mekanism.xml'/>
@@ -431,6 +429,10 @@
     <Import file='modules/default/Thaumcraft4.xml'/>
     <Import file='modules/default/ThermalFoundation.xml'/>
     <Import file='modules/default/TinkersConstruct.xml'/>
+    <!-- Gregtech checks for other ores' oredict values.  It will need to be
+	 among the last default configurations to load. -->
+    <Import file='modules/default/Gregtech6.xml'/>
+    <Import file='modules/default/Gregtech.xml'/>
 
     <!-- ***************** Import Mod-provided configs ********************* -->
     <!-- NOTE: mods will overwrite these configs upon each load -->
@@ -438,6 +440,11 @@
     
     <!-- ******************** Import Custom Configs ************************ -->
     <OptionalImport file='modules/custom/*.xml'/>
+
+    <!-- Gregtech checks for other ores' oredict values.  Uncomment the
+	 the following to have it override custom configurations -->
+<!--    <Import file='modules/default/Gregtech6.xml'/>   -->
+<!--    <Import file='modules/default/Gregtech.xml'/>    -->
     
     <!--*************************   Testing & Debugging   *********************
     *   I use this section for quick-and-dirty experiments


### PR DESCRIPTION
GregTech uses oredict values in order to override the ores generated by other mods.  Because of this, its current place in the load order needs to be corrected.  At this point, the gregtech configurations have been moved to last place, so they can override all other mods' ore placement with their own special form.