### PR TITLE
Stone, sand, dirt, and gravel now use oredict.

### DIFF
--- a/src/main/resources/config/modules/AppliedEnergistics.xml
+++ b/src/main/resources/config/modules/AppliedEnergistics.xml
@@ -120,7 +120,7 @@
                             </Description>
                             <IfCondition condition=':= ?blockExists("appliedenergistics2:tile.OreQuartz")'> <OreBlock block='appliedenergistics2:tile.OreQuartz' weight='0.90' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("appliedenergistics2:tile.OreQuartzCharged")'> <OreBlock block='appliedenergistics2:tile.OreQuartzCharged' weight='0.10' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 3.355 * _default_ * apenCertusQuartzFreq ' range=':= 3.355 * _default_ * apenCertusQuartzFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * apenCertusQuartzSize ' range=':= 0 * _default_ * apenCertusQuartzSize ' type='normal' />
@@ -153,7 +153,7 @@
                             </Description>
                             <IfCondition condition=':= ?blockExists("appliedenergistics2:tile.OreQuartz")'> <OreBlock block='appliedenergistics2:tile.OreQuartz' weight='0.90' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("appliedenergistics2:tile.OreQuartzCharged")'> <OreBlock block='appliedenergistics2:tile.OreQuartzCharged' weight='0.10' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4 * apenCertusQuartzSize ' range=':= _default_ * apenCertusQuartzSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 15 * apenCertusQuartzFreq ' range=':= _default_ * apenCertusQuartzFreq ' type='normal' scaleTo='base' />
@@ -185,7 +185,7 @@
                             </Description>
                             <IfCondition condition=':= ?blockExists("appliedenergistics2:tile.OreQuartz")'> <OreBlock block='appliedenergistics2:tile.OreQuartz' weight='0.90' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("appliedenergistics2:tile.OreQuartzCharged")'> <OreBlock block='appliedenergistics2:tile.OreQuartzCharged' weight='0.10' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.095 * _default_ * apenCertusQuartzSize ' range=':= 1.095 * _default_ * apenCertusQuartzSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.095 * _default_ * apenCertusQuartzSize ' range=':= 1.095 * _default_ * apenCertusQuartzSize ' type='normal' scaleTo='base' />

--- a/src/main/resources/config/modules/ArsMagica2.xml
+++ b/src/main/resources/config/modules/ArsMagica2.xml
@@ -184,7 +184,7 @@
                                 their  direction while mining.
                             </Description>
                             <IfCondition condition=':= ?blockExists("arsmagica2:vinteumOre")'> <OreBlock block='arsmagica2:vinteumOre' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.122 * _default_ * arsmVinteumFreq ' range=':= 2.122 * _default_ * arsmVinteumFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * arsmVinteumSize ' range=':= 0 * _default_ * arsmVinteumSize ' type='normal' />
@@ -226,7 +226,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("arsmagica2:vinteumOre")'> <OreBlock block='arsmagica2:vinteumOre' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.871 * _default_ * arsmVinteumSize ' range=':= 0.871 * _default_ * arsmVinteumSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.871 * _default_ * arsmVinteumSize ' range=':= 0.871 * _default_ * arsmVinteumSize ' type='normal' scaleTo='base' />
@@ -278,7 +278,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("arsmagica2:vinteumOre")'> <OreBlock block='arsmagica2:vinteumOre' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4 * arsmVinteumSize ' range=':= _default_ * arsmVinteumSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 6 * arsmVinteumFreq ' range=':= _default_ * arsmVinteumFreq ' type='normal' scaleTo='base' />
@@ -310,7 +310,7 @@
                                 their  direction while mining.
                             </Description>
                             <IfCondition condition=':= ?blockExists("arsmagica2:vinteumOre:1")'> <OreBlock block='arsmagica2:vinteumOre:1' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 3.001 * _default_ * arsmChimeriteFreq ' range=':= 3.001 * _default_ * arsmChimeriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * arsmChimeriteSize ' range=':= 0 * _default_ * arsmChimeriteSize ' type='normal' />
@@ -352,7 +352,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("arsmagica2:vinteumOre:1")'> <OreBlock block='arsmagica2:vinteumOre:1' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.036 * _default_ * arsmChimeriteSize ' range=':= 1.036 * _default_ * arsmChimeriteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.036 * _default_ * arsmChimeriteSize ' range=':= 1.036 * _default_ * arsmChimeriteSize ' type='normal' scaleTo='base' />
@@ -404,7 +404,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("arsmagica2:vinteumOre:1")'> <OreBlock block='arsmagica2:vinteumOre:1' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 6 * arsmChimeriteSize ' range=':= _default_ * arsmChimeriteSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 8 * arsmChimeriteFreq ' range=':= _default_ * arsmChimeriteFreq ' type='normal' scaleTo='base' />
@@ -436,7 +436,7 @@
                                 their  direction while mining.
                             </Description>
                             <IfCondition condition=':= ?blockExists("arsmagica2:vinteumOre:2")'> <OreBlock block='arsmagica2:vinteumOre:2' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 3.001 * _default_ * arsmBlueTopazFreq ' range=':= 3.001 * _default_ * arsmBlueTopazFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * arsmBlueTopazSize ' range=':= 0 * _default_ * arsmBlueTopazSize ' type='normal' />
@@ -478,7 +478,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("arsmagica2:vinteumOre:2")'> <OreBlock block='arsmagica2:vinteumOre:2' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.036 * _default_ * arsmBlueTopazSize ' range=':= 1.036 * _default_ * arsmBlueTopazSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.036 * _default_ * arsmBlueTopazSize ' range=':= 1.036 * _default_ * arsmBlueTopazSize ' type='normal' scaleTo='base' />
@@ -530,7 +530,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("arsmagica2:vinteumOre:2")'> <OreBlock block='arsmagica2:vinteumOre:2' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 6 * arsmBlueTopazSize ' range=':= _default_ * arsmBlueTopazSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 8 * arsmBlueTopazFreq ' range=':= _default_ * arsmBlueTopazFreq ' type='normal' scaleTo='base' />

--- a/src/main/resources/config/modules/BiomesOPlenty.xml
+++ b/src/main/resources/config/modules/BiomesOPlenty.xml
@@ -352,7 +352,7 @@
                                 up from near the bottom  of the map.
                             </Description>
                             <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:2")'> <OreBlock block='BiomesOPlenty:gemOre:2' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Desert'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.270 * _default_ * boplRubyFreq ' range=':= 0.270 * _default_ * boplRubyFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * boplRubySize ' range=':= 0 * _default_ * boplRubySize ' type='normal' />
@@ -374,7 +374,7 @@
                         <!-- Configuring contained material. -->
                         <Veins name='boplRubyVeinsPipe'  inherits='boplRubyVeins' seed='0x706D' drawWireframe='true' wireframeColor='0x60C60031' drawBoundBox='false' boundBoxColor='0x60C60031'>
                             <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:2")'> <Replaces block='BiomesOPlenty:gemOre:2' weight='1.0' /> </IfCondition>
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * boplRubySize  * 0.5 ' range=':= 0 * _default_ * boplRubySize  * 0.5 ' type='normal' />
                             <Setting name='SegmentRadius' avg=':= 0.721 * _default_ * boplRubySize  * 0.5 ' range=':= 0.721 * _default_ * boplRubySize  * 0.5 ' type='normal' />
@@ -404,7 +404,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:2")'> <OreBlock block='BiomesOPlenty:gemOre:2' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Desert'  />
                             <Setting name='CloudRadius' avg=':= 0.393 * _default_ * boplRubySize ' range=':= 0.393 * _default_ * boplRubySize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.393 * _default_ * boplRubySize ' range=':= 0.393 * _default_ * boplRubySize ' type='normal' scaleTo='base' />
@@ -456,7 +456,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:2")'> <OreBlock block='BiomesOPlenty:gemOre:2' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Desert'  />
                             <Setting name='Size' avg=':= 1 * boplRubySize ' range=':= _default_ * boplRubySize ' type='normal' />
                             <Setting name='Frequency' avg=':= 1 * boplRubyFreq ' range=':= _default_ * boplRubyFreq ' type='normal' scaleTo='base' />
@@ -481,7 +481,7 @@
                                 up from near the bottom  of the map.
                             </Description>
                             <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:4")'> <OreBlock block='BiomesOPlenty:gemOre:4' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Plains'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.270 * _default_ * boplPeridotFreq ' range=':= 0.270 * _default_ * boplPeridotFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * boplPeridotSize ' range=':= 0 * _default_ * boplPeridotSize ' type='normal' />
@@ -503,7 +503,7 @@
                         <!-- Configuring contained material. -->
                         <Veins name='boplPeridotVeinsPipe'  inherits='boplPeridotVeins' seed='0xA6AC' drawWireframe='true' wireframeColor='0x60076855' drawBoundBox='false' boundBoxColor='0x60076855'>
                             <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:4")'> <Replaces block='BiomesOPlenty:gemOre:4' weight='1.0' /> </IfCondition>
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * boplPeridotSize  * 0.5 ' range=':= 0 * _default_ * boplPeridotSize  * 0.5 ' type='normal' />
                             <Setting name='SegmentRadius' avg=':= 0.721 * _default_ * boplPeridotSize  * 0.5 ' range=':= 0.721 * _default_ * boplPeridotSize  * 0.5 ' type='normal' />
@@ -533,7 +533,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:4")'> <OreBlock block='BiomesOPlenty:gemOre:4' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Plains'  />
                             <Setting name='CloudRadius' avg=':= 0.393 * _default_ * boplPeridotSize ' range=':= 0.393 * _default_ * boplPeridotSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.393 * _default_ * boplPeridotSize ' range=':= 0.393 * _default_ * boplPeridotSize ' type='normal' scaleTo='base' />
@@ -585,7 +585,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:4")'> <OreBlock block='BiomesOPlenty:gemOre:4' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Plains'  />
                             <Setting name='Size' avg=':= 1 * boplPeridotSize ' range=':= _default_ * boplPeridotSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 1 * boplPeridotFreq ' range=':= _default_ * boplPeridotFreq ' type='normal' scaleTo='base' />
@@ -610,7 +610,7 @@
                                 up from near the bottom  of the map.
                             </Description>
                             <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:6")'> <OreBlock block='BiomesOPlenty:gemOre:6' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Jungle'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.270 * _default_ * boplTopazFreq ' range=':= 0.270 * _default_ * boplTopazFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * boplTopazSize ' range=':= 0 * _default_ * boplTopazSize ' type='normal' />
@@ -632,7 +632,7 @@
                         <!-- Configuring contained material. -->
                         <Veins name='boplTopazVeinsPipe'  inherits='boplTopazVeins' seed='0xB7E1' drawWireframe='true' wireframeColor='0x60D95A03' drawBoundBox='false' boundBoxColor='0x60D95A03'>
                             <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:6")'> <Replaces block='BiomesOPlenty:gemOre:6' weight='1.0' /> </IfCondition>
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * boplTopazSize  * 0.5 ' range=':= 0 * _default_ * boplTopazSize  * 0.5 ' type='normal' />
                             <Setting name='SegmentRadius' avg=':= 0.721 * _default_ * boplTopazSize  * 0.5 ' range=':= 0.721 * _default_ * boplTopazSize  * 0.5 ' type='normal' />
@@ -662,7 +662,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:6")'> <OreBlock block='BiomesOPlenty:gemOre:6' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Jungle'  />
                             <Setting name='CloudRadius' avg=':= 0.393 * _default_ * boplTopazSize ' range=':= 0.393 * _default_ * boplTopazSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.393 * _default_ * boplTopazSize ' range=':= 0.393 * _default_ * boplTopazSize ' type='normal' scaleTo='base' />
@@ -714,7 +714,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:6")'> <OreBlock block='BiomesOPlenty:gemOre:6' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Jungle'  />
                             <Setting name='Size' avg=':= 1 * boplTopazSize ' range=':= _default_ * boplTopazSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 1 * boplTopazFreq ' range=':= _default_ * boplTopazFreq ' type='normal' scaleTo='base' />
@@ -739,7 +739,7 @@
                                 up from near the bottom  of the map.
                             </Description>
                             <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:8")'> <OreBlock block='BiomesOPlenty:gemOre:8' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Frozen'  />
                             <Biome name='Alps'  weight='-1' />
                             <Biome name='Alps Forest'  weight='-1' />
@@ -763,7 +763,7 @@
                         <!-- Configuring contained material. -->
                         <Veins name='boplTanzaniteVeinsPipe'  inherits='boplTanzaniteVeins' seed='0xA51A' drawWireframe='true' wireframeColor='0x607701B9' drawBoundBox='false' boundBoxColor='0x607701B9'>
                             <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:8")'> <Replaces block='BiomesOPlenty:gemOre:8' weight='1.0' /> </IfCondition>
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * boplTanzaniteSize  * 0.5 ' range=':= 0 * _default_ * boplTanzaniteSize  * 0.5 ' type='normal' />
                             <Setting name='SegmentRadius' avg=':= 0.721 * _default_ * boplTanzaniteSize  * 0.5 ' range=':= 0.721 * _default_ * boplTanzaniteSize  * 0.5 ' type='normal' />
@@ -793,7 +793,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:8")'> <OreBlock block='BiomesOPlenty:gemOre:8' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Frozen'  />
                             <Biome name='Alps'  weight='-1' />
                             <Biome name='Alps Forest'  weight='-1' />
@@ -847,7 +847,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:8")'> <OreBlock block='BiomesOPlenty:gemOre:8' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Frozen'  />
                             <Biome name='Alps'  weight='-1' />
                             <Biome name='Alps Forest'  weight='-1' />
@@ -874,7 +874,7 @@
                                 up from near the bottom  of the map.
                             </Description>
                             <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:10")'> <OreBlock block='BiomesOPlenty:gemOre:10' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Swamp'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.270 * _default_ * boplMalachiteFreq ' range=':= 0.270 * _default_ * boplMalachiteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * boplMalachiteSize ' range=':= 0 * _default_ * boplMalachiteSize ' type='normal' />
@@ -896,7 +896,7 @@
                         <!-- Configuring contained material. -->
                         <Veins name='boplMalachiteVeinsPipe'  inherits='boplMalachiteVeins' seed='0x5A38' drawWireframe='true' wireframeColor='0x60109D81' drawBoundBox='false' boundBoxColor='0x60109D81'>
                             <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:10")'> <Replaces block='BiomesOPlenty:gemOre:10' weight='1.0' /> </IfCondition>
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * boplMalachiteSize  * 0.5 ' range=':= 0 * _default_ * boplMalachiteSize  * 0.5 ' type='normal' />
                             <Setting name='SegmentRadius' avg=':= 0.721 * _default_ * boplMalachiteSize  * 0.5 ' range=':= 0.721 * _default_ * boplMalachiteSize  * 0.5 ' type='normal' />
@@ -926,7 +926,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:10")'> <OreBlock block='BiomesOPlenty:gemOre:10' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Swamp'  />
                             <Setting name='CloudRadius' avg=':= 0.393 * _default_ * boplMalachiteSize ' range=':= 0.393 * _default_ * boplMalachiteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.393 * _default_ * boplMalachiteSize ' range=':= 0.393 * _default_ * boplMalachiteSize ' type='normal' scaleTo='base' />
@@ -978,7 +978,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:10")'> <OreBlock block='BiomesOPlenty:gemOre:10' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Swamp'  />
                             <Setting name='Size' avg=':= 1 * boplMalachiteSize ' range=':= _default_ * boplMalachiteSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 1 * boplMalachiteFreq ' range=':= _default_ * boplMalachiteFreq ' type='normal' scaleTo='base' />
@@ -1003,7 +1003,7 @@
                                 up from near the bottom  of the map.
                             </Description>
                             <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:12")'> <OreBlock block='BiomesOPlenty:gemOre:12' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='Coral Reef'  />
                             <Biome name='Crag'  />
                             <Biome name='Hot Springs'  />
@@ -1031,7 +1031,7 @@
                         <!-- Configuring contained material. -->
                         <Veins name='boplSapphireVeinsPipe'  inherits='boplSapphireVeins' seed='0x7474' drawWireframe='true' wireframeColor='0x603494C3' drawBoundBox='false' boundBoxColor='0x603494C3'>
                             <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:12")'> <Replaces block='BiomesOPlenty:gemOre:12' weight='1.0' /> </IfCondition>
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * boplSapphireSize  * 0.5 ' range=':= 0 * _default_ * boplSapphireSize  * 0.5 ' type='normal' />
                             <Setting name='SegmentRadius' avg=':= 0.721 * _default_ * boplSapphireSize  * 0.5 ' range=':= 0.721 * _default_ * boplSapphireSize  * 0.5 ' type='normal' />
@@ -1061,7 +1061,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:12")'> <OreBlock block='BiomesOPlenty:gemOre:12' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='Coral Reef'  />
                             <Biome name='Crag'  />
                             <Biome name='Hot Springs'  />
@@ -1119,7 +1119,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:12")'> <OreBlock block='BiomesOPlenty:gemOre:12' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='Coral Reef'  />
                             <Biome name='Crag'  />
                             <Biome name='Hot Springs'  />
@@ -1150,7 +1150,7 @@
                                 up from near the bottom  of the map.
                             </Description>
                             <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:14")'> <OreBlock block='BiomesOPlenty:gemOre:14' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='River'  />
                             <Biome name='Grove'  />
                             <Biome name='Shield'  />
@@ -1175,7 +1175,7 @@
                         <!-- Configuring contained material. -->
                         <Veins name='boplAmberVeinsPipe'  inherits='boplAmberVeins' seed='0x1FEF' drawWireframe='true' wireframeColor='0x60FE9D1B' drawBoundBox='false' boundBoxColor='0x60FE9D1B'>
                             <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:14")'> <Replaces block='BiomesOPlenty:gemOre:14' weight='1.0' /> </IfCondition>
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * boplAmberSize  * 0.5 ' range=':= 0 * _default_ * boplAmberSize  * 0.5 ' type='normal' />
                             <Setting name='SegmentRadius' avg=':= 0.721 * _default_ * boplAmberSize  * 0.5 ' range=':= 0.721 * _default_ * boplAmberSize  * 0.5 ' type='normal' />
@@ -1205,7 +1205,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:14")'> <OreBlock block='BiomesOPlenty:gemOre:14' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='River'  />
                             <Biome name='Grove'  />
                             <Biome name='Shield'  />
@@ -1260,7 +1260,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:14")'> <OreBlock block='BiomesOPlenty:gemOre:14' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='River'  />
                             <Biome name='Grove'  />
                             <Biome name='Shield'  />
@@ -1321,7 +1321,7 @@
                                 up from near the bottom  of the map.
                             </Description>
                             <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre")'> <OreBlock block='BiomesOPlenty:gemOre' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.270 * _default_ * boplEnderAmathystFreq ' range=':= 0.270 * _default_ * boplEnderAmathystFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * boplEnderAmathystSize ' range=':= 0 * _default_ * boplEnderAmathystSize ' type='normal' />
@@ -1343,7 +1343,7 @@
                         <!-- Configuring contained material. -->
                         <Veins name='boplEnderAmathystVeinsPipe'  inherits='boplEnderAmathystVeins' seed='0x58D8' drawWireframe='true' wireframeColor='0x60DD4EEA' drawBoundBox='false' boundBoxColor='0x60DD4EEA'>
                             <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre")'> <Replaces block='BiomesOPlenty:gemOre' weight='1.0' /> </IfCondition>
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * boplEnderAmathystSize  * 0.5 ' range=':= 0 * _default_ * boplEnderAmathystSize  * 0.5 ' type='normal' />
                             <Setting name='SegmentRadius' avg=':= 0.721 * _default_ * boplEnderAmathystSize  * 0.5 ' range=':= 0.721 * _default_ * boplEnderAmathystSize  * 0.5 ' type='normal' />
@@ -1373,7 +1373,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre")'> <OreBlock block='BiomesOPlenty:gemOre' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.393 * _default_ * boplEnderAmathystSize ' range=':= 0.393 * _default_ * boplEnderAmathystSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.393 * _default_ * boplEnderAmathystSize ' range=':= 0.393 * _default_ * boplEnderAmathystSize ' type='normal' scaleTo='base' />
@@ -1425,7 +1425,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre")'> <OreBlock block='BiomesOPlenty:gemOre' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 1 * boplEnderAmathystSize ' range=':= _default_ * boplEnderAmathystSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 1 * boplEnderAmathystFreq ' range=':= _default_ * boplEnderAmathystFreq ' type='normal' scaleTo='base' />

--- a/src/main/resources/config/modules/Chisel2.xml
+++ b/src/main/resources/config/modules/Chisel2.xml
@@ -224,7 +224,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("chisel:andesite")'> <OreBlock block='chisel:andesite' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.002 * _default_ * chslAndesiteFreq ' range=':= 2.002 * _default_ * chslAndesiteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.123 * _default_ * chslAndesiteSize ' range=':= 1.123 * _default_ * chslAndesiteSize ' type='normal' />
@@ -266,7 +266,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("chisel:andesite")'> <OreBlock block='chisel:andesite' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.323 * _default_ * chslAndesiteSize ' range=':= 1.323 * _default_ * chslAndesiteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.323 * _default_ * chslAndesiteSize ' range=':= 1.323 * _default_ * chslAndesiteSize ' type='normal' scaleTo='base' />
@@ -322,7 +322,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("chisel:diorite")'> <OreBlock block='chisel:diorite' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.002 * _default_ * chslDioriteFreq ' range=':= 2.002 * _default_ * chslDioriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.123 * _default_ * chslDioriteSize ' range=':= 1.123 * _default_ * chslDioriteSize ' type='normal' />
@@ -364,7 +364,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("chisel:diorite")'> <OreBlock block='chisel:diorite' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.323 * _default_ * chslDioriteSize ' range=':= 1.323 * _default_ * chslDioriteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.323 * _default_ * chslDioriteSize ' range=':= 1.323 * _default_ * chslDioriteSize ' type='normal' scaleTo='base' />
@@ -420,7 +420,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("chisel:granite")'> <OreBlock block='chisel:granite' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.002 * _default_ * chslGraniteFreq ' range=':= 2.002 * _default_ * chslGraniteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.123 * _default_ * chslGraniteSize ' range=':= 1.123 * _default_ * chslGraniteSize ' type='normal' />
@@ -462,7 +462,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("chisel:granite")'> <OreBlock block='chisel:granite' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.323 * _default_ * chslGraniteSize ' range=':= 1.323 * _default_ * chslGraniteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.323 * _default_ * chslGraniteSize ' range=':= 1.323 * _default_ * chslGraniteSize ' type='normal' scaleTo='base' />
@@ -518,7 +518,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("chisel:limestone")'> <OreBlock block='chisel:limestone' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.348 * _default_ * chslLimestoneFreq ' range=':= 2.348 * _default_ * chslLimestoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.153 * _default_ * chslLimestoneSize ' range=':= 1.153 * _default_ * chslLimestoneSize ' type='normal' />
@@ -560,7 +560,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("chisel:limestone")'> <OreBlock block='chisel:limestone' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.433 * _default_ * chslLimestoneSize ' range=':= 1.433 * _default_ * chslLimestoneSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.433 * _default_ * chslLimestoneSize ' range=':= 1.433 * _default_ * chslLimestoneSize ' type='normal' scaleTo='base' />
@@ -616,7 +616,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("chisel:marble")'> <OreBlock block='chisel:marble' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.196 * _default_ * chslMarbleFreq ' range=':= 2.196 * _default_ * chslMarbleFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.140 * _default_ * chslMarbleSize ' range=':= 1.140 * _default_ * chslMarbleSize ' type='normal' />
@@ -658,7 +658,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("chisel:marble")'> <OreBlock block='chisel:marble' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.386 * _default_ * chslMarbleSize ' range=':= 1.386 * _default_ * chslMarbleSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.386 * _default_ * chslMarbleSize ' range=':= 1.386 * _default_ * chslMarbleSize ' type='normal' scaleTo='base' />

--- a/src/main/resources/config/modules/DenseOres.xml
+++ b/src/main/resources/config/modules/DenseOres.xml
@@ -365,7 +365,7 @@
                             </Description>
                             <IfCondition condition=':= ?blockExists("minecraft:iron_ore")'> <OreBlock block='minecraft:iron_ore' weight='0.9' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("denseores:block0")'> <OreBlock block='denseores:block0' weight='0.1' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.583 * _default_ * dnsoIronFreq ' range=':= 1.583 * _default_ * dnsoIronFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.080 * _default_ * dnsoIronSize ' range=':= 1.080 * _default_ * dnsoIronSize ' type='normal' />
@@ -398,7 +398,7 @@
                             </Description>
                             <IfCondition condition=':= ?blockExists("minecraft:iron_ore")'> <OreBlock block='minecraft:iron_ore' weight='0.9' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("denseores:block0")'> <OreBlock block='denseores:block0' weight='0.1' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 8.000 * dnsoIronSize ' range=':= _default_ * dnsoIronSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 10.000 * dnsoIronFreq ' range=':= _default_ * dnsoIronFreq ' type='normal' scaleTo='base' />
@@ -430,7 +430,7 @@
                             </Description>
                             <IfCondition condition=':= ?blockExists("minecraft:iron_ore")'> <OreBlock block='minecraft:iron_ore' weight='0.9' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("denseores:block0")'> <OreBlock block='denseores:block0' weight='0.1' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.177 * _default_ * dnsoIronSize ' range=':= 1.177 * _default_ * dnsoIronSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.177 * _default_ * dnsoIronSize ' range=':= 1.177 * _default_ * dnsoIronSize ' type='normal' scaleTo='base' />
@@ -488,7 +488,7 @@
                             </Description>
                             <IfCondition condition=':= ?blockExists("minecraft:gold_ore")'> <OreBlock block='minecraft:gold_ore' weight='0.9' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("denseores:block0:1")'> <OreBlock block='denseores:block0:1' weight='0.1' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.500 * _default_ * dnsoGoldFreq ' range=':= 0.500 * _default_ * dnsoGoldFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.891 * _default_ * dnsoGoldSize ' range=':= 0.891 * _default_ * dnsoGoldSize ' type='normal' />
@@ -521,7 +521,7 @@
                             </Description>
                             <IfCondition condition=':= ?blockExists("minecraft:gold_ore")'> <OreBlock block='minecraft:gold_ore' weight='0.9' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("denseores:block0:1")'> <OreBlock block='denseores:block0:1' weight='0.1' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 8.000 * dnsoGoldSize ' range=':= _default_ * dnsoGoldSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 1.000 * dnsoGoldFreq ' range=':= _default_ * dnsoGoldFreq ' type='normal' scaleTo='base' />
@@ -553,7 +553,7 @@
                             </Description>
                             <IfCondition condition=':= ?blockExists("minecraft:gold_ore")'> <OreBlock block='minecraft:gold_ore' weight='0.9' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("denseores:block0:1")'> <OreBlock block='denseores:block0:1' weight='0.1' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.662 * _default_ * dnsoGoldSize ' range=':= 0.662 * _default_ * dnsoGoldSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.662 * _default_ * dnsoGoldSize ' range=':= 0.662 * _default_ * dnsoGoldSize ' type='normal' scaleTo='base' />
@@ -611,7 +611,7 @@
                             </Description>
                             <IfCondition condition=':= ?blockExists("minecraft:lapis_ore")'> <OreBlock block='minecraft:lapis_ore' weight='0.9' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("denseores:block0:2")'> <OreBlock block='denseores:block0:2' weight='0.1' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.787 * _default_ * dnsoLapisFreq ' range=':= 0.787 * _default_ * dnsoLapisFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * dnsoLapisSize ' range=':= 0 * _default_ * dnsoLapisSize ' type='normal' />
@@ -638,7 +638,7 @@
                             </Description>
                             <IfCondition condition=':= ?blockExists("minecraft:lapis_ore")'> <OreBlock block='minecraft:lapis_ore' weight='0.9' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("denseores:block0:2")'> <OreBlock block='denseores:block0:2' weight='0.1' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Ocean'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.787 * _default_ * dnsoLapisFreq ' range=':= 0.787 * _default_ * dnsoLapisFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * dnsoLapisSize ' range=':= 0 * _default_ * dnsoLapisSize ' type='normal' />
@@ -673,7 +673,7 @@
                             </Description>
                             <IfCondition condition=':= ?blockExists("minecraft:lapis_ore")'> <OreBlock block='minecraft:lapis_ore' weight='0.9' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("denseores:block0:2")'> <OreBlock block='denseores:block0:2' weight='0.1' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 6.000 * dnsoLapisSize ' range=':= _default_ * dnsoLapisSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 1.000 * dnsoLapisFreq ' range=':= _default_ * dnsoLapisFreq ' type='normal' scaleTo='base' />
@@ -705,7 +705,7 @@
                             </Description>
                             <IfCondition condition=':= ?blockExists("minecraft:lapis_ore")'> <OreBlock block='minecraft:lapis_ore' weight='0.9' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("denseores:block0:2")'> <OreBlock block='denseores:block0:2' weight='0.1' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.616 * _default_ * dnsoLapisSize ' range=':= 0.616 * _default_ * dnsoLapisSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.616 * _default_ * dnsoLapisSize ' range=':= 0.616 * _default_ * dnsoLapisSize ' type='normal' scaleTo='base' />
@@ -753,7 +753,7 @@
                             </Description>
                             <IfCondition condition=':= ?blockExists("minecraft:lapis_ore")'> <OreBlock block='minecraft:lapis_ore' weight='0.9' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("denseores:block0:2")'> <OreBlock block='denseores:block0:2' weight='0.1' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Ocean'  />
                             <Setting name='CloudRadius' avg=':= 0.616 * _default_ * dnsoLapisSize ' range=':= 0.616 * _default_ * dnsoLapisSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.616 * _default_ * dnsoLapisSize ' range=':= 0.616 * _default_ * dnsoLapisSize ' type='normal' scaleTo='base' />
@@ -797,7 +797,7 @@
                             </Description>
                             <IfCondition condition=':= ?blockExists("minecraft:diamond_ore")'> <OreBlock block='minecraft:diamond_ore' weight='0.9' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("denseores:block0:3")'> <OreBlock block='denseores:block0:3' weight='0.1' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.505 * _default_ * dnsoDiamondFreq ' range=':= 0.505 * _default_ * dnsoDiamondFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * dnsoDiamondSize ' range=':= 0 * _default_ * dnsoDiamondSize ' type='normal' />
@@ -819,7 +819,7 @@
                         <!-- Configuring contained material. -->
                         <Veins name='dnsoDiamondVeinsPipe'  inherits='dnsoDiamondVeins' seed='0x197B' drawWireframe='true' wireframeColor='0x608BF4E3' drawBoundBox='false' boundBoxColor='0x608BF4E3'>
                             <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <IfCondition condition=':= ?blockExists("minecraft:diamond_ore")'> <Replaces block='minecraft:diamond_ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("denseores:block0:3")'> <Replaces block='denseores:block0:3' weight='1.0' /> </IfCondition>
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * dnsoDiamondSize  * 0.5 ' range=':= 0 * _default_ * dnsoDiamondSize  * 0.5 ' type='normal' />
@@ -841,7 +841,7 @@
                             </Description>
                             <IfCondition condition=':= ?blockExists("minecraft:diamond_ore")'> <OreBlock block='minecraft:diamond_ore' weight='0.9' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("denseores:block0:3")'> <OreBlock block='denseores:block0:3' weight='0.1' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 7.000 * dnsoDiamondSize ' range=':= _default_ * dnsoDiamondSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 0.500 * dnsoDiamondFreq ' range=':= _default_ * dnsoDiamondFreq ' type='normal' scaleTo='base' />
@@ -873,7 +873,7 @@
                             </Description>
                             <IfCondition condition=':= ?blockExists("minecraft:diamond_ore")'> <OreBlock block='minecraft:diamond_ore' weight='0.9' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("denseores:block0:3")'> <OreBlock block='denseores:block0:3' weight='0.1' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.538 * _default_ * dnsoDiamondSize ' range=':= 0.538 * _default_ * dnsoDiamondSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.538 * _default_ * dnsoDiamondSize ' range=':= 0.538 * _default_ * dnsoDiamondSize ' type='normal' scaleTo='base' />
@@ -931,7 +931,7 @@
                             </Description>
                             <IfCondition condition=':= ?blockExists("minecraft:emerald_ore")'> <OreBlock block='minecraft:emerald_ore' weight='0.9' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("denseores:block0:4")'> <OreBlock block='denseores:block0:4' weight='0.1' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Mountain'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.121 * _default_ * dnsoEmeraldFreq ' range=':= 0.121 * _default_ * dnsoEmeraldFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * dnsoEmeraldSize ' range=':= 0 * _default_ * dnsoEmeraldSize ' type='normal' />
@@ -953,7 +953,7 @@
                         <!-- Configuring contained material. -->
                         <Veins name='dnsoEmeraldVeinsPipe'  inherits='dnsoEmeraldVeins' seed='0x81E5' drawWireframe='true' wireframeColor='0x606CE391' drawBoundBox='false' boundBoxColor='0x606CE391'>
                             <IfCondition condition=':= ?blockExists("minecraft:monster_egg")'> <OreBlock block='minecraft:monster_egg' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <IfCondition condition=':= ?blockExists("minecraft:emerald_ore")'> <Replaces block='minecraft:emerald_ore' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("denseores:block0:4")'> <Replaces block='denseores:block0:4' weight='1.0' /> </IfCondition>
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * dnsoEmeraldSize  * 0.5 ' range=':= 0 * _default_ * dnsoEmeraldSize  * 0.5 ' type='normal' />
@@ -975,7 +975,7 @@
                             </Description>
                             <IfCondition condition=':= ?blockExists("minecraft:emerald_ore")'> <OreBlock block='minecraft:emerald_ore' weight='0.9' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("denseores:block0:4")'> <OreBlock block='denseores:block0:4' weight='0.1' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Mountain'  />
                             <Setting name='Size' avg=':= 1.000 * dnsoEmeraldSize ' range=':= _default_ * dnsoEmeraldSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 0.200 * dnsoEmeraldFreq ' range=':= _default_ * dnsoEmeraldFreq ' type='normal' scaleTo='base' />
@@ -1007,7 +1007,7 @@
                             </Description>
                             <IfCondition condition=':= ?blockExists("minecraft:emerald_ore")'> <OreBlock block='minecraft:emerald_ore' weight='0.9' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("denseores:block0:4")'> <OreBlock block='denseores:block0:4' weight='0.1' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Mountain'  />
                             <Setting name='CloudRadius' avg=':= 0.263 * _default_ * dnsoEmeraldSize ' range=':= 0.263 * _default_ * dnsoEmeraldSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.263 * _default_ * dnsoEmeraldSize ' range=':= 0.263 * _default_ * dnsoEmeraldSize ' type='normal' scaleTo='base' />
@@ -1065,7 +1065,7 @@
                             </Description>
                             <IfCondition condition=':= ?blockExists("minecraft:redstone_ore")'> <OreBlock block='minecraft:redstone_ore' weight='0.9' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("denseores:block0:5")'> <OreBlock block='denseores:block0:5' weight='0.1' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.575 * _default_ * dnsoRedstoneFreq ' range=':= 1.575 * _default_ * dnsoRedstoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * dnsoRedstoneSize ' range=':= 0 * _default_ * dnsoRedstoneSize ' type='normal' />
@@ -1092,7 +1092,7 @@
                             </Description>
                             <IfCondition condition=':= ?blockExists("minecraft:redstone_ore")'> <OreBlock block='minecraft:redstone_ore' weight='0.9' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("denseores:block0:5")'> <OreBlock block='denseores:block0:5' weight='0.1' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Desert'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.575 * _default_ * dnsoRedstoneFreq ' range=':= 1.575 * _default_ * dnsoRedstoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * dnsoRedstoneSize ' range=':= 0 * _default_ * dnsoRedstoneSize ' type='normal' />
@@ -1127,7 +1127,7 @@
                             </Description>
                             <IfCondition condition=':= ?blockExists("minecraft:redstone_ore")'> <OreBlock block='minecraft:redstone_ore' weight='0.9' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("denseores:block0:5")'> <OreBlock block='denseores:block0:5' weight='0.1' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 6.000 * dnsoRedstoneSize ' range=':= _default_ * dnsoRedstoneSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 4.000 * dnsoRedstoneFreq ' range=':= _default_ * dnsoRedstoneFreq ' type='normal' scaleTo='base' />
@@ -1159,7 +1159,7 @@
                             </Description>
                             <IfCondition condition=':= ?blockExists("minecraft:redstone_ore")'> <OreBlock block='minecraft:redstone_ore' weight='0.9' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("denseores:block0:5")'> <OreBlock block='denseores:block0:5' weight='0.1' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.871 * _default_ * dnsoRedstoneSize ' range=':= 0.871 * _default_ * dnsoRedstoneSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.871 * _default_ * dnsoRedstoneSize ' range=':= 0.871 * _default_ * dnsoRedstoneSize ' type='normal' scaleTo='base' />
@@ -1207,7 +1207,7 @@
                             </Description>
                             <IfCondition condition=':= ?blockExists("minecraft:redstone_ore")'> <OreBlock block='minecraft:redstone_ore' weight='0.9' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("denseores:block0:5")'> <OreBlock block='denseores:block0:5' weight='0.1' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Desert'  />
                             <Setting name='CloudRadius' avg=':= 0.871 * _default_ * dnsoRedstoneSize ' range=':= 0.871 * _default_ * dnsoRedstoneSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.871 * _default_ * dnsoRedstoneSize ' range=':= 0.871 * _default_ * dnsoRedstoneSize ' type='normal' scaleTo='base' />
@@ -1258,7 +1258,7 @@
                             </Description>
                             <IfCondition condition=':= ?blockExists("minecraft:coal_ore")'> <OreBlock block='minecraft:coal_ore' weight='0.9' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("denseores:block0:6")'> <OreBlock block='denseores:block0:6' weight='0.1' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 5.198 * _default_ * dnsoCoalFreq ' range=':= 5.198 * _default_ * dnsoCoalFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * dnsoCoalSize ' range=':= 0 * _default_ * dnsoCoalSize ' type='normal' />
@@ -1301,7 +1301,7 @@
                             </Description>
                             <IfCondition condition=':= ?blockExists("minecraft:coal_ore")'> <OreBlock block='minecraft:coal_ore' weight='0.9' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("denseores:block0:6")'> <OreBlock block='denseores:block0:6' weight='0.1' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.363 * _default_ * dnsoCoalSize ' range=':= 1.363 * _default_ * dnsoCoalSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.363 * _default_ * dnsoCoalSize ' range=':= 1.363 * _default_ * dnsoCoalSize ' type='normal' scaleTo='base' />
@@ -1355,7 +1355,7 @@
                             </Description>
                             <IfCondition condition=':= ?blockExists("minecraft:coal_ore")'> <OreBlock block='minecraft:coal_ore' weight='0.9' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("denseores:block0:6")'> <OreBlock block='denseores:block0:6' weight='0.1' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 16.000 * dnsoCoalSize ' range=':= _default_ * dnsoCoalSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 9.000 * dnsoCoalFreq ' range=':= _default_ * dnsoCoalFreq ' type='normal' scaleTo='base' />
@@ -1387,7 +1387,7 @@
                             </Description>
                             <IfCondition condition=':= ?blockExists("minecraft:coal_ore")'> <OreBlock block='minecraft:coal_ore' weight='0.9' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("denseores:block0:6")'> <OreBlock block='denseores:block0:6' weight='0.1' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.363 * _default_ * dnsoCoalSize ' range=':= 1.363 * _default_ * dnsoCoalSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.363 * _default_ * dnsoCoalSize ' range=':= 1.363 * _default_ * dnsoCoalSize ' type='normal' scaleTo='base' />

--- a/src/main/resources/config/modules/ElectriCraft.xml
+++ b/src/main/resources/config/modules/ElectriCraft.xml
@@ -285,7 +285,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore")'> <OreBlock block='ElectriCraft:electricraft_block_ore' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.226 * _default_ * elcrCopperFreq ' range=':= 1.226 * _default_ * elcrCopperFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.035 * _default_ * elcrCopperSize ' range=':= 1.035 * _default_ * elcrCopperSize ' type='normal' />
@@ -317,7 +317,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore")'> <OreBlock block='ElectriCraft:electricraft_block_ore' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 6.000 * elcrCopperSize ' range=':= _default_ * elcrCopperSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 8.000 * elcrCopperFreq ' range=':= _default_ * elcrCopperFreq ' type='normal' scaleTo='base' />
@@ -348,7 +348,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore")'> <OreBlock block='ElectriCraft:electricraft_block_ore' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.036 * _default_ * elcrCopperSize ' range=':= 1.036 * _default_ * elcrCopperSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.036 * _default_ * elcrCopperSize ' range=':= 1.036 * _default_ * elcrCopperSize ' type='normal' scaleTo='base' />
@@ -404,7 +404,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:1")'> <OreBlock block='ElectriCraft:electricraft_block_ore:1' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.416 * _default_ * elcrTinFreq ' range=':= 1.416 * _default_ * elcrTinFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.060 * _default_ * elcrTinSize ' range=':= 1.060 * _default_ * elcrTinSize ' type='normal' />
@@ -436,7 +436,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:1")'> <OreBlock block='ElectriCraft:electricraft_block_ore:1' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 8.000 * elcrTinSize ' range=':= _default_ * elcrTinSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 8.000 * elcrTinFreq ' range=':= _default_ * elcrTinFreq ' type='normal' scaleTo='base' />
@@ -467,7 +467,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:1")'> <OreBlock block='ElectriCraft:electricraft_block_ore:1' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.113 * _default_ * elcrTinSize ' range=':= 1.113 * _default_ * elcrTinSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.113 * _default_ * elcrTinSize ' range=':= 1.113 * _default_ * elcrTinSize ' type='normal' scaleTo='base' />
@@ -523,7 +523,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:2")'> <OreBlock block='ElectriCraft:electricraft_block_ore:2' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.867 * _default_ * elcrSilverFreq ' range=':= 0.867 * _default_ * elcrSilverFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.976 * _default_ * elcrSilverSize ' range=':= 0.976 * _default_ * elcrSilverSize ' type='normal' />
@@ -555,7 +555,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:2")'> <OreBlock block='ElectriCraft:electricraft_block_ore:2' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 6.000 * elcrSilverSize ' range=':= _default_ * elcrSilverSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 4.000 * elcrSilverFreq ' range=':= _default_ * elcrSilverFreq ' type='normal' scaleTo='base' />
@@ -586,7 +586,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:2")'> <OreBlock block='ElectriCraft:electricraft_block_ore:2' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.871 * _default_ * elcrSilverSize ' range=':= 0.871 * _default_ * elcrSilverSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.871 * _default_ * elcrSilverSize ' range=':= 0.871 * _default_ * elcrSilverSize ' type='normal' scaleTo='base' />
@@ -642,7 +642,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:3")'> <OreBlock block='ElectriCraft:electricraft_block_ore:3' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.226 * _default_ * elcrNickelFreq ' range=':= 1.226 * _default_ * elcrNickelFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.035 * _default_ * elcrNickelSize ' range=':= 1.035 * _default_ * elcrNickelSize ' type='normal' />
@@ -674,7 +674,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:3")'> <OreBlock block='ElectriCraft:electricraft_block_ore:3' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 8.000 * elcrNickelSize ' range=':= _default_ * elcrNickelSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 6.000 * elcrNickelFreq ' range=':= _default_ * elcrNickelFreq ' type='normal' scaleTo='base' />
@@ -705,7 +705,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:3")'> <OreBlock block='ElectriCraft:electricraft_block_ore:3' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.036 * _default_ * elcrNickelSize ' range=':= 1.036 * _default_ * elcrNickelSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.036 * _default_ * elcrNickelSize ' range=':= 1.036 * _default_ * elcrNickelSize ' type='normal' scaleTo='base' />
@@ -761,7 +761,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:4")'> <OreBlock block='ElectriCraft:electricraft_block_ore:4' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.583 * _default_ * elcrAluminumFreq ' range=':= 1.583 * _default_ * elcrAluminumFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.080 * _default_ * elcrAluminumSize ' range=':= 1.080 * _default_ * elcrAluminumSize ' type='normal' />
@@ -793,7 +793,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:4")'> <OreBlock block='ElectriCraft:electricraft_block_ore:4' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 8.000 * elcrAluminumSize ' range=':= _default_ * elcrAluminumSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 10.000 * elcrAluminumFreq ' range=':= _default_ * elcrAluminumFreq ' type='normal' scaleTo='base' />
@@ -824,7 +824,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:4")'> <OreBlock block='ElectriCraft:electricraft_block_ore:4' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.177 * _default_ * elcrAluminumSize ' range=':= 1.177 * _default_ * elcrAluminumSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.177 * _default_ * elcrAluminumSize ' range=':= 1.177 * _default_ * elcrAluminumSize ' type='normal' scaleTo='base' />
@@ -880,7 +880,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:5")'> <OreBlock block='ElectriCraft:electricraft_block_ore:5' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.500 * _default_ * elcrPlatinumFreq ' range=':= 0.500 * _default_ * elcrPlatinumFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.891 * _default_ * elcrPlatinumSize ' range=':= 0.891 * _default_ * elcrPlatinumSize ' type='normal' />
@@ -912,7 +912,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:5")'> <OreBlock block='ElectriCraft:electricraft_block_ore:5' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * elcrPlatinumSize ' range=':= _default_ * elcrPlatinumSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 2.000 * elcrPlatinumFreq ' range=':= _default_ * elcrPlatinumFreq ' type='normal' scaleTo='base' />
@@ -943,7 +943,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:5")'> <OreBlock block='ElectriCraft:electricraft_block_ore:5' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.662 * _default_ * elcrPlatinumSize ' range=':= 0.662 * _default_ * elcrPlatinumSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.662 * _default_ * elcrPlatinumSize ' range=':= 0.662 * _default_ * elcrPlatinumSize ' type='normal' scaleTo='base' />

--- a/src/main/resources/config/modules/Factorization.xml
+++ b/src/main/resources/config/modules/Factorization.xml
@@ -142,7 +142,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("factorization:ResourceBlock")'> <OreBlock block='factorization:ResourceBlock' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.811 * _default_ * fctrSilverFreq ' range=':= 0.811 * _default_ * fctrSilverFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.966 * _default_ * fctrSilverSize ' range=':= 0.966 * _default_ * fctrSilverSize ' type='normal' />
@@ -184,7 +184,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("factorization:ResourceBlock")'> <OreBlock block='factorization:ResourceBlock' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.842 * _default_ * fctrSilverSize ' range=':= 0.842 * _default_ * fctrSilverSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.842 * _default_ * fctrSilverSize ' range=':= 0.842 * _default_ * fctrSilverSize ' type='normal' scaleTo='base' />
@@ -236,7 +236,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("factorization:ResourceBlock")'> <OreBlock block='factorization:ResourceBlock' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 7.000 * fctrSilverSize ' range=':= _default_ * fctrSilverSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 3.000 * fctrSilverFreq ' range=':= _default_ * fctrSilverFreq ' type='normal' scaleTo='base' />
@@ -268,9 +268,9 @@
                                 their  direction while mining.
                             </Description>
                             <IfCondition condition=':= ?blockExists("factorization:DarkIronOre")'> <OreBlock block='factorization:DarkIronOre' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("dirt")'> <ReplacesOre block='dirt' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("gravel")'> <ReplacesOre block='gravel' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.433 * _default_ * fctrDarkIronFreq ' range=':= 0.433 * _default_ * fctrDarkIronFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * fctrDarkIronSize ' range=':= 0 * _default_ * fctrDarkIronSize ' type='normal' />
@@ -312,9 +312,9 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("factorization:DarkIronOre")'> <OreBlock block='factorization:DarkIronOre' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("dirt")'> <ReplacesOre block='dirt' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("gravel")'> <ReplacesOre block='gravel' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.393 * _default_ * fctrDarkIronSize ' range=':= 0.393 * _default_ * fctrDarkIronSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.393 * _default_ * fctrDarkIronSize ' range=':= 0.393 * _default_ * fctrDarkIronSize ' type='normal' scaleTo='base' />
@@ -366,9 +366,9 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("factorization:DarkIronOre")'> <OreBlock block='factorization:DarkIronOre' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("dirt")'> <ReplacesOre block='dirt' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("gravel")'> <ReplacesOre block='gravel' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 1.000 * fctrDarkIronSize ' range=':= _default_ * fctrDarkIronSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 1.000 * fctrDarkIronFreq ' range=':= _default_ * fctrDarkIronFreq ' type='normal' scaleTo='base' />

--- a/src/main/resources/config/modules/FlaxbeardsSteamcraft.xml
+++ b/src/main/resources/config/modules/FlaxbeardsSteamcraft.xml
@@ -143,7 +143,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Steamcraft:steamcraftOre")'> <OreBlock block='Steamcraft:steamcraftOre' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.251 * _default_ * flxbCopperFreq ' range=':= 1.251 * _default_ * flxbCopperFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.038 * _default_ * flxbCopperSize ' range=':= 1.038 * _default_ * flxbCopperSize ' type='normal' />
@@ -185,7 +185,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Steamcraft:steamcraftOre")'> <OreBlock block='Steamcraft:steamcraftOre' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.046 * _default_ * flxbCopperSize ' range=':= 1.046 * _default_ * flxbCopperSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.046 * _default_ * flxbCopperSize ' range=':= 1.046 * _default_ * flxbCopperSize ' type='normal' scaleTo='base' />
@@ -237,7 +237,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Steamcraft:steamcraftOre")'> <OreBlock block='Steamcraft:steamcraftOre' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 5.000 * flxbCopperSize ' range=':= _default_ * flxbCopperSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 10.000 * flxbCopperFreq ' range=':= _default_ * flxbCopperFreq ' type='normal' scaleTo='base' />
@@ -262,7 +262,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Steamcraft:steamcraftOre:1")'> <OreBlock block='Steamcraft:steamcraftOre:1' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.936 * _default_ * flxbZincFreq ' range=':= 0.936 * _default_ * flxbZincFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.989 * _default_ * flxbZincSize ' range=':= 0.989 * _default_ * flxbZincSize ' type='normal' />
@@ -304,7 +304,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Steamcraft:steamcraftOre:1")'> <OreBlock block='Steamcraft:steamcraftOre:1' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.905 * _default_ * flxbZincSize ' range=':= 0.905 * _default_ * flxbZincSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.905 * _default_ * flxbZincSize ' range=':= 0.905 * _default_ * flxbZincSize ' type='normal' scaleTo='base' />
@@ -356,7 +356,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Steamcraft:steamcraftOre:1")'> <OreBlock block='Steamcraft:steamcraftOre:1' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * flxbZincSize ' range=':= _default_ * flxbZincSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 7.000 * flxbZincFreq ' range=':= _default_ * flxbZincFreq ' type='normal' scaleTo='base' />

--- a/src/main/resources/config/modules/Forestry.xml
+++ b/src/main/resources/config/modules/Forestry.xml
@@ -184,7 +184,7 @@
                                 their  direction while mining.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Forestry:resources")'> <OreBlock block='Forestry:resources' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.599 * _default_ * frstApatiteFreq ' range=':= 2.599 * _default_ * frstApatiteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * frstApatiteSize ' range=':= 0 * _default_ * frstApatiteSize ' type='normal' />
@@ -226,7 +226,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Forestry:resources")'> <OreBlock block='Forestry:resources' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.964 * _default_ * frstApatiteSize ' range=':= 0.964 * _default_ * frstApatiteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.964 * _default_ * frstApatiteSize ' range=':= 0.964 * _default_ * frstApatiteSize ' type='normal' scaleTo='base' />
@@ -278,7 +278,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Forestry:resources")'> <OreBlock block='Forestry:resources' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 36.000 * frstApatiteSize ' range=':= _default_ * frstApatiteSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 1.000 * frstApatiteFreq ' range=':= _default_ * frstApatiteFreq ' type='normal' scaleTo='base' />
@@ -303,7 +303,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Forestry:resources:1")'> <OreBlock block='Forestry:resources:1' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.938 * _default_ * frstCopperFreq ' range=':= 1.938 * _default_ * frstCopperFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.117 * _default_ * frstCopperSize ' range=':= 1.117 * _default_ * frstCopperSize ' type='normal' />
@@ -345,7 +345,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Forestry:resources:1")'> <OreBlock block='Forestry:resources:1' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.302 * _default_ * frstCopperSize ' range=':= 1.302 * _default_ * frstCopperSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.302 * _default_ * frstCopperSize ' range=':= 1.302 * _default_ * frstCopperSize ' type='normal' scaleTo='base' />
@@ -397,7 +397,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Forestry:resources:1")'> <OreBlock block='Forestry:resources:1' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 6.000 * frstCopperSize ' range=':= _default_ * frstCopperSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 20.000 * frstCopperFreq ' range=':= _default_ * frstCopperFreq ' type='normal' scaleTo='base' />
@@ -422,7 +422,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Forestry:resources:2")'> <OreBlock block='Forestry:resources:2' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.839 * _default_ * frstTinFreq ' range=':= 1.839 * _default_ * frstTinFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.107 * _default_ * frstTinSize ' range=':= 1.107 * _default_ * frstTinSize ' type='normal' />
@@ -464,7 +464,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Forestry:resources:2")'> <OreBlock block='Forestry:resources:2' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.268 * _default_ * frstTinSize ' range=':= 1.268 * _default_ * frstTinSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.268 * _default_ * frstTinSize ' range=':= 1.268 * _default_ * frstTinSize ' type='normal' scaleTo='base' />
@@ -516,7 +516,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Forestry:resources:2")'> <OreBlock block='Forestry:resources:2' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 6.000 * frstTinSize ' range=':= _default_ * frstTinSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 18.000 * frstTinFreq ' range=':= _default_ * frstTinFreq ' type='normal' scaleTo='base' />

--- a/src/main/resources/config/modules/FossilsandArchaeology.xml
+++ b/src/main/resources/config/modules/FossilsandArchaeology.xml
@@ -150,7 +150,7 @@
                                 their  direction while mining.
                             </Description>
                             <IfCondition condition=':= ?blockExists("fossil:fossil")'> <OreBlock block='fossil:fossil' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 7.552 * _default_ * fsarFossilsFreq ' range=':= 7.552 * _default_ * fsarFossilsFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * fsarFossilsSize ' range=':= 0 * _default_ * fsarFossilsSize ' type='normal' />
@@ -176,7 +176,7 @@
                                 preferred biomes.
                             </Description>
                             <IfCondition condition=':= ?blockExists("fossil:fossil")'> <OreBlock block='fossil:fossil' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Swamp'  />
                             <BiomeType name='desert'  />
                             <Setting name='MotherlodeFrequency' avg=':= 7.552 * _default_ * fsarFossilsFreq ' range=':= 7.552 * _default_ * fsarFossilsFreq ' type='normal' scaleTo='base' />
@@ -221,7 +221,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("fossil:fossil")'> <OreBlock block='fossil:fossil' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.643 * _default_ * fsarFossilsSize ' range=':= 1.643 * _default_ * fsarFossilsSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.643 * _default_ * fsarFossilsSize ' range=':= 1.643 * _default_ * fsarFossilsSize ' type='normal' scaleTo='base' />
@@ -267,7 +267,7 @@
                                 preferred biomes.
                             </Description>
                             <IfCondition condition=':= ?blockExists("fossil:fossil")'> <OreBlock block='fossil:fossil' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Swamp'  />
                             <BiomeType name='desert'  />
                             <Setting name='CloudRadius' avg=':= 1.643 * _default_ * fsarFossilsSize ' range=':= 1.643 * _default_ * fsarFossilsSize ' type='normal' />
@@ -306,7 +306,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("fossil:fossil")'> <OreBlock block='fossil:fossil' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 8.000 * fsarFossilsSize ' range=':= _default_ * fsarFossilsSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 38.000 * fsarFossilsFreq ' range=':= _default_ * fsarFossilsFreq ' type='normal' scaleTo='base' />
@@ -338,7 +338,7 @@
                                 their  direction while mining.
                             </Description>
                             <IfCondition condition=':= ?blockExists("fossil:permafrost")'> <OreBlock block='fossil:permafrost' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <BiomeType name='Frozen'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.450 * _default_ * fsarPermafrostFreq ' range=':= 2.450 * _default_ * fsarPermafrostFreq ' type='normal' scaleTo='base' />
@@ -381,7 +381,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("fossil:permafrost")'> <OreBlock block='fossil:permafrost' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <BiomeType name='Frozen'  />
                             <Setting name='CloudRadius' avg=':= 0.936 * _default_ * fsarPermafrostSize ' range=':= 0.936 * _default_ * fsarPermafrostSize ' type='normal' />
@@ -434,7 +434,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("fossil:permafrost")'> <OreBlock block='fossil:permafrost' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <BiomeType name='Frozen'  />
                             <Setting name='Size' avg=':= 4.000 * fsarPermafrostSize ' range=':= _default_ * fsarPermafrostSize ' type='normal' />

--- a/src/main/resources/config/modules/Galacticraft.xml
+++ b/src/main/resources/config/modules/Galacticraft.xml
@@ -212,7 +212,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("GalacticraftCore:tile.gcBlockCore:5")'> <OreBlock block='GalacticraftCore:tile.gcBlockCore:5' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.294 * _default_ * glctCopperFreq ' range=':= 2.294 * _default_ * glctCopperFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.148 * _default_ * glctCopperSize ' range=':= 1.148 * _default_ * glctCopperSize ' type='normal' />
@@ -254,7 +254,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("GalacticraftCore:tile.gcBlockCore:5")'> <OreBlock block='GalacticraftCore:tile.gcBlockCore:5' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.417 * _default_ * glctCopperSize ' range=':= 1.417 * _default_ * glctCopperSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.417 * _default_ * glctCopperSize ' range=':= 1.417 * _default_ * glctCopperSize ' type='normal' scaleTo='base' />
@@ -306,7 +306,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("GalacticraftCore:tile.gcBlockCore:5")'> <OreBlock block='GalacticraftCore:tile.gcBlockCore:5' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 7.000 * glctCopperSize ' range=':= _default_ * glctCopperSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 24.000 * glctCopperFreq ' range=':= _default_ * glctCopperFreq ' type='normal' scaleTo='base' />
@@ -331,7 +331,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("GalacticraftCore:tile.gcBlockCore:6")'> <OreBlock block='GalacticraftCore:tile.gcBlockCore:6' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.196 * _default_ * glctTinFreq ' range=':= 2.196 * _default_ * glctTinFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.140 * _default_ * glctTinSize ' range=':= 1.140 * _default_ * glctTinSize ' type='normal' />
@@ -373,7 +373,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("GalacticraftCore:tile.gcBlockCore:6")'> <OreBlock block='GalacticraftCore:tile.gcBlockCore:6' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.386 * _default_ * glctTinSize ' range=':= 1.386 * _default_ * glctTinSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.386 * _default_ * glctTinSize ' range=':= 1.386 * _default_ * glctTinSize ' type='normal' scaleTo='base' />
@@ -425,7 +425,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("GalacticraftCore:tile.gcBlockCore:6")'> <OreBlock block='GalacticraftCore:tile.gcBlockCore:6' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 7.000 * glctTinSize ' range=':= _default_ * glctTinSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 22.000 * glctTinFreq ' range=':= _default_ * glctTinFreq ' type='normal' scaleTo='base' />
@@ -450,7 +450,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("GalacticraftCore:tile.gcBlockCore:7")'> <OreBlock block='GalacticraftCore:tile.gcBlockCore:7' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.986 * _default_ * glctAluminumFreq ' range=':= 1.986 * _default_ * glctAluminumFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.121 * _default_ * glctAluminumSize ' range=':= 1.121 * _default_ * glctAluminumSize ' type='normal' />
@@ -492,7 +492,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("GalacticraftCore:tile.gcBlockCore:7")'> <OreBlock block='GalacticraftCore:tile.gcBlockCore:7' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.318 * _default_ * glctAluminumSize ' range=':= 1.318 * _default_ * glctAluminumSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.318 * _default_ * glctAluminumSize ' range=':= 1.318 * _default_ * glctAluminumSize ' type='normal' scaleTo='base' />
@@ -544,7 +544,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("GalacticraftCore:tile.gcBlockCore:7")'> <OreBlock block='GalacticraftCore:tile.gcBlockCore:7' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 7.000 * glctAluminumSize ' range=':= _default_ * glctAluminumSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 18.000 * glctAluminumFreq ' range=':= _default_ * glctAluminumFreq ' type='normal' scaleTo='base' />
@@ -569,7 +569,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("GalacticraftCore:tile.gcBlockCore:8")'> <OreBlock block='GalacticraftCore:tile.gcBlockCore:8' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.811 * _default_ * glctSiliconFreq ' range=':= 0.811 * _default_ * glctSiliconFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.966 * _default_ * glctSiliconSize ' range=':= 0.966 * _default_ * glctSiliconSize ' type='normal' />
@@ -611,7 +611,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("GalacticraftCore:tile.gcBlockCore:8")'> <OreBlock block='GalacticraftCore:tile.gcBlockCore:8' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.842 * _default_ * glctSiliconSize ' range=':= 0.842 * _default_ * glctSiliconSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.842 * _default_ * glctSiliconSize ' range=':= 0.842 * _default_ * glctSiliconSize ' type='normal' scaleTo='base' />
@@ -663,7 +663,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("GalacticraftCore:tile.gcBlockCore:8")'> <OreBlock block='GalacticraftCore:tile.gcBlockCore:8' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 7.000 * glctSiliconSize ' range=':= _default_ * glctSiliconSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 3.000 * glctSiliconFreq ' range=':= _default_ * glctSiliconFreq ' type='normal' scaleTo='base' />

--- a/src/main/resources/config/modules/GeoStrata.xml
+++ b/src/main/resources/config/modules/GeoStrata.xml
@@ -669,7 +669,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_shale_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_shale_smooth' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 4.904 * _default_ * gstaShaleFreq ' range=':= 4.904 * _default_ * gstaShaleFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.303 * _default_ * gstaShaleSize ' range=':= 1.303 * _default_ * gstaShaleSize ' type='normal' />
@@ -711,7 +711,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_shale_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_shale_smooth' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 2.071 * _default_ * gstaShaleSize ' range=':= 2.071 * _default_ * gstaShaleSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 2.071 * _default_ * gstaShaleSize ' range=':= 2.071 * _default_ * gstaShaleSize ' type='normal' scaleTo='base' />
@@ -763,7 +763,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_shale_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_shale_smooth' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 32 * gstaShaleSize ' range=':= _default_ * gstaShaleSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 24.000 * gstaShaleFreq ' range=':= _default_ * gstaShaleFreq ' type='normal' scaleTo='base' />
@@ -788,7 +788,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_sandstone_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_sandstone_smooth' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 4.904 * _default_ * gstaSandstoneFreq ' range=':= 4.904 * _default_ * gstaSandstoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.303 * _default_ * gstaSandstoneSize ' range=':= 1.303 * _default_ * gstaSandstoneSize ' type='normal' />
@@ -830,7 +830,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_sandstone_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_sandstone_smooth' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 2.071 * _default_ * gstaSandstoneSize ' range=':= 2.071 * _default_ * gstaSandstoneSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 2.071 * _default_ * gstaSandstoneSize ' range=':= 2.071 * _default_ * gstaSandstoneSize ' type='normal' scaleTo='base' />
@@ -882,7 +882,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_sandstone_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_sandstone_smooth' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 32 * gstaSandstoneSize ' range=':= _default_ * gstaSandstoneSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 24.000 * gstaSandstoneFreq ' range=':= _default_ * gstaSandstoneFreq ' type='normal' scaleTo='base' />
@@ -907,7 +907,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_limestone_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_limestone_smooth' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 4.904 * _default_ * gstaLimestoneFreq ' range=':= 4.904 * _default_ * gstaLimestoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.303 * _default_ * gstaLimestoneSize ' range=':= 1.303 * _default_ * gstaLimestoneSize ' type='normal' />
@@ -949,7 +949,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_limestone_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_limestone_smooth' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 2.071 * _default_ * gstaLimestoneSize ' range=':= 2.071 * _default_ * gstaLimestoneSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 2.071 * _default_ * gstaLimestoneSize ' range=':= 2.071 * _default_ * gstaLimestoneSize ' type='normal' scaleTo='base' />
@@ -1001,7 +1001,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_limestone_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_limestone_smooth' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 32 * gstaLimestoneSize ' range=':= _default_ * gstaLimestoneSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 24.000 * gstaLimestoneFreq ' range=':= _default_ * gstaLimestoneFreq ' type='normal' scaleTo='base' />
@@ -1026,7 +1026,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_pumice_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_pumice_smooth' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 3.798 * _default_ * gstaPumiceFreq ' range=':= 3.798 * _default_ * gstaPumiceFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.249 * _default_ * gstaPumiceSize ' range=':= 1.249 * _default_ * gstaPumiceSize ' type='normal' />
@@ -1068,7 +1068,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_pumice_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_pumice_smooth' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.823 * _default_ * gstaPumiceSize ' range=':= 1.823 * _default_ * gstaPumiceSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.823 * _default_ * gstaPumiceSize ' range=':= 1.823 * _default_ * gstaPumiceSize ' type='normal' scaleTo='base' />
@@ -1120,7 +1120,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_pumice_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_pumice_smooth' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 32 * gstaPumiceSize ' range=':= _default_ * gstaPumiceSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 14.400 * gstaPumiceFreq ' range=':= _default_ * gstaPumiceFreq ' type='normal' scaleTo='base' />
@@ -1145,7 +1145,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_opal_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_opal_smooth' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.734 * _default_ * gstaOpalFreq ' range=':= 1.734 * _default_ * gstaOpalFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.096 * _default_ * gstaOpalSize ' range=':= 1.096 * _default_ * gstaOpalSize ' type='normal' />
@@ -1187,7 +1187,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_opal_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_opal_smooth' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.232 * _default_ * gstaOpalSize ' range=':= 1.232 * _default_ * gstaOpalSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.232 * _default_ * gstaOpalSize ' range=':= 1.232 * _default_ * gstaOpalSize ' type='normal' scaleTo='base' />
@@ -1239,7 +1239,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_opal_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_opal_smooth' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 32 * gstaOpalSize ' range=':= _default_ * gstaOpalSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 3.000 * gstaOpalFreq ' range=':= _default_ * gstaOpalFreq ' type='normal' scaleTo='base' />
@@ -1264,7 +1264,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_slate_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_slate_smooth' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 4.904 * _default_ * gstaSlateFreq ' range=':= 4.904 * _default_ * gstaSlateFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.303 * _default_ * gstaSlateSize ' range=':= 1.303 * _default_ * gstaSlateSize ' type='normal' />
@@ -1306,7 +1306,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_slate_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_slate_smooth' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 2.071 * _default_ * gstaSlateSize ' range=':= 2.071 * _default_ * gstaSlateSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 2.071 * _default_ * gstaSlateSize ' range=':= 2.071 * _default_ * gstaSlateSize ' type='normal' scaleTo='base' />
@@ -1358,7 +1358,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_slate_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_slate_smooth' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 32 * gstaSlateSize ' range=':= _default_ * gstaSlateSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 24.000 * gstaSlateFreq ' range=':= _default_ * gstaSlateFreq ' type='normal' scaleTo='base' />
@@ -1383,7 +1383,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_gneiss_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_gneiss_smooth' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 4.386 * _default_ * gstaGneissFreq ' range=':= 4.386 * _default_ * gstaGneissFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.279 * _default_ * gstaGneissSize ' range=':= 1.279 * _default_ * gstaGneissSize ' type='normal' />
@@ -1425,7 +1425,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_gneiss_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_gneiss_smooth' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.959 * _default_ * gstaGneissSize ' range=':= 1.959 * _default_ * gstaGneissSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.959 * _default_ * gstaGneissSize ' range=':= 1.959 * _default_ * gstaGneissSize ' type='normal' scaleTo='base' />
@@ -1477,7 +1477,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_gneiss_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_gneiss_smooth' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 32 * gstaGneissSize ' range=':= _default_ * gstaGneissSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 19.200 * gstaGneissFreq ' range=':= _default_ * gstaGneissFreq ' type='normal' scaleTo='base' />
@@ -1502,7 +1502,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_peridotite_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_peridotite_smooth' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 3.798 * _default_ * gstaPeridotiteFreq ' range=':= 3.798 * _default_ * gstaPeridotiteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.249 * _default_ * gstaPeridotiteSize ' range=':= 1.249 * _default_ * gstaPeridotiteSize ' type='normal' />
@@ -1544,7 +1544,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_peridotite_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_peridotite_smooth' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.823 * _default_ * gstaPeridotiteSize ' range=':= 1.823 * _default_ * gstaPeridotiteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.823 * _default_ * gstaPeridotiteSize ' range=':= 1.823 * _default_ * gstaPeridotiteSize ' type='normal' scaleTo='base' />
@@ -1596,7 +1596,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_peridotite_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_peridotite_smooth' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 32 * gstaPeridotiteSize ' range=':= _default_ * gstaPeridotiteSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 14.400 * gstaPeridotiteFreq ' range=':= _default_ * gstaPeridotiteFreq ' type='normal' scaleTo='base' />
@@ -1621,7 +1621,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_granulite_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_granulite_smooth' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 4.103 * _default_ * gstaGranuliteFreq ' range=':= 4.103 * _default_ * gstaGranuliteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.265 * _default_ * gstaGranuliteSize ' range=':= 1.265 * _default_ * gstaGranuliteSize ' type='normal' />
@@ -1663,7 +1663,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_granulite_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_granulite_smooth' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.895 * _default_ * gstaGranuliteSize ' range=':= 1.895 * _default_ * gstaGranuliteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.895 * _default_ * gstaGranuliteSize ' range=':= 1.895 * _default_ * gstaGranuliteSize ' type='normal' scaleTo='base' />
@@ -1715,7 +1715,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_granulite_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_granulite_smooth' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 32 * gstaGranuliteSize ' range=':= _default_ * gstaGranuliteSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 16.800 * gstaGranuliteFreq ' range=':= _default_ * gstaGranuliteFreq ' type='normal' scaleTo='base' />
@@ -1740,7 +1740,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_migmatite_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_migmatite_smooth' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 3.798 * _default_ * gstaMigmatiteFreq ' range=':= 3.798 * _default_ * gstaMigmatiteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.249 * _default_ * gstaMigmatiteSize ' range=':= 1.249 * _default_ * gstaMigmatiteSize ' type='normal' />
@@ -1782,7 +1782,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_migmatite_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_migmatite_smooth' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.823 * _default_ * gstaMigmatiteSize ' range=':= 1.823 * _default_ * gstaMigmatiteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.823 * _default_ * gstaMigmatiteSize ' range=':= 1.823 * _default_ * gstaMigmatiteSize ' type='normal' scaleTo='base' />
@@ -1834,7 +1834,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_migmatite_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_migmatite_smooth' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 32 * gstaMigmatiteSize ' range=':= _default_ * gstaMigmatiteSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 14.400 * gstaMigmatiteFreq ' range=':= _default_ * gstaMigmatiteFreq ' type='normal' scaleTo='base' />
@@ -1859,7 +1859,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_schist_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_schist_smooth' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 4.386 * _default_ * gstaSchistFreq ' range=':= 4.386 * _default_ * gstaSchistFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.279 * _default_ * gstaSchistSize ' range=':= 1.279 * _default_ * gstaSchistSize ' type='normal' />
@@ -1901,7 +1901,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_schist_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_schist_smooth' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.959 * _default_ * gstaSchistSize ' range=':= 1.959 * _default_ * gstaSchistSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.959 * _default_ * gstaSchistSize ' range=':= 1.959 * _default_ * gstaSchistSize ' type='normal' scaleTo='base' />
@@ -1953,7 +1953,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_schist_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_schist_smooth' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 32 * gstaSchistSize ' range=':= _default_ * gstaSchistSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 19.200 * gstaSchistFreq ' range=':= _default_ * gstaSchistFreq ' type='normal' scaleTo='base' />
@@ -1978,7 +1978,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_basalt_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_basalt_smooth' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 4.904 * _default_ * gstaBasaltFreq ' range=':= 4.904 * _default_ * gstaBasaltFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.303 * _default_ * gstaBasaltSize ' range=':= 1.303 * _default_ * gstaBasaltSize ' type='normal' />
@@ -2020,7 +2020,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_basalt_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_basalt_smooth' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 2.071 * _default_ * gstaBasaltSize ' range=':= 2.071 * _default_ * gstaBasaltSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 2.071 * _default_ * gstaBasaltSize ' range=':= 2.071 * _default_ * gstaBasaltSize ' type='normal' scaleTo='base' />
@@ -2072,7 +2072,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_basalt_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_basalt_smooth' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 32 * gstaBasaltSize ' range=':= _default_ * gstaBasaltSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 24.000 * gstaBasaltFreq ' range=':= _default_ * gstaBasaltFreq ' type='normal' scaleTo='base' />
@@ -2097,7 +2097,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_onyx_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_onyx_smooth' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 4.904 * _default_ * gstaOnyxFreq ' range=':= 4.904 * _default_ * gstaOnyxFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.303 * _default_ * gstaOnyxSize ' range=':= 1.303 * _default_ * gstaOnyxSize ' type='normal' />
@@ -2139,7 +2139,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_onyx_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_onyx_smooth' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 2.071 * _default_ * gstaOnyxSize ' range=':= 2.071 * _default_ * gstaOnyxSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 2.071 * _default_ * gstaOnyxSize ' range=':= 2.071 * _default_ * gstaOnyxSize ' type='normal' scaleTo='base' />
@@ -2191,7 +2191,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_onyx_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_onyx_smooth' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 32 * gstaOnyxSize ' range=':= _default_ * gstaOnyxSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 24.000 * gstaOnyxFreq ' range=':= _default_ * gstaOnyxFreq ' type='normal' scaleTo='base' />
@@ -2216,7 +2216,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_quartz_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_quartz_smooth' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 3.467 * _default_ * gstaQuartzFreq ' range=':= 3.467 * _default_ * gstaQuartzFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.230 * _default_ * gstaQuartzSize ' range=':= 1.230 * _default_ * gstaQuartzSize ' type='normal' />
@@ -2258,7 +2258,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_quartz_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_quartz_smooth' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.742 * _default_ * gstaQuartzSize ' range=':= 1.742 * _default_ * gstaQuartzSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.742 * _default_ * gstaQuartzSize ' range=':= 1.742 * _default_ * gstaQuartzSize ' type='normal' scaleTo='base' />
@@ -2310,7 +2310,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_quartz_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_quartz_smooth' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 32 * gstaQuartzSize ' range=':= _default_ * gstaQuartzSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 12.000 * gstaQuartzFreq ' range=':= _default_ * gstaQuartzFreq ' type='normal' scaleTo='base' />
@@ -2335,7 +2335,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_marble_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_marble_smooth' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 4.904 * _default_ * gstaMarbleFreq ' range=':= 4.904 * _default_ * gstaMarbleFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.303 * _default_ * gstaMarbleSize ' range=':= 1.303 * _default_ * gstaMarbleSize ' type='normal' />
@@ -2377,7 +2377,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_marble_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_marble_smooth' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 2.071 * _default_ * gstaMarbleSize ' range=':= 2.071 * _default_ * gstaMarbleSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 2.071 * _default_ * gstaMarbleSize ' range=':= 2.071 * _default_ * gstaMarbleSize ' type='normal' scaleTo='base' />
@@ -2429,7 +2429,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_marble_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_marble_smooth' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 32 * gstaMarbleSize ' range=':= _default_ * gstaMarbleSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 24.000 * gstaMarbleFreq ' range=':= _default_ * gstaMarbleFreq ' type='normal' scaleTo='base' />
@@ -2454,7 +2454,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_granite_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_granite_smooth' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 4.904 * _default_ * gstaGraniteFreq ' range=':= 4.904 * _default_ * gstaGraniteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.303 * _default_ * gstaGraniteSize ' range=':= 1.303 * _default_ * gstaGraniteSize ' type='normal' />
@@ -2496,7 +2496,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_granite_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_granite_smooth' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 2.071 * _default_ * gstaGraniteSize ' range=':= 2.071 * _default_ * gstaGraniteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 2.071 * _default_ * gstaGraniteSize ' range=':= 2.071 * _default_ * gstaGraniteSize ' type='normal' scaleTo='base' />
@@ -2548,7 +2548,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_granite_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_granite_smooth' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 32 * gstaGraniteSize ' range=':= _default_ * gstaGraniteSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 24.000 * gstaGraniteFreq ' range=':= _default_ * gstaGraniteFreq ' type='normal' scaleTo='base' />
@@ -2573,7 +2573,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_hornfel_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_hornfel_smooth' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 4.386 * _default_ * gstaHornfelFreq ' range=':= 4.386 * _default_ * gstaHornfelFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.279 * _default_ * gstaHornfelSize ' range=':= 1.279 * _default_ * gstaHornfelSize ' type='normal' />
@@ -2615,7 +2615,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_hornfel_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_hornfel_smooth' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.959 * _default_ * gstaHornfelSize ' range=':= 1.959 * _default_ * gstaHornfelSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.959 * _default_ * gstaHornfelSize ' range=':= 1.959 * _default_ * gstaHornfelSize ' type='normal' scaleTo='base' />
@@ -2667,7 +2667,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_hornfel_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_hornfel_smooth' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 32 * gstaHornfelSize ' range=':= _default_ * gstaHornfelSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 19.200 * gstaHornfelFreq ' range=':= _default_ * gstaHornfelFreq ' type='normal' scaleTo='base' />

--- a/src/main/resources/config/modules/ImmersiveEngineering.xml
+++ b/src/main/resources/config/modules/ImmersiveEngineering.xml
@@ -248,7 +248,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ImmersiveEngineering:ore:0")'> <OreBlock block='ImmersiveEngineering:ore:0' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.416 * _default_ * iengCopperFreq ' range=':= 1.416 * _default_ * iengCopperFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.060 * _default_ * iengCopperSize ' range=':= 1.060 * _default_ * iengCopperSize ' type='normal' />
@@ -290,7 +290,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ImmersiveEngineering:ore:0")'> <OreBlock block='ImmersiveEngineering:ore:0' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.113 * _default_ * iengCopperSize ' range=':= 1.113 * _default_ * iengCopperSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.113 * _default_ * iengCopperSize ' range=':= 1.113 * _default_ * iengCopperSize ' type='normal' scaleTo='base' />
@@ -342,7 +342,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ImmersiveEngineering:ore:0")'> <OreBlock block='ImmersiveEngineering:ore:0' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 8.000 * iengCopperSize ' range=':= _default_ * iengCopperSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 8.000 * iengCopperFreq ' range=':= _default_ * iengCopperFreq ' type='normal' scaleTo='base' />
@@ -367,7 +367,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ImmersiveEngineering:ore:1")'> <OreBlock block='ImmersiveEngineering:ore:1' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.001 * _default_ * iengBauxiteFreq ' range=':= 1.001 * _default_ * iengBauxiteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.000 * _default_ * iengBauxiteSize ' range=':= 1.000 * _default_ * iengBauxiteSize ' type='normal' />
@@ -409,7 +409,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ImmersiveEngineering:ore:1")'> <OreBlock block='ImmersiveEngineering:ore:1' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.936 * _default_ * iengBauxiteSize ' range=':= 0.936 * _default_ * iengBauxiteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.936 * _default_ * iengBauxiteSize ' range=':= 0.936 * _default_ * iengBauxiteSize ' type='normal' scaleTo='base' />
@@ -461,7 +461,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ImmersiveEngineering:ore:1")'> <OreBlock block='ImmersiveEngineering:ore:1' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * iengBauxiteSize ' range=':= _default_ * iengBauxiteSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 8.000 * iengBauxiteFreq ' range=':= _default_ * iengBauxiteFreq ' type='normal' scaleTo='base' />
@@ -486,7 +486,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ImmersiveEngineering:ore:2")'> <OreBlock block='ImmersiveEngineering:ore:2' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.867 * _default_ * iengLeadFreq ' range=':= 0.867 * _default_ * iengLeadFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.976 * _default_ * iengLeadSize ' range=':= 0.976 * _default_ * iengLeadSize ' type='normal' />
@@ -528,7 +528,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ImmersiveEngineering:ore:2")'> <OreBlock block='ImmersiveEngineering:ore:2' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.871 * _default_ * iengLeadSize ' range=':= 0.871 * _default_ * iengLeadSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.871 * _default_ * iengLeadSize ' range=':= 0.871 * _default_ * iengLeadSize ' type='normal' scaleTo='base' />
@@ -580,7 +580,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ImmersiveEngineering:ore:2")'> <OreBlock block='ImmersiveEngineering:ore:2' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 6.000 * iengLeadSize ' range=':= _default_ * iengLeadSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 4.000 * iengLeadFreq ' range=':= _default_ * iengLeadFreq ' type='normal' scaleTo='base' />
@@ -605,7 +605,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ImmersiveEngineering:ore:3")'> <OreBlock block='ImmersiveEngineering:ore:3' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.001 * _default_ * iengSilverFreq ' range=':= 1.001 * _default_ * iengSilverFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.000 * _default_ * iengSilverSize ' range=':= 1.000 * _default_ * iengSilverSize ' type='normal' />
@@ -647,7 +647,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ImmersiveEngineering:ore:3")'> <OreBlock block='ImmersiveEngineering:ore:3' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.936 * _default_ * iengSilverSize ' range=':= 0.936 * _default_ * iengSilverSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.936 * _default_ * iengSilverSize ' range=':= 0.936 * _default_ * iengSilverSize ' type='normal' scaleTo='base' />
@@ -699,7 +699,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ImmersiveEngineering:ore:3")'> <OreBlock block='ImmersiveEngineering:ore:3' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 8.000 * iengSilverSize ' range=':= _default_ * iengSilverSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 4.000 * iengSilverFreq ' range=':= _default_ * iengSilverFreq ' type='normal' scaleTo='base' />
@@ -724,7 +724,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ImmersiveEngineering:ore:4")'> <OreBlock block='ImmersiveEngineering:ore:4' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.613 * _default_ * iengNickelFreq ' range=':= 0.613 * _default_ * iengNickelFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * iengNickelSize ' range=':= 0.922 * _default_ * iengNickelSize ' type='normal' />
@@ -766,7 +766,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ImmersiveEngineering:ore:4")'> <OreBlock block='ImmersiveEngineering:ore:4' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.732 * _default_ * iengNickelSize ' range=':= 0.732 * _default_ * iengNickelSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.732 * _default_ * iengNickelSize ' range=':= 0.732 * _default_ * iengNickelSize ' type='normal' scaleTo='base' />
@@ -818,7 +818,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ImmersiveEngineering:ore:4")'> <OreBlock block='ImmersiveEngineering:ore:4' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 6.000 * iengNickelSize ' range=':= _default_ * iengNickelSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 2.000 * iengNickelFreq ' range=':= _default_ * iengNickelFreq ' type='normal' scaleTo='base' />

--- a/src/main/resources/config/modules/Mekanism.xml
+++ b/src/main/resources/config/modules/Mekanism.xml
@@ -177,7 +177,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Mekanism:OreBlock")'> <OreBlock block='Mekanism:OreBlock' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.734 * _default_ * mknsOsmiumFreq ' range=':= 1.734 * _default_ * mknsOsmiumFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.096 * _default_ * mknsOsmiumSize ' range=':= 1.096 * _default_ * mknsOsmiumSize ' type='normal' />
@@ -219,7 +219,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Mekanism:OreBlock")'> <OreBlock block='Mekanism:OreBlock' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.232 * _default_ * mknsOsmiumSize ' range=':= 1.232 * _default_ * mknsOsmiumSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.232 * _default_ * mknsOsmiumSize ' range=':= 1.232 * _default_ * mknsOsmiumSize ' type='normal' scaleTo='base' />
@@ -271,7 +271,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Mekanism:OreBlock")'> <OreBlock block='Mekanism:OreBlock' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 8.000 * mknsOsmiumSize ' range=':= _default_ * mknsOsmiumSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 12.000 * mknsOsmiumFreq ' range=':= _default_ * mknsOsmiumFreq ' type='normal' scaleTo='base' />
@@ -296,7 +296,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Mekanism:OreBlock:1")'> <OreBlock block='Mekanism:OreBlock:1' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.002 * _default_ * mknsCopperFreq ' range=':= 2.002 * _default_ * mknsCopperFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.123 * _default_ * mknsCopperSize ' range=':= 1.123 * _default_ * mknsCopperSize ' type='normal' />
@@ -338,7 +338,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Mekanism:OreBlock:1")'> <OreBlock block='Mekanism:OreBlock:1' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.323 * _default_ * mknsCopperSize ' range=':= 1.323 * _default_ * mknsCopperSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.323 * _default_ * mknsCopperSize ' range=':= 1.323 * _default_ * mknsCopperSize ' type='normal' scaleTo='base' />
@@ -390,7 +390,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Mekanism:OreBlock:1")'> <OreBlock block='Mekanism:OreBlock:1' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 8.000 * mknsCopperSize ' range=':= _default_ * mknsCopperSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 16.000 * mknsCopperFreq ' range=':= _default_ * mknsCopperFreq ' type='normal' scaleTo='base' />
@@ -415,7 +415,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Mekanism:OreBlock:2")'> <OreBlock block='Mekanism:OreBlock:2' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.873 * _default_ * mknsTinFreq ' range=':= 1.873 * _default_ * mknsTinFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.110 * _default_ * mknsTinSize ' range=':= 1.110 * _default_ * mknsTinSize ' type='normal' />
@@ -457,7 +457,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Mekanism:OreBlock:2")'> <OreBlock block='Mekanism:OreBlock:2' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.280 * _default_ * mknsTinSize ' range=':= 1.280 * _default_ * mknsTinSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.280 * _default_ * mknsTinSize ' range=':= 1.280 * _default_ * mknsTinSize ' type='normal' scaleTo='base' />
@@ -509,7 +509,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Mekanism:OreBlock:2")'> <OreBlock block='Mekanism:OreBlock:2' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 8.000 * mknsTinSize ' range=':= _default_ * mknsTinSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 14.000 * mknsTinFreq ' range=':= _default_ * mknsTinFreq ' type='normal' scaleTo='base' />

--- a/src/main/resources/config/modules/Metallurgy4.xml
+++ b/src/main/resources/config/modules/Metallurgy4.xml
@@ -1300,7 +1300,7 @@
                                 their  direction while mining.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore")'> <OreBlock block='Metallurgy:utility.ore' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.733 * _default_ * mtlgSulfurFreq ' range=':= 1.733 * _default_ * mtlgSulfurFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * mtlgSulfurSize ' range=':= 0 * _default_ * mtlgSulfurSize ' type='normal' />
@@ -1342,7 +1342,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore")'> <OreBlock block='Metallurgy:utility.ore' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.787 * _default_ * mtlgSulfurSize ' range=':= 0.787 * _default_ * mtlgSulfurSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.787 * _default_ * mtlgSulfurSize ' range=':= 0.787 * _default_ * mtlgSulfurSize ' type='normal' scaleTo='base' />
@@ -1394,7 +1394,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore")'> <OreBlock block='Metallurgy:utility.ore' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * mtlgSulfurSize ' range=':= _default_ * mtlgSulfurSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 4.000 * mtlgSulfurFreq ' range=':= _default_ * mtlgSulfurFreq ' type='normal' scaleTo='base' />
@@ -1426,7 +1426,7 @@
                                 their  direction while mining.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:1")'> <OreBlock block='Metallurgy:utility.ore:1' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.733 * _default_ * mtlgPhosphoriteFreq ' range=':= 1.733 * _default_ * mtlgPhosphoriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * mtlgPhosphoriteSize ' range=':= 0 * _default_ * mtlgPhosphoriteSize ' type='normal' />
@@ -1468,7 +1468,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:1")'> <OreBlock block='Metallurgy:utility.ore:1' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.787 * _default_ * mtlgPhosphoriteSize ' range=':= 0.787 * _default_ * mtlgPhosphoriteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.787 * _default_ * mtlgPhosphoriteSize ' range=':= 0.787 * _default_ * mtlgPhosphoriteSize ' type='normal' scaleTo='base' />
@@ -1520,7 +1520,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:1")'> <OreBlock block='Metallurgy:utility.ore:1' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * mtlgPhosphoriteSize ' range=':= _default_ * mtlgPhosphoriteSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 4.000 * mtlgPhosphoriteFreq ' range=':= _default_ * mtlgPhosphoriteFreq ' type='normal' scaleTo='base' />
@@ -1552,7 +1552,7 @@
                                 their  direction while mining.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:2")'> <OreBlock block='Metallurgy:utility.ore:2' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.733 * _default_ * mtlgSaltpeterFreq ' range=':= 1.733 * _default_ * mtlgSaltpeterFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * mtlgSaltpeterSize ' range=':= 0 * _default_ * mtlgSaltpeterSize ' type='normal' />
@@ -1594,7 +1594,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:2")'> <OreBlock block='Metallurgy:utility.ore:2' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.787 * _default_ * mtlgSaltpeterSize ' range=':= 0.787 * _default_ * mtlgSaltpeterSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.787 * _default_ * mtlgSaltpeterSize ' range=':= 0.787 * _default_ * mtlgSaltpeterSize ' type='normal' scaleTo='base' />
@@ -1646,7 +1646,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:2")'> <OreBlock block='Metallurgy:utility.ore:2' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * mtlgSaltpeterSize ' range=':= _default_ * mtlgSaltpeterSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 4.000 * mtlgSaltpeterFreq ' range=':= _default_ * mtlgSaltpeterFreq ' type='normal' scaleTo='base' />
@@ -1678,7 +1678,7 @@
                                 their  direction while mining.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:3")'> <OreBlock block='Metallurgy:utility.ore:3' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.733 * _default_ * mtlgMagnesiumFreq ' range=':= 1.733 * _default_ * mtlgMagnesiumFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * mtlgMagnesiumSize ' range=':= 0 * _default_ * mtlgMagnesiumSize ' type='normal' />
@@ -1720,7 +1720,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:3")'> <OreBlock block='Metallurgy:utility.ore:3' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.787 * _default_ * mtlgMagnesiumSize ' range=':= 0.787 * _default_ * mtlgMagnesiumSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.787 * _default_ * mtlgMagnesiumSize ' range=':= 0.787 * _default_ * mtlgMagnesiumSize ' type='normal' scaleTo='base' />
@@ -1772,7 +1772,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:3")'> <OreBlock block='Metallurgy:utility.ore:3' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * mtlgMagnesiumSize ' range=':= _default_ * mtlgMagnesiumSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 4.000 * mtlgMagnesiumFreq ' range=':= _default_ * mtlgMagnesiumFreq ' type='normal' scaleTo='base' />
@@ -1804,7 +1804,7 @@
                                 their  direction while mining.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:4")'> <OreBlock block='Metallurgy:utility.ore:4' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.733 * _default_ * mtlgBitumenFreq ' range=':= 1.733 * _default_ * mtlgBitumenFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * mtlgBitumenSize ' range=':= 0 * _default_ * mtlgBitumenSize ' type='normal' />
@@ -1846,7 +1846,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:4")'> <OreBlock block='Metallurgy:utility.ore:4' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.787 * _default_ * mtlgBitumenSize ' range=':= 0.787 * _default_ * mtlgBitumenSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.787 * _default_ * mtlgBitumenSize ' range=':= 0.787 * _default_ * mtlgBitumenSize ' type='normal' scaleTo='base' />
@@ -1898,7 +1898,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:4")'> <OreBlock block='Metallurgy:utility.ore:4' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * mtlgBitumenSize ' range=':= _default_ * mtlgBitumenSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 4.000 * mtlgBitumenFreq ' range=':= _default_ * mtlgBitumenFreq ' type='normal' scaleTo='base' />
@@ -1930,7 +1930,7 @@
                                 their  direction while mining.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:5")'> <OreBlock block='Metallurgy:utility.ore:5' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.733 * _default_ * mtlgPotashFreq ' range=':= 1.733 * _default_ * mtlgPotashFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * mtlgPotashSize ' range=':= 0 * _default_ * mtlgPotashSize ' type='normal' />
@@ -1972,7 +1972,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:5")'> <OreBlock block='Metallurgy:utility.ore:5' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.787 * _default_ * mtlgPotashSize ' range=':= 0.787 * _default_ * mtlgPotashSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.787 * _default_ * mtlgPotashSize ' range=':= 0.787 * _default_ * mtlgPotashSize ' type='normal' scaleTo='base' />
@@ -2024,7 +2024,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:5")'> <OreBlock block='Metallurgy:utility.ore:5' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * mtlgPotashSize ' range=':= _default_ * mtlgPotashSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 4.000 * mtlgPotashFreq ' range=':= _default_ * mtlgPotashFreq ' type='normal' scaleTo='base' />
@@ -2049,7 +2049,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:base.ore")'> <OreBlock block='Metallurgy:base.ore' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.501 * _default_ * mtlgCopperFreq ' range=':= 1.501 * _default_ * mtlgCopperFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.070 * _default_ * mtlgCopperSize ' range=':= 1.070 * _default_ * mtlgCopperSize ' type='normal' />
@@ -2091,7 +2091,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:base.ore")'> <OreBlock block='Metallurgy:base.ore' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.146 * _default_ * mtlgCopperSize ' range=':= 1.146 * _default_ * mtlgCopperSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.146 * _default_ * mtlgCopperSize ' range=':= 1.146 * _default_ * mtlgCopperSize ' type='normal' scaleTo='base' />
@@ -2143,7 +2143,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:base.ore")'> <OreBlock block='Metallurgy:base.ore' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 6.000 * mtlgCopperSize ' range=':= _default_ * mtlgCopperSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 12.000 * mtlgCopperFreq ' range=':= _default_ * mtlgCopperFreq ' type='normal' scaleTo='base' />
@@ -2168,7 +2168,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:base.ore:1")'> <OreBlock block='Metallurgy:base.ore:1' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.480 * _default_ * mtlgTinFreq ' range=':= 1.480 * _default_ * mtlgTinFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.068 * _default_ * mtlgTinSize ' range=':= 1.068 * _default_ * mtlgTinSize ' type='normal' />
@@ -2210,7 +2210,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:base.ore:1")'> <OreBlock block='Metallurgy:base.ore:1' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.138 * _default_ * mtlgTinSize ' range=':= 1.138 * _default_ * mtlgTinSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.138 * _default_ * mtlgTinSize ' range=':= 1.138 * _default_ * mtlgTinSize ' type='normal' scaleTo='base' />
@@ -2262,7 +2262,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:base.ore:1")'> <OreBlock block='Metallurgy:base.ore:1' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 10.000 * mtlgTinSize ' range=':= _default_ * mtlgTinSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 7.000 * mtlgTinFreq ' range=':= _default_ * mtlgTinFreq ' type='normal' scaleTo='base' />
@@ -2287,7 +2287,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:base.ore:2")'> <OreBlock block='Metallurgy:base.ore:2' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.791 * _default_ * mtlgManganeseFreq ' range=':= 0.791 * _default_ * mtlgManganeseFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.962 * _default_ * mtlgManganeseSize ' range=':= 0.962 * _default_ * mtlgManganeseSize ' type='normal' />
@@ -2329,7 +2329,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:base.ore:2")'> <OreBlock block='Metallurgy:base.ore:2' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.832 * _default_ * mtlgManganeseSize ' range=':= 0.832 * _default_ * mtlgManganeseSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.832 * _default_ * mtlgManganeseSize ' range=':= 0.832 * _default_ * mtlgManganeseSize ' type='normal' scaleTo='base' />
@@ -2381,7 +2381,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:base.ore:2")'> <OreBlock block='Metallurgy:base.ore:2' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * mtlgManganeseSize ' range=':= _default_ * mtlgManganeseSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 5.000 * mtlgManganeseFreq ' range=':= _default_ * mtlgManganeseFreq ' type='normal' scaleTo='base' />
@@ -2406,7 +2406,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:precious.ore")'> <OreBlock block='Metallurgy:precious.ore' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * mtlgZincFreq ' range=':= 0.969 * _default_ * mtlgZincFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.995 * _default_ * mtlgZincSize ' range=':= 0.995 * _default_ * mtlgZincSize ' type='normal' />
@@ -2448,7 +2448,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:precious.ore")'> <OreBlock block='Metallurgy:precious.ore' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.921 * _default_ * mtlgZincSize ' range=':= 0.921 * _default_ * mtlgZincSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.921 * _default_ * mtlgZincSize ' range=':= 0.921 * _default_ * mtlgZincSize ' type='normal' scaleTo='base' />
@@ -2500,7 +2500,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:precious.ore")'> <OreBlock block='Metallurgy:precious.ore' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 5.000 * mtlgZincSize ' range=':= _default_ * mtlgZincSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 6.000 * mtlgZincFreq ' range=':= _default_ * mtlgZincFreq ' type='normal' scaleTo='base' />
@@ -2525,7 +2525,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:precious.ore:1")'> <OreBlock block='Metallurgy:precious.ore:1' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * mtlgSilverFreq ' range=':= 0.969 * _default_ * mtlgSilverFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.995 * _default_ * mtlgSilverSize ' range=':= 0.995 * _default_ * mtlgSilverSize ' type='normal' />
@@ -2567,7 +2567,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:precious.ore:1")'> <OreBlock block='Metallurgy:precious.ore:1' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.921 * _default_ * mtlgSilverSize ' range=':= 0.921 * _default_ * mtlgSilverSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.921 * _default_ * mtlgSilverSize ' range=':= 0.921 * _default_ * mtlgSilverSize ' type='normal' scaleTo='base' />
@@ -2619,7 +2619,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:precious.ore:1")'> <OreBlock block='Metallurgy:precious.ore:1' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 5.000 * mtlgSilverSize ' range=':= _default_ * mtlgSilverSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 6.000 * mtlgSilverFreq ' range=':= _default_ * mtlgSilverFreq ' type='normal' scaleTo='base' />
@@ -2644,7 +2644,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:precious.ore:2")'> <OreBlock block='Metallurgy:precious.ore:2' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.531 * _default_ * mtlgPlatinumFreq ' range=':= 0.531 * _default_ * mtlgPlatinumFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.900 * _default_ * mtlgPlatinumSize ' range=':= 0.900 * _default_ * mtlgPlatinumSize ' type='normal' />
@@ -2686,7 +2686,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:precious.ore:2")'> <OreBlock block='Metallurgy:precious.ore:2' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.682 * _default_ * mtlgPlatinumSize ' range=':= 0.682 * _default_ * mtlgPlatinumSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.682 * _default_ * mtlgPlatinumSize ' range=':= 0.682 * _default_ * mtlgPlatinumSize ' type='normal' scaleTo='base' />
@@ -2738,7 +2738,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:precious.ore:2")'> <OreBlock block='Metallurgy:precious.ore:2' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.000 * mtlgPlatinumSize ' range=':= _default_ * mtlgPlatinumSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 3.000 * mtlgPlatinumFreq ' range=':= _default_ * mtlgPlatinumFreq ' type='normal' scaleTo='base' />
@@ -2763,7 +2763,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore")'> <OreBlock block='Metallurgy:fantasy.ore' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * mtlgPromethiumFreq ' range=':= 0.969 * _default_ * mtlgPromethiumFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.995 * _default_ * mtlgPromethiumSize ' range=':= 0.995 * _default_ * mtlgPromethiumSize ' type='normal' />
@@ -2805,7 +2805,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore")'> <OreBlock block='Metallurgy:fantasy.ore' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.921 * _default_ * mtlgPromethiumSize ' range=':= 0.921 * _default_ * mtlgPromethiumSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.921 * _default_ * mtlgPromethiumSize ' range=':= 0.921 * _default_ * mtlgPromethiumSize ' type='normal' scaleTo='base' />
@@ -2857,7 +2857,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore")'> <OreBlock block='Metallurgy:fantasy.ore' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 6.000 * mtlgPromethiumSize ' range=':= _default_ * mtlgPromethiumSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 5.000 * mtlgPromethiumFreq ' range=':= _default_ * mtlgPromethiumFreq ' type='normal' scaleTo='base' />
@@ -2882,7 +2882,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:1")'> <OreBlock block='Metallurgy:fantasy.ore:1' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.791 * _default_ * mtlgDeepIronFreq ' range=':= 0.791 * _default_ * mtlgDeepIronFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.962 * _default_ * mtlgDeepIronSize ' range=':= 0.962 * _default_ * mtlgDeepIronSize ' type='normal' />
@@ -2924,7 +2924,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:1")'> <OreBlock block='Metallurgy:fantasy.ore:1' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.832 * _default_ * mtlgDeepIronSize ' range=':= 0.832 * _default_ * mtlgDeepIronSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.832 * _default_ * mtlgDeepIronSize ' range=':= 0.832 * _default_ * mtlgDeepIronSize ' type='normal' scaleTo='base' />
@@ -2976,7 +2976,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:1")'> <OreBlock block='Metallurgy:fantasy.ore:1' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * mtlgDeepIronSize ' range=':= _default_ * mtlgDeepIronSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 5.000 * mtlgDeepIronFreq ' range=':= _default_ * mtlgDeepIronFreq ' type='normal' scaleTo='base' />
@@ -3001,7 +3001,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:2")'> <OreBlock block='Metallurgy:fantasy.ore:2' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.791 * _default_ * mtlgInfuscoliumFreq ' range=':= 0.791 * _default_ * mtlgInfuscoliumFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.962 * _default_ * mtlgInfuscoliumSize ' range=':= 0.962 * _default_ * mtlgInfuscoliumSize ' type='normal' />
@@ -3043,7 +3043,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:2")'> <OreBlock block='Metallurgy:fantasy.ore:2' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.832 * _default_ * mtlgInfuscoliumSize ' range=':= 0.832 * _default_ * mtlgInfuscoliumSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.832 * _default_ * mtlgInfuscoliumSize ' range=':= 0.832 * _default_ * mtlgInfuscoliumSize ' type='normal' scaleTo='base' />
@@ -3095,7 +3095,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:2")'> <OreBlock block='Metallurgy:fantasy.ore:2' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * mtlgInfuscoliumSize ' range=':= _default_ * mtlgInfuscoliumSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 5.000 * mtlgInfuscoliumFreq ' range=':= _default_ * mtlgInfuscoliumFreq ' type='normal' scaleTo='base' />
@@ -3120,7 +3120,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:4")'> <OreBlock block='Metallurgy:fantasy.ore:4' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.613 * _default_ * mtlgOureclaseFreq ' range=':= 0.613 * _default_ * mtlgOureclaseFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * mtlgOureclaseSize ' range=':= 0.922 * _default_ * mtlgOureclaseSize ' type='normal' />
@@ -3162,7 +3162,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:4")'> <OreBlock block='Metallurgy:fantasy.ore:4' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.732 * _default_ * mtlgOureclaseSize ' range=':= 0.732 * _default_ * mtlgOureclaseSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.732 * _default_ * mtlgOureclaseSize ' range=':= 0.732 * _default_ * mtlgOureclaseSize ' type='normal' scaleTo='base' />
@@ -3214,7 +3214,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:4")'> <OreBlock block='Metallurgy:fantasy.ore:4' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.000 * mtlgOureclaseSize ' range=':= _default_ * mtlgOureclaseSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 4.000 * mtlgOureclaseFreq ' range=':= _default_ * mtlgOureclaseFreq ' type='normal' scaleTo='base' />
@@ -3239,7 +3239,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:5")'> <OreBlock block='Metallurgy:fantasy.ore:5' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.613 * _default_ * mtlgAstralSilverFreq ' range=':= 0.613 * _default_ * mtlgAstralSilverFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * mtlgAstralSilverSize ' range=':= 0.922 * _default_ * mtlgAstralSilverSize ' type='normal' />
@@ -3282,7 +3282,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:5")'> <OreBlock block='Metallurgy:fantasy.ore:5' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.732 * _default_ * mtlgAstralSilverSize ' range=':= 0.732 * _default_ * mtlgAstralSilverSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.732 * _default_ * mtlgAstralSilverSize ' range=':= 0.732 * _default_ * mtlgAstralSilverSize ' type='normal' scaleTo='base' />
@@ -3334,7 +3334,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:5")'> <OreBlock block='Metallurgy:fantasy.ore:5' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.000 * mtlgAstralSilverSize ' range=':= _default_ * mtlgAstralSilverSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 4.000 * mtlgAstralSilverFreq ' range=':= _default_ * mtlgAstralSilverFreq ' type='normal' scaleTo='base' />
@@ -3359,7 +3359,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:6")'> <OreBlock block='Metallurgy:fantasy.ore:6' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.531 * _default_ * mtlgCarmotFreq ' range=':= 0.531 * _default_ * mtlgCarmotFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.900 * _default_ * mtlgCarmotSize ' range=':= 0.900 * _default_ * mtlgCarmotSize ' type='normal' />
@@ -3401,7 +3401,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:6")'> <OreBlock block='Metallurgy:fantasy.ore:6' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.682 * _default_ * mtlgCarmotSize ' range=':= 0.682 * _default_ * mtlgCarmotSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.682 * _default_ * mtlgCarmotSize ' range=':= 0.682 * _default_ * mtlgCarmotSize ' type='normal' scaleTo='base' />
@@ -3453,7 +3453,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:6")'> <OreBlock block='Metallurgy:fantasy.ore:6' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.000 * mtlgCarmotSize ' range=':= _default_ * mtlgCarmotSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 3.000 * mtlgCarmotFreq ' range=':= _default_ * mtlgCarmotFreq ' type='normal' scaleTo='base' />
@@ -3478,7 +3478,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:7")'> <OreBlock block='Metallurgy:fantasy.ore:7' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.531 * _default_ * mtlgMithrilFreq ' range=':= 0.531 * _default_ * mtlgMithrilFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.900 * _default_ * mtlgMithrilSize ' range=':= 0.900 * _default_ * mtlgMithrilSize ' type='normal' />
@@ -3520,7 +3520,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:7")'> <OreBlock block='Metallurgy:fantasy.ore:7' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.682 * _default_ * mtlgMithrilSize ' range=':= 0.682 * _default_ * mtlgMithrilSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.682 * _default_ * mtlgMithrilSize ' range=':= 0.682 * _default_ * mtlgMithrilSize ' type='normal' scaleTo='base' />
@@ -3572,7 +3572,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:7")'> <OreBlock block='Metallurgy:fantasy.ore:7' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.000 * mtlgMithrilSize ' range=':= _default_ * mtlgMithrilSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 3.000 * mtlgMithrilFreq ' range=':= _default_ * mtlgMithrilFreq ' type='normal' scaleTo='base' />
@@ -3597,7 +3597,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:8")'> <OreBlock block='Metallurgy:fantasy.ore:8' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.433 * _default_ * mtlgRubraciumFreq ' range=':= 0.433 * _default_ * mtlgRubraciumFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.870 * _default_ * mtlgRubraciumSize ' range=':= 0.870 * _default_ * mtlgRubraciumSize ' type='normal' />
@@ -3639,7 +3639,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:8")'> <OreBlock block='Metallurgy:fantasy.ore:8' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.616 * _default_ * mtlgRubraciumSize ' range=':= 0.616 * _default_ * mtlgRubraciumSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.616 * _default_ * mtlgRubraciumSize ' range=':= 0.616 * _default_ * mtlgRubraciumSize ' type='normal' scaleTo='base' />
@@ -3691,7 +3691,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:8")'> <OreBlock block='Metallurgy:fantasy.ore:8' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.000 * mtlgRubraciumSize ' range=':= _default_ * mtlgRubraciumSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 2.000 * mtlgRubraciumFreq ' range=':= _default_ * mtlgRubraciumFreq ' type='normal' scaleTo='base' />
@@ -3716,7 +3716,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:11")'> <OreBlock block='Metallurgy:fantasy.ore:11' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.500 * _default_ * mtlgOrichalcumFreq ' range=':= 0.500 * _default_ * mtlgOrichalcumFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.891 * _default_ * mtlgOrichalcumSize ' range=':= 0.891 * _default_ * mtlgOrichalcumSize ' type='normal' />
@@ -3758,7 +3758,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:11")'> <OreBlock block='Metallurgy:fantasy.ore:11' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.662 * _default_ * mtlgOrichalcumSize ' range=':= 0.662 * _default_ * mtlgOrichalcumSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.662 * _default_ * mtlgOrichalcumSize ' range=':= 0.662 * _default_ * mtlgOrichalcumSize ' type='normal' scaleTo='base' />
@@ -3810,7 +3810,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:11")'> <OreBlock block='Metallurgy:fantasy.ore:11' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * mtlgOrichalcumSize ' range=':= _default_ * mtlgOrichalcumSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 2.000 * mtlgOrichalcumFreq ' range=':= _default_ * mtlgOrichalcumFreq ' type='normal' scaleTo='base' />
@@ -3835,7 +3835,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:13")'> <OreBlock block='Metallurgy:fantasy.ore:13' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.433 * _default_ * mtlgAdamantineFreq ' range=':= 0.433 * _default_ * mtlgAdamantineFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.870 * _default_ * mtlgAdamantineSize ' range=':= 0.870 * _default_ * mtlgAdamantineSize ' type='normal' />
@@ -3877,7 +3877,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:13")'> <OreBlock block='Metallurgy:fantasy.ore:13' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.616 * _default_ * mtlgAdamantineSize ' range=':= 0.616 * _default_ * mtlgAdamantineSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.616 * _default_ * mtlgAdamantineSize ' range=':= 0.616 * _default_ * mtlgAdamantineSize ' type='normal' scaleTo='base' />
@@ -3929,7 +3929,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:13")'> <OreBlock block='Metallurgy:fantasy.ore:13' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.000 * mtlgAdamantineSize ' range=':= _default_ * mtlgAdamantineSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 2.000 * mtlgAdamantineFreq ' range=':= _default_ * mtlgAdamantineFreq ' type='normal' scaleTo='base' />
@@ -3954,7 +3954,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:14")'> <OreBlock block='Metallurgy:fantasy.ore:14' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.433 * _default_ * mtlgAtlarusFreq ' range=':= 0.433 * _default_ * mtlgAtlarusFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.870 * _default_ * mtlgAtlarusSize ' range=':= 0.870 * _default_ * mtlgAtlarusSize ' type='normal' />
@@ -3996,7 +3996,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:14")'> <OreBlock block='Metallurgy:fantasy.ore:14' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.616 * _default_ * mtlgAtlarusSize ' range=':= 0.616 * _default_ * mtlgAtlarusSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.616 * _default_ * mtlgAtlarusSize ' range=':= 0.616 * _default_ * mtlgAtlarusSize ' type='normal' scaleTo='base' />
@@ -4048,7 +4048,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:14")'> <OreBlock block='Metallurgy:fantasy.ore:14' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.000 * mtlgAtlarusSize ' range=':= _default_ * mtlgAtlarusSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 2.000 * mtlgAtlarusFreq ' range=':= _default_ * mtlgAtlarusFreq ' type='normal' scaleTo='base' />
@@ -4114,7 +4114,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.300 * _default_ * mtlgIgnatiusFreq ' range=':= 1.300 * _default_ * mtlgIgnatiusFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.045 * _default_ * mtlgIgnatiusSize ' range=':= 1.045 * _default_ * mtlgIgnatiusSize ' type='normal' />
@@ -4156,7 +4156,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.067 * _default_ * mtlgIgnatiusSize ' range=':= 1.067 * _default_ * mtlgIgnatiusSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.067 * _default_ * mtlgIgnatiusSize ' range=':= 1.067 * _default_ * mtlgIgnatiusSize ' type='normal' scaleTo='base' />
@@ -4208,7 +4208,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 6.000 * mtlgIgnatiusSize ' range=':= _default_ * mtlgIgnatiusSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 9.000 * mtlgIgnatiusFreq ' range=':= _default_ * mtlgIgnatiusFreq ' type='normal' scaleTo='base' />
@@ -4233,7 +4233,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:1")'> <OreBlock block='Metallurgy:nether.ore:1' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.147 * _default_ * mtlgShadowIronFreq ' range=':= 1.147 * _default_ * mtlgShadowIronFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.023 * _default_ * mtlgShadowIronSize ' range=':= 1.023 * _default_ * mtlgShadowIronSize ' type='normal' />
@@ -4275,7 +4275,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:1")'> <OreBlock block='Metallurgy:nether.ore:1' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.002 * _default_ * mtlgShadowIronSize ' range=':= 1.002 * _default_ * mtlgShadowIronSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.002 * _default_ * mtlgShadowIronSize ' range=':= 1.002 * _default_ * mtlgShadowIronSize ' type='normal' scaleTo='base' />
@@ -4327,7 +4327,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:1")'> <OreBlock block='Metallurgy:nether.ore:1' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 6.000 * mtlgShadowIronSize ' range=':= _default_ * mtlgShadowIronSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 7.000 * mtlgShadowIronFreq ' range=':= _default_ * mtlgShadowIronFreq ' type='normal' scaleTo='base' />
@@ -4352,7 +4352,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:2")'> <OreBlock block='Metallurgy:nether.ore:2' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.062 * _default_ * mtlgLemuriteFreq ' range=':= 1.062 * _default_ * mtlgLemuriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.010 * _default_ * mtlgLemuriteSize ' range=':= 1.010 * _default_ * mtlgLemuriteSize ' type='normal' />
@@ -4394,7 +4394,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:2")'> <OreBlock block='Metallurgy:nether.ore:2' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.964 * _default_ * mtlgLemuriteSize ' range=':= 0.964 * _default_ * mtlgLemuriteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.964 * _default_ * mtlgLemuriteSize ' range=':= 0.964 * _default_ * mtlgLemuriteSize ' type='normal' scaleTo='base' />
@@ -4446,7 +4446,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:2")'> <OreBlock block='Metallurgy:nether.ore:2' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 6.000 * mtlgLemuriteSize ' range=':= _default_ * mtlgLemuriteSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 6.000 * mtlgLemuriteFreq ' range=':= _default_ * mtlgLemuriteFreq ' type='normal' scaleTo='base' />
@@ -4471,7 +4471,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:3")'> <OreBlock block='Metallurgy:nether.ore:3' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * mtlgMidasiumFreq ' range=':= 0.969 * _default_ * mtlgMidasiumFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.995 * _default_ * mtlgMidasiumSize ' range=':= 0.995 * _default_ * mtlgMidasiumSize ' type='normal' />
@@ -4513,7 +4513,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:3")'> <OreBlock block='Metallurgy:nether.ore:3' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.921 * _default_ * mtlgMidasiumSize ' range=':= 0.921 * _default_ * mtlgMidasiumSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.921 * _default_ * mtlgMidasiumSize ' range=':= 0.921 * _default_ * mtlgMidasiumSize ' type='normal' scaleTo='base' />
@@ -4565,7 +4565,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:3")'> <OreBlock block='Metallurgy:nether.ore:3' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 6.000 * mtlgMidasiumSize ' range=':= _default_ * mtlgMidasiumSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 5.000 * mtlgMidasiumFreq ' range=':= _default_ * mtlgMidasiumFreq ' type='normal' scaleTo='base' />
@@ -4590,7 +4590,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:4")'> <OreBlock block='Metallurgy:nether.ore:4' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.936 * _default_ * mtlgVyroxeresFreq ' range=':= 0.936 * _default_ * mtlgVyroxeresFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.989 * _default_ * mtlgVyroxeresSize ' range=':= 0.989 * _default_ * mtlgVyroxeresSize ' type='normal' />
@@ -4632,7 +4632,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:4")'> <OreBlock block='Metallurgy:nether.ore:4' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.905 * _default_ * mtlgVyroxeresSize ' range=':= 0.905 * _default_ * mtlgVyroxeresSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.905 * _default_ * mtlgVyroxeresSize ' range=':= 0.905 * _default_ * mtlgVyroxeresSize ' type='normal' scaleTo='base' />
@@ -4684,7 +4684,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:4")'> <OreBlock block='Metallurgy:nether.ore:4' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 7.000 * mtlgVyroxeresSize ' range=':= _default_ * mtlgVyroxeresSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 4.000 * mtlgVyroxeresFreq ' range=':= _default_ * mtlgVyroxeresFreq ' type='normal' scaleTo='base' />
@@ -4709,7 +4709,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:5")'> <OreBlock block='Metallurgy:nether.ore:5' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.708 * _default_ * mtlgCeruclaseFreq ' range=':= 0.708 * _default_ * mtlgCeruclaseFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.944 * _default_ * mtlgCeruclaseSize ' range=':= 0.944 * _default_ * mtlgCeruclaseSize ' type='normal' />
@@ -4751,7 +4751,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:5")'> <OreBlock block='Metallurgy:nether.ore:5' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.787 * _default_ * mtlgCeruclaseSize ' range=':= 0.787 * _default_ * mtlgCeruclaseSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.787 * _default_ * mtlgCeruclaseSize ' range=':= 0.787 * _default_ * mtlgCeruclaseSize ' type='normal' scaleTo='base' />
@@ -4803,7 +4803,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:5")'> <OreBlock block='Metallurgy:nether.ore:5' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * mtlgCeruclaseSize ' range=':= _default_ * mtlgCeruclaseSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 4.000 * mtlgCeruclaseFreq ' range=':= _default_ * mtlgCeruclaseFreq ' type='normal' scaleTo='base' />
@@ -4828,7 +4828,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:6")'> <OreBlock block='Metallurgy:nether.ore:6' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.613 * _default_ * mtlgAlduoriteFreq ' range=':= 0.613 * _default_ * mtlgAlduoriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * mtlgAlduoriteSize ' range=':= 0.922 * _default_ * mtlgAlduoriteSize ' type='normal' />
@@ -4870,7 +4870,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:6")'> <OreBlock block='Metallurgy:nether.ore:6' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.732 * _default_ * mtlgAlduoriteSize ' range=':= 0.732 * _default_ * mtlgAlduoriteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.732 * _default_ * mtlgAlduoriteSize ' range=':= 0.732 * _default_ * mtlgAlduoriteSize ' type='normal' scaleTo='base' />
@@ -4922,7 +4922,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:6")'> <OreBlock block='Metallurgy:nether.ore:6' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * mtlgAlduoriteSize ' range=':= _default_ * mtlgAlduoriteSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 3.000 * mtlgAlduoriteFreq ' range=':= _default_ * mtlgAlduoriteFreq ' type='normal' scaleTo='base' />
@@ -4947,7 +4947,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:7")'> <OreBlock block='Metallurgy:nether.ore:7' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.613 * _default_ * mtlgKalendriteFreq ' range=':= 0.613 * _default_ * mtlgKalendriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * mtlgKalendriteSize ' range=':= 0.922 * _default_ * mtlgKalendriteSize ' type='normal' />
@@ -4989,7 +4989,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:7")'> <OreBlock block='Metallurgy:nether.ore:7' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.732 * _default_ * mtlgKalendriteSize ' range=':= 0.732 * _default_ * mtlgKalendriteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.732 * _default_ * mtlgKalendriteSize ' range=':= 0.732 * _default_ * mtlgKalendriteSize ' type='normal' scaleTo='base' />
@@ -5041,7 +5041,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:7")'> <OreBlock block='Metallurgy:nether.ore:7' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * mtlgKalendriteSize ' range=':= _default_ * mtlgKalendriteSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 3.000 * mtlgKalendriteFreq ' range=':= _default_ * mtlgKalendriteFreq ' type='normal' scaleTo='base' />
@@ -5066,7 +5066,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:8")'> <OreBlock block='Metallurgy:nether.ore:8' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.433 * _default_ * mtlgVulcaniteFreq ' range=':= 0.433 * _default_ * mtlgVulcaniteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.870 * _default_ * mtlgVulcaniteSize ' range=':= 0.870 * _default_ * mtlgVulcaniteSize ' type='normal' />
@@ -5108,7 +5108,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:8")'> <OreBlock block='Metallurgy:nether.ore:8' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.616 * _default_ * mtlgVulcaniteSize ' range=':= 0.616 * _default_ * mtlgVulcaniteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.616 * _default_ * mtlgVulcaniteSize ' range=':= 0.616 * _default_ * mtlgVulcaniteSize ' type='normal' scaleTo='base' />
@@ -5160,7 +5160,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:8")'> <OreBlock block='Metallurgy:nether.ore:8' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.000 * mtlgVulcaniteSize ' range=':= _default_ * mtlgVulcaniteSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 2.000 * mtlgVulcaniteFreq ' range=':= _default_ * mtlgVulcaniteFreq ' type='normal' scaleTo='base' />
@@ -5185,7 +5185,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:9")'> <OreBlock block='Metallurgy:nether.ore:9' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.433 * _default_ * mtlgSanguiniteFreq ' range=':= 0.433 * _default_ * mtlgSanguiniteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.870 * _default_ * mtlgSanguiniteSize ' range=':= 0.870 * _default_ * mtlgSanguiniteSize ' type='normal' />
@@ -5227,7 +5227,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:9")'> <OreBlock block='Metallurgy:nether.ore:9' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.616 * _default_ * mtlgSanguiniteSize ' range=':= 0.616 * _default_ * mtlgSanguiniteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.616 * _default_ * mtlgSanguiniteSize ' range=':= 0.616 * _default_ * mtlgSanguiniteSize ' type='normal' scaleTo='base' />
@@ -5279,7 +5279,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:9")'> <OreBlock block='Metallurgy:nether.ore:9' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.000 * mtlgSanguiniteSize ' range=':= _default_ * mtlgSanguiniteSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 2.000 * mtlgSanguiniteFreq ' range=':= _default_ * mtlgSanguiniteFreq ' type='normal' scaleTo='base' />
@@ -5337,7 +5337,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:ender.ore")'> <OreBlock block='Metallurgy:ender.ore' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.867 * _default_ * mtlgEximiteFreq ' range=':= 0.867 * _default_ * mtlgEximiteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.976 * _default_ * mtlgEximiteSize ' range=':= 0.976 * _default_ * mtlgEximiteSize ' type='normal' />
@@ -5379,7 +5379,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:ender.ore")'> <OreBlock block='Metallurgy:ender.ore' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.871 * _default_ * mtlgEximiteSize ' range=':= 0.871 * _default_ * mtlgEximiteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.871 * _default_ * mtlgEximiteSize ' range=':= 0.871 * _default_ * mtlgEximiteSize ' type='normal' scaleTo='base' />
@@ -5431,7 +5431,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:ender.ore")'> <OreBlock block='Metallurgy:ender.ore' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * mtlgEximiteSize ' range=':= _default_ * mtlgEximiteSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 6.000 * mtlgEximiteFreq ' range=':= _default_ * mtlgEximiteFreq ' type='normal' scaleTo='base' />
@@ -5456,7 +5456,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:ender.ore:1")'> <OreBlock block='Metallurgy:ender.ore:1' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.531 * _default_ * mtlgMeutoiteFreq ' range=':= 0.531 * _default_ * mtlgMeutoiteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.900 * _default_ * mtlgMeutoiteSize ' range=':= 0.900 * _default_ * mtlgMeutoiteSize ' type='normal' />
@@ -5498,7 +5498,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:ender.ore:1")'> <OreBlock block='Metallurgy:ender.ore:1' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.682 * _default_ * mtlgMeutoiteSize ' range=':= 0.682 * _default_ * mtlgMeutoiteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.682 * _default_ * mtlgMeutoiteSize ' range=':= 0.682 * _default_ * mtlgMeutoiteSize ' type='normal' scaleTo='base' />
@@ -5550,7 +5550,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Metallurgy:ender.ore:1")'> <OreBlock block='Metallurgy:ender.ore:1' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.000 * mtlgMeutoiteSize ' range=':= _default_ * mtlgMeutoiteSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 3.000 * mtlgMeutoiteFreq ' range=':= _default_ * mtlgMeutoiteFreq ' type='normal' scaleTo='base' />

--- a/src/main/resources/config/modules/MineChem.xml
+++ b/src/main/resources/config/modules/MineChem.xml
@@ -109,7 +109,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("minechem:tile.oreUranium")'> <OreBlock block='minechem:tile.oreUranium' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.500 * _default_ * mchmUraniumFreq ' range=':= 0.500 * _default_ * mchmUraniumFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.891 * _default_ * mchmUraniumSize ' range=':= 0.891 * _default_ * mchmUraniumSize ' type='normal' />
@@ -151,7 +151,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("minechem:tile.oreUranium")'> <OreBlock block='minechem:tile.oreUranium' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.662 * _default_ * mchmUraniumSize ' range=':= 0.662 * _default_ * mchmUraniumSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.662 * _default_ * mchmUraniumSize ' range=':= 0.662 * _default_ * mchmUraniumSize ' type='normal' scaleTo='base' />
@@ -203,7 +203,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("minechem:tile.oreUranium")'> <OreBlock block='minechem:tile.oreUranium' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * mchmUraniumSize ' range=':= _default_ * mchmUraniumSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 2.000 * mchmUraniumFreq ' range=':= _default_ * mchmUraniumFreq ' type='normal' scaleTo='base' />

--- a/src/main/resources/config/modules/MinecraftComesAlive.xml
+++ b/src/main/resources/config/modules/MinecraftComesAlive.xml
@@ -111,7 +111,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("MCA:tile.roseGoldOre")'> <OreBlock block='MCA:tile.roseGoldOre' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * mccaRoseGoldFreq ' range=':= 0.969 * _default_ * mccaRoseGoldFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.995 * _default_ * mccaRoseGoldSize ' range=':= 0.995 * _default_ * mccaRoseGoldSize ' type='normal' />
@@ -153,7 +153,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("MCA:tile.roseGoldOre")'> <OreBlock block='MCA:tile.roseGoldOre' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.921 * _default_ * mccaRoseGoldSize ' range=':= 0.921 * _default_ * mccaRoseGoldSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.921 * _default_ * mccaRoseGoldSize ' range=':= 0.921 * _default_ * mccaRoseGoldSize ' type='normal' scaleTo='base' />
@@ -205,7 +205,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("MCA:tile.roseGoldOre")'> <OreBlock block='MCA:tile.roseGoldOre' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 6.000 * mccaRoseGoldSize ' range=':= _default_ * mccaRoseGoldSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 5.000 * mccaRoseGoldFreq ' range=':= _default_ * mccaRoseGoldFreq ' type='normal' scaleTo='base' />

--- a/src/main/resources/config/modules/PamsHarvestCraft.xml
+++ b/src/main/resources/config/modules/PamsHarvestCraft.xml
@@ -114,7 +114,7 @@
                                 their  direction while mining.
                             </Description>
                             <IfCondition condition=':= ?blockExists("harvestcraft:salt")'> <OreBlock block='harvestcraft:salt' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 5.305 * _default_ * hvstSaltFreq ' range=':= 5.305 * _default_ * hvstSaltFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * hvstSaltSize ' range=':= 0 * _default_ * hvstSaltSize ' type='normal' />
@@ -156,7 +156,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("harvestcraft:salt")'> <OreBlock block='harvestcraft:salt' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.377 * _default_ * hvstSaltSize ' range=':= 1.377 * _default_ * hvstSaltSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.377 * _default_ * hvstSaltSize ' range=':= 1.377 * _default_ * hvstSaltSize ' type='normal' scaleTo='base' />
@@ -208,7 +208,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("harvestcraft:salt")'> <OreBlock block='harvestcraft:salt' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 5.000 * hvstSaltSize ' range=':= _default_ * hvstSaltSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 30.000 * hvstSaltFreq ' range=':= _default_ * hvstSaltFreq ' type='normal' scaleTo='base' />

--- a/src/main/resources/config/modules/ProjectRed.xml
+++ b/src/main/resources/config/modules/ProjectRed.xml
@@ -353,7 +353,7 @@
                                 up from near the bottom  of the map.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.270 * _default_ * predRubyFreq ' range=':= 0.270 * _default_ * predRubyFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * predRubySize ' range=':= 0 * _default_ * predRubySize ' type='normal' />
@@ -375,7 +375,7 @@
                         <!-- Configuring contained material. -->
                         <Veins name='predRubyVeinsPipe'  inherits='predRubyVeins' seed='0xE23A' drawWireframe='true' wireframeColor='0x60900113' drawBoundBox='false' boundBoxColor='0x60900113'>
                             <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore")'> <Replaces block='ProjRed|Exploration:projectred.exploration.ore' weight='1.0' /> </IfCondition>
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * predRubySize  * 0.5 ' range=':= 0 * _default_ * predRubySize  * 0.5 ' type='normal' />
                             <Setting name='SegmentRadius' avg=':= 0.721 * _default_ * predRubySize  * 0.5 ' range=':= 0.721 * _default_ * predRubySize  * 0.5 ' type='normal' />
@@ -405,7 +405,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.393 * _default_ * predRubySize ' range=':= 0.393 * _default_ * predRubySize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.393 * _default_ * predRubySize ' range=':= 0.393 * _default_ * predRubySize ' type='normal' scaleTo='base' />
@@ -457,7 +457,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 1.000 * predRubySize ' range=':= _default_ * predRubySize ' type='normal' />
                             <Setting name='Frequency' avg=':= 1.000 * predRubyFreq ' range=':= _default_ * predRubyFreq ' type='normal' scaleTo='base' />
@@ -482,7 +482,7 @@
                                 up from near the bottom  of the map.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:1")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:1' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.270 * _default_ * predSapphireFreq ' range=':= 0.270 * _default_ * predSapphireFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * predSapphireSize ' range=':= 0 * _default_ * predSapphireSize ' type='normal' />
@@ -504,7 +504,7 @@
                         <!-- Configuring contained material. -->
                         <Veins name='predSapphireVeinsPipe'  inherits='predSapphireVeins' seed='0x5196' drawWireframe='true' wireframeColor='0x600011C8' drawBoundBox='false' boundBoxColor='0x600011C8'>
                             <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:1")'> <Replaces block='ProjRed|Exploration:projectred.exploration.ore:1' weight='1.0' /> </IfCondition>
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * predSapphireSize  * 0.5 ' range=':= 0 * _default_ * predSapphireSize  * 0.5 ' type='normal' />
                             <Setting name='SegmentRadius' avg=':= 0.721 * _default_ * predSapphireSize  * 0.5 ' range=':= 0.721 * _default_ * predSapphireSize  * 0.5 ' type='normal' />
@@ -534,7 +534,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:1")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:1' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.393 * _default_ * predSapphireSize ' range=':= 0.393 * _default_ * predSapphireSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.393 * _default_ * predSapphireSize ' range=':= 0.393 * _default_ * predSapphireSize ' type='normal' scaleTo='base' />
@@ -586,7 +586,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:1")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:1' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 1.000 * predSapphireSize ' range=':= _default_ * predSapphireSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 1.000 * predSapphireFreq ' range=':= _default_ * predSapphireFreq ' type='normal' scaleTo='base' />
@@ -611,7 +611,7 @@
                                 up from near the bottom  of the map.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:2")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:2' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.270 * _default_ * predPeridotFreq ' range=':= 0.270 * _default_ * predPeridotFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * predPeridotSize ' range=':= 0 * _default_ * predPeridotSize ' type='normal' />
@@ -633,7 +633,7 @@
                         <!-- Configuring contained material. -->
                         <Veins name='predPeridotVeinsPipe'  inherits='predPeridotVeins' seed='0x8759' drawWireframe='true' wireframeColor='0x60057529' drawBoundBox='false' boundBoxColor='0x60057529'>
                             <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:2")'> <Replaces block='ProjRed|Exploration:projectred.exploration.ore:2' weight='1.0' /> </IfCondition>
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * predPeridotSize  * 0.5 ' range=':= 0 * _default_ * predPeridotSize  * 0.5 ' type='normal' />
                             <Setting name='SegmentRadius' avg=':= 0.721 * _default_ * predPeridotSize  * 0.5 ' range=':= 0.721 * _default_ * predPeridotSize  * 0.5 ' type='normal' />
@@ -663,7 +663,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:2")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:2' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.393 * _default_ * predPeridotSize ' range=':= 0.393 * _default_ * predPeridotSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.393 * _default_ * predPeridotSize ' range=':= 0.393 * _default_ * predPeridotSize ' type='normal' scaleTo='base' />
@@ -715,7 +715,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:2")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:2' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 1.000 * predPeridotSize ' range=':= _default_ * predPeridotSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 1.000 * predPeridotFreq ' range=':= _default_ * predPeridotFreq ' type='normal' scaleTo='base' />
@@ -740,7 +740,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:3")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:3' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.416 * _default_ * predCopperFreq ' range=':= 1.416 * _default_ * predCopperFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.060 * _default_ * predCopperSize ' range=':= 1.060 * _default_ * predCopperSize ' type='normal' />
@@ -782,7 +782,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:3")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:3' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.113 * _default_ * predCopperSize ' range=':= 1.113 * _default_ * predCopperSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.113 * _default_ * predCopperSize ' range=':= 1.113 * _default_ * predCopperSize ' type='normal' scaleTo='base' />
@@ -834,7 +834,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:3")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:3' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 8.000 * predCopperSize ' range=':= _default_ * predCopperSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 8.000 * predCopperFreq ' range=':= _default_ * predCopperFreq ' type='normal' scaleTo='base' />
@@ -859,7 +859,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:4")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:4' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.119 * _default_ * predTinFreq ' range=':= 1.119 * _default_ * predTinFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.019 * _default_ * predTinSize ' range=':= 1.019 * _default_ * predTinSize ' type='normal' />
@@ -901,7 +901,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:4")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:4' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.990 * _default_ * predTinSize ' range=':= 0.990 * _default_ * predTinSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.990 * _default_ * predTinSize ' range=':= 0.990 * _default_ * predTinSize ' type='normal' scaleTo='base' />
@@ -953,7 +953,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:4")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:4' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 8.000 * predTinSize ' range=':= _default_ * predTinSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 5.000 * predTinFreq ' range=':= _default_ * predTinFreq ' type='normal' scaleTo='base' />
@@ -978,7 +978,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:5")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:5' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.354 * _default_ * predSilverFreq ' range=':= 0.354 * _default_ * predSilverFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.841 * _default_ * predSilverSize ' range=':= 0.841 * _default_ * predSilverSize ' type='normal' />
@@ -1020,7 +1020,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:5")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:5' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.556 * _default_ * predSilverSize ' range=':= 0.556 * _default_ * predSilverSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.556 * _default_ * predSilverSize ' range=':= 0.556 * _default_ * predSilverSize ' type='normal' scaleTo='base' />
@@ -1072,7 +1072,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:5")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:5' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * predSilverSize ' range=':= _default_ * predSilverSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 1.000 * predSilverFreq ' range=':= _default_ * predSilverFreq ' type='normal' scaleTo='base' />
@@ -1097,7 +1097,7 @@
                                 no motherlodes.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:6")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:6' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.286 * _default_ * predElectrotineFreq ' range=':= 1.286 * _default_ * predElectrotineFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * predElectrotineSize ' range=':= 0 * _default_ * predElectrotineSize ' type='normal' />
@@ -1139,7 +1139,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:6")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:6' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.787 * _default_ * predElectrotineSize ' range=':= 0.787 * _default_ * predElectrotineSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.787 * _default_ * predElectrotineSize ' range=':= 0.787 * _default_ * predElectrotineSize ' type='normal' scaleTo='base' />
@@ -1191,7 +1191,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:6")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:6' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 8.000 * predElectrotineSize ' range=':= _default_ * predElectrotineSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 2.000 * predElectrotineFreq ' range=':= _default_ * predElectrotineFreq ' type='normal' scaleTo='base' />
@@ -1216,7 +1216,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.stone")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.stone' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.708 * _default_ * predMarbleFreq ' range=':= 0.708 * _default_ * predMarbleFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.944 * _default_ * predMarbleSize ' range=':= 0.944 * _default_ * predMarbleSize ' type='normal' />
@@ -1258,7 +1258,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.stone")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.stone' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.787 * _default_ * predMarbleSize ' range=':= 0.787 * _default_ * predMarbleSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.787 * _default_ * predMarbleSize ' range=':= 0.787 * _default_ * predMarbleSize ' type='normal' scaleTo='base' />
@@ -1310,7 +1310,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.stone")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.stone' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 16.000 * predMarbleSize ' range=':= _default_ * predMarbleSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 1.000 * predMarbleFreq ' range=':= _default_ * predMarbleFreq ' type='normal' scaleTo='base' />

--- a/src/main/resources/config/modules/RailCraft.xml
+++ b/src/main/resources/config/modules/RailCraft.xml
@@ -399,10 +399,10 @@
                                 contained ores.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Railcraft:cube:6")'> <OreBlock block='Railcraft:cube:6' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:sand")'> <Replaces block='minecraft:sand' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("dirt")'> <ReplacesOre block='dirt' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("gravel")'> <ReplacesOre block='gravel' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("sand")'> <ReplacesOre block='sand' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:lava")'> <Replaces block='minecraft:lava' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:water")'> <Replaces block='minecraft:water' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:air")'> <Replaces block='minecraft:air' weight='1.0' /> </IfCondition>
@@ -428,10 +428,10 @@
                             <IfCondition condition=':= ?blockExists("Railcraft:ore:2")'> <OreBlock block='Railcraft:ore:2' weight='0.0167' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("Railcraft:ore:3")'> <OreBlock block='Railcraft:ore:3' weight='0.0167' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("Railcraft:ore:4")'> <OreBlock block='Railcraft:ore:4' weight='0.05' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:sand")'> <Replaces block='minecraft:sand' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("dirt")'> <ReplacesOre block='dirt' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("gravel")'> <ReplacesOre block='gravel' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("sand")'> <ReplacesOre block='sand' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:lava")'> <Replaces block='minecraft:lava' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:water")'> <Replaces block='minecraft:water' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:air")'> <Replaces block='minecraft:air' weight='1.0' /> </IfCondition>
@@ -453,10 +453,10 @@
                             <IfCondition condition=':= ?blockExists("Railcraft:ore:2")'> <Replaces block='Railcraft:ore:2' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("Railcraft:ore:3")'> <Replaces block='Railcraft:ore:3' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("Railcraft:ore:4")'> <Replaces block='Railcraft:ore:4' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:sand")'> <Replaces block='minecraft:sand' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
+                            <IfCondition condition=':= ?blockExists("dirt")'> <ReplacesOre block='dirt' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("gravel")'> <ReplacesOre block='gravel' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("sand")'> <ReplacesOre block='sand' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:lava")'> <Replaces block='minecraft:lava' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:water")'> <Replaces block='minecraft:water' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:air")'> <Replaces block='minecraft:air' weight='1.0' /> </IfCondition>
@@ -489,7 +489,7 @@
                                 their  direction while mining.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Railcraft:ore:7")'> <OreBlock block='Railcraft:ore:7' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 9.801 * _default_ * rlcrPoorIronFreq ' range=':= 9.801 * _default_ * rlcrPoorIronFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * rlcrPoorIronSize ' range=':= 0 * _default_ * rlcrPoorIronSize ' type='normal' />
@@ -531,7 +531,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Railcraft:ore:7")'> <OreBlock block='Railcraft:ore:7' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.872 * _default_ * rlcrPoorIronSize ' range=':= 1.872 * _default_ * rlcrPoorIronSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.872 * _default_ * rlcrPoorIronSize ' range=':= 1.872 * _default_ * rlcrPoorIronSize ' type='normal' scaleTo='base' />
@@ -583,7 +583,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Railcraft:ore:7")'> <OreBlock block='Railcraft:ore:7' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 16.000 * rlcrPoorIronSize ' range=':= _default_ * rlcrPoorIronSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 32.000 * rlcrPoorIronFreq ' range=':= _default_ * rlcrPoorIronFreq ' type='normal' scaleTo='base' />
@@ -615,7 +615,7 @@
                                 their  direction while mining.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Railcraft:ore:8")'> <OreBlock block='Railcraft:ore:8' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.450 * _default_ * rlcrPoorGoldFreq ' range=':= 2.450 * _default_ * rlcrPoorGoldFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * rlcrPoorGoldSize ' range=':= 0 * _default_ * rlcrPoorGoldSize ' type='normal' />
@@ -657,7 +657,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Railcraft:ore:8")'> <OreBlock block='Railcraft:ore:8' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.936 * _default_ * rlcrPoorGoldSize ' range=':= 0.936 * _default_ * rlcrPoorGoldSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.936 * _default_ * rlcrPoorGoldSize ' range=':= 0.936 * _default_ * rlcrPoorGoldSize ' type='normal' scaleTo='base' />
@@ -709,7 +709,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Railcraft:ore:8")'> <OreBlock block='Railcraft:ore:8' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 1.000 * rlcrPoorGoldSize ' range=':= _default_ * rlcrPoorGoldSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 32.000 * rlcrPoorGoldFreq ' range=':= _default_ * rlcrPoorGoldFreq ' type='normal' scaleTo='base' />
@@ -741,7 +741,7 @@
                                 their  direction while mining.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Railcraft:ore:9")'> <OreBlock block='Railcraft:ore:9' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 6.930 * _default_ * rlcrPoorCopperFreq ' range=':= 6.930 * _default_ * rlcrPoorCopperFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * rlcrPoorCopperSize ' range=':= 0 * _default_ * rlcrPoorCopperSize ' type='normal' />
@@ -783,7 +783,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Railcraft:ore:9")'> <OreBlock block='Railcraft:ore:9' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.574 * _default_ * rlcrPoorCopperSize ' range=':= 1.574 * _default_ * rlcrPoorCopperSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.574 * _default_ * rlcrPoorCopperSize ' range=':= 1.574 * _default_ * rlcrPoorCopperSize ' type='normal' scaleTo='base' />
@@ -835,7 +835,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Railcraft:ore:9")'> <OreBlock block='Railcraft:ore:9' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 8.000 * rlcrPoorCopperSize ' range=':= _default_ * rlcrPoorCopperSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 32.000 * rlcrPoorCopperFreq ' range=':= _default_ * rlcrPoorCopperFreq ' type='normal' scaleTo='base' />
@@ -867,7 +867,7 @@
                                 their  direction while mining.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Railcraft:ore:10")'> <OreBlock block='Railcraft:ore:10' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 3.465 * _default_ * rlcrPoorTinFreq ' range=':= 3.465 * _default_ * rlcrPoorTinFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * rlcrPoorTinSize ' range=':= 0 * _default_ * rlcrPoorTinSize ' type='normal' />
@@ -909,7 +909,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Railcraft:ore:10")'> <OreBlock block='Railcraft:ore:10' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.113 * _default_ * rlcrPoorTinSize ' range=':= 1.113 * _default_ * rlcrPoorTinSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.113 * _default_ * rlcrPoorTinSize ' range=':= 1.113 * _default_ * rlcrPoorTinSize ' type='normal' scaleTo='base' />
@@ -961,7 +961,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Railcraft:ore:10")'> <OreBlock block='Railcraft:ore:10' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 2.000 * rlcrPoorTinSize ' range=':= _default_ * rlcrPoorTinSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 32.000 * rlcrPoorTinFreq ' range=':= _default_ * rlcrPoorTinFreq ' type='normal' scaleTo='base' />
@@ -993,7 +993,7 @@
                                 their  direction while mining.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Railcraft:ore:11")'> <OreBlock block='Railcraft:ore:11' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 6.002 * _default_ * rlcrPoorLeadFreq ' range=':= 6.002 * _default_ * rlcrPoorLeadFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * rlcrPoorLeadSize ' range=':= 0 * _default_ * rlcrPoorLeadSize ' type='normal' />
@@ -1035,7 +1035,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Railcraft:ore:11")'> <OreBlock block='Railcraft:ore:11' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.465 * _default_ * rlcrPoorLeadSize ' range=':= 1.465 * _default_ * rlcrPoorLeadSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.465 * _default_ * rlcrPoorLeadSize ' range=':= 1.465 * _default_ * rlcrPoorLeadSize ' type='normal' scaleTo='base' />
@@ -1087,7 +1087,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Railcraft:ore:11")'> <OreBlock block='Railcraft:ore:11' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 6.000 * rlcrPoorLeadSize ' range=':= _default_ * rlcrPoorLeadSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 32.000 * rlcrPoorLeadFreq ' range=':= _default_ * rlcrPoorLeadFreq ' type='normal' scaleTo='base' />
@@ -1119,7 +1119,7 @@
                                 their  direction while mining.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Railcraft:ore:1")'> <OreBlock block='Railcraft:ore:1' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:sand")'> <Replaces block='minecraft:sand' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("sand")'> <ReplacesOre block='sand' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
                             <BiomeType name='Desert'  minRainfall='0' maxRainfall='0.1' minTemperature='1.5' maxTemperature='2.0' />
                             <Setting name='MotherlodeFrequency' avg=':= 3.465 * _default_ * rlcrSaltpeterFreq ' range=':= 3.465 * _default_ * rlcrSaltpeterFreq ' type='normal' scaleTo='base' />
@@ -1162,7 +1162,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Railcraft:ore:1")'> <OreBlock block='Railcraft:ore:1' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:sand")'> <Replaces block='minecraft:sand' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("sand")'> <ReplacesOre block='sand' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
                             <BiomeType name='Desert'  minRainfall='0' maxRainfall='0.1' minTemperature='1.5' maxTemperature='2.0' />
                             <Setting name='CloudRadius' avg=':= 1.113 * _default_ * rlcrSaltpeterSize ' range=':= 1.113 * _default_ * rlcrSaltpeterSize ' type='normal' />
@@ -1215,7 +1215,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Railcraft:ore:1")'> <OreBlock block='Railcraft:ore:1' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:sand")'> <Replaces block='minecraft:sand' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("sand")'> <ReplacesOre block='sand' weight='1.0' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
                             <BiomeType name='Desert'  minRainfall='0' maxRainfall='0.1' minTemperature='1.5' maxTemperature='2.0' />
                             <Setting name='Size' avg=':= 1.000 * rlcrSaltpeterSize ' range=':= _default_ * rlcrSaltpeterSize ' type='normal' />
@@ -1241,7 +1241,7 @@
                                 up from near the bottom  of the map.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Railcraft:ore")'> <OreBlock block='Railcraft:ore' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.707 * _default_ * rlcrSulfurFreq ' range=':= 1.707 * _default_ * rlcrSulfurFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * rlcrSulfurSize ' range=':= 0 * _default_ * rlcrSulfurSize ' type='normal' />
@@ -1263,7 +1263,7 @@
                         <!-- Configuring contained material. -->
                         <Veins name='rlcrSulfurVeinsPipe'  inherits='rlcrSulfurVeins' seed='0xEE54' drawWireframe='true' wireframeColor='0x60FFE25C' drawBoundBox='false' boundBoxColor='0x60FFE25C'>
                             <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <IfCondition condition=':= ?blockExists("Railcraft:ore")'> <Replaces block='Railcraft:ore' weight='1.0' /> </IfCondition>
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * rlcrSulfurSize  * 0.5 ' range=':= 0 * _default_ * rlcrSulfurSize  * 0.5 ' type='normal' />
                             <Setting name='SegmentRadius' avg=':= 1.143 * _default_ * rlcrSulfurSize  * 0.5 ' range=':= 1.143 * _default_ * rlcrSulfurSize  * 0.5 ' type='normal' />
@@ -1293,7 +1293,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Railcraft:ore")'> <OreBlock block='Railcraft:ore' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.990 * _default_ * rlcrSulfurSize ' range=':= 0.990 * _default_ * rlcrSulfurSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.990 * _default_ * rlcrSulfurSize ' range=':= 0.990 * _default_ * rlcrSulfurSize ' type='normal' scaleTo='base' />
@@ -1345,7 +1345,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Railcraft:ore")'> <OreBlock block='Railcraft:ore' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 10.000 * rlcrSulfurSize ' range=':= _default_ * rlcrSulfurSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 4.000 * rlcrSulfurFreq ' range=':= _default_ * rlcrSulfurFreq ' type='normal' scaleTo='base' />
@@ -1404,7 +1404,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Railcraft:ore:5")'> <OreBlock block='Railcraft:ore:5' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.221 * _default_ * rlcrFirestoneFreq ' range=':= 0.221 * _default_ * rlcrFirestoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.778 * _default_ * rlcrFirestoneSize ' range=':= 0.778 * _default_ * rlcrFirestoneSize ' type='normal' />
@@ -1446,7 +1446,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Railcraft:ore:5")'> <OreBlock block='Railcraft:ore:5' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.393 * _default_ * rlcrFirestoneSize ' range=':= 0.393 * _default_ * rlcrFirestoneSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.393 * _default_ * rlcrFirestoneSize ' range=':= 0.393 * _default_ * rlcrFirestoneSize ' type='normal' scaleTo='base' />
@@ -1498,7 +1498,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Railcraft:ore:5")'> <OreBlock block='Railcraft:ore:5' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 1.000 * rlcrFirestoneSize ' range=':= _default_ * rlcrFirestoneSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 1.000 * rlcrFirestoneFreq ' range=':= _default_ * rlcrFirestoneFreq ' type='normal' scaleTo='base' />

--- a/src/main/resources/config/modules/ReactorCraft.xml
+++ b/src/main/resources/config/modules/ReactorCraft.xml
@@ -676,7 +676,7 @@
                                 their  direction while mining.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:1")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:1' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Mushroom'  />
                             <BiomeType name='Ocean'  />
                             <BiomeType name='River'  />
@@ -710,7 +710,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:1")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:1' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Mushroom'  />
                             <BiomeType name='Ocean'  />
                             <BiomeType name='River'  />
@@ -743,7 +743,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:1")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:1' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Mushroom'  />
                             <BiomeType name='Ocean'  />
                             <BiomeType name='River'  />
@@ -801,7 +801,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:2")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:2' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.919 * _default_ * recrCadmiumFreq ' range=':= 0.919 * _default_ * recrCadmiumFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.986 * _default_ * recrCadmiumSize ' range=':= 0.986 * _default_ * recrCadmiumSize ' type='normal' />
@@ -833,7 +833,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:2")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:2' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 9.000 * recrCadmiumSize ' range=':= _default_ * recrCadmiumSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 3.000 * recrCadmiumFreq ' range=':= _default_ * recrCadmiumFreq ' type='normal' scaleTo='base' />
@@ -864,7 +864,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:2")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:2' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.897 * _default_ * recrCadmiumSize ' range=':= 0.897 * _default_ * recrCadmiumSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.897 * _default_ * recrCadmiumSize ' range=':= 0.897 * _default_ * recrCadmiumSize ' type='normal' scaleTo='base' />
@@ -920,7 +920,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:3")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:3' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.662 * _default_ * recrIndiumFreq ' range=':= 0.662 * _default_ * recrIndiumFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.934 * _default_ * recrIndiumSize ' range=':= 0.934 * _default_ * recrIndiumSize ' type='normal' />
@@ -952,7 +952,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:3")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:3' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 7.000 * recrIndiumSize ' range=':= _default_ * recrIndiumSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 2.000 * recrIndiumFreq ' range=':= _default_ * recrIndiumFreq ' type='normal' scaleTo='base' />
@@ -983,7 +983,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:3")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:3' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.761 * _default_ * recrIndiumSize ' range=':= 0.761 * _default_ * recrIndiumSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.761 * _default_ * recrIndiumSize ' range=':= 0.761 * _default_ * recrIndiumSize ' type='normal' scaleTo='base' />
@@ -1039,7 +1039,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:4")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:4' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.751 * _default_ * recrSilverFreq ' range=':= 0.751 * _default_ * recrSilverFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.953 * _default_ * recrSilverSize ' range=':= 0.953 * _default_ * recrSilverSize ' type='normal' />
@@ -1071,7 +1071,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:4")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:4' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 9.000 * recrSilverSize ' range=':= _default_ * recrSilverSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 2.000 * recrSilverFreq ' range=':= _default_ * recrSilverFreq ' type='normal' scaleTo='base' />
@@ -1102,7 +1102,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:4")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:4' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.810 * _default_ * recrSilverSize ' range=':= 0.810 * _default_ * recrSilverSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.810 * _default_ * recrSilverSize ' range=':= 0.810 * _default_ * recrSilverSize ' type='normal' scaleTo='base' />
@@ -1165,7 +1165,7 @@
                                 their  direction while mining.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:7")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:7' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 3.001 * _default_ * recrCalciteFreq ' range=':= 3.001 * _default_ * recrCalciteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * recrCalciteSize ' range=':= 0 * _default_ * recrCalciteSize ' type='normal' />
@@ -1197,7 +1197,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:7")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:7' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * recrCalciteSize ' range=':= _default_ * recrCalciteSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 12.000 * recrCalciteFreq ' range=':= _default_ * recrCalciteFreq ' type='normal' scaleTo='base' />
@@ -1228,7 +1228,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:7")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:7' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.036 * _default_ * recrCalciteSize ' range=':= 1.036 * _default_ * recrCalciteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.036 * _default_ * recrCalciteSize ' range=':= 1.036 * _default_ * recrCalciteSize ' type='normal' scaleTo='base' />
@@ -1291,7 +1291,7 @@
                                 their  direction while mining.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:8")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:8' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 4.584 * _default_ * recrMagnetiteFreq ' range=':= 4.584 * _default_ * recrMagnetiteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * recrMagnetiteSize ' range=':= 0 * _default_ * recrMagnetiteSize ' type='normal' />
@@ -1323,7 +1323,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:8")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:8' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 16.000 * recrMagnetiteSize ' range=':= _default_ * recrMagnetiteSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 7.000 * recrMagnetiteFreq ' range=':= _default_ * recrMagnetiteFreq ' type='normal' scaleTo='base' />
@@ -1354,7 +1354,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:8")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:8' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.280 * _default_ * recrMagnetiteSize ' range=':= 1.280 * _default_ * recrMagnetiteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.280 * _default_ * recrMagnetiteSize ' range=':= 1.280 * _default_ * recrMagnetiteSize ' type='normal' scaleTo='base' />
@@ -1410,7 +1410,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.613 * _default_ * recrBlueFluoriteFreq ' range=':= 0.613 * _default_ * recrBlueFluoriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * recrBlueFluoriteSize ' range=':= 0.922 * _default_ * recrBlueFluoriteSize ' type='normal' />
@@ -1443,7 +1443,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 1.000 * recrBlueFluoriteSize ' range=':= _default_ * recrBlueFluoriteSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 1.500 * recrBlueFluoriteFreq ' range=':= _default_ * recrBlueFluoriteFreq ' type='normal' scaleTo='base' />
@@ -1474,7 +1474,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.732 * _default_ * recrBlueFluoriteSize ' range=':= 0.732 * _default_ * recrBlueFluoriteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.732 * _default_ * recrBlueFluoriteSize ' range=':= 0.732 * _default_ * recrBlueFluoriteSize ' type='normal' scaleTo='base' />
@@ -1530,7 +1530,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:1")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:1' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.613 * _default_ * recrPinkFluoriteFreq ' range=':= 0.613 * _default_ * recrPinkFluoriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * recrPinkFluoriteSize ' range=':= 0.922 * _default_ * recrPinkFluoriteSize ' type='normal' />
@@ -1563,7 +1563,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:1")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:1' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 1.000 * recrPinkFluoriteSize ' range=':= _default_ * recrPinkFluoriteSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 1.500 * recrPinkFluoriteFreq ' range=':= _default_ * recrPinkFluoriteFreq ' type='normal' scaleTo='base' />
@@ -1594,7 +1594,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:1")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:1' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.732 * _default_ * recrPinkFluoriteSize ' range=':= 0.732 * _default_ * recrPinkFluoriteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.732 * _default_ * recrPinkFluoriteSize ' range=':= 0.732 * _default_ * recrPinkFluoriteSize ' type='normal' scaleTo='base' />
@@ -1650,7 +1650,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:2")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:2' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.613 * _default_ * recrOrangeFluoriteFreq ' range=':= 0.613 * _default_ * recrOrangeFluoriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * recrOrangeFluoriteSize ' range=':= 0.922 * _default_ * recrOrangeFluoriteSize ' type='normal' />
@@ -1683,7 +1683,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:2")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:2' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 1.000 * recrOrangeFluoriteSize ' range=':= _default_ * recrOrangeFluoriteSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 1.500 * recrOrangeFluoriteFreq ' range=':= _default_ * recrOrangeFluoriteFreq ' type='normal' scaleTo='base' />
@@ -1714,7 +1714,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:2")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:2' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.732 * _default_ * recrOrangeFluoriteSize ' range=':= 0.732 * _default_ * recrOrangeFluoriteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.732 * _default_ * recrOrangeFluoriteSize ' range=':= 0.732 * _default_ * recrOrangeFluoriteSize ' type='normal' scaleTo='base' />
@@ -1771,7 +1771,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:3")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:3' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.613 * _default_ * recrMagentaFluoriteFreq ' range=':= 0.613 * _default_ * recrMagentaFluoriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * recrMagentaFluoriteSize ' range=':= 0.922 * _default_ * recrMagentaFluoriteSize ' type='normal' />
@@ -1804,7 +1804,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:3")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:3' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 1.000 * recrMagentaFluoriteSize ' range=':= _default_ * recrMagentaFluoriteSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 1.500 * recrMagentaFluoriteFreq ' range=':= _default_ * recrMagentaFluoriteFreq ' type='normal' scaleTo='base' />
@@ -1835,7 +1835,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:3")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:3' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.732 * _default_ * recrMagentaFluoriteSize ' range=':= 0.732 * _default_ * recrMagentaFluoriteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.732 * _default_ * recrMagentaFluoriteSize ' range=':= 0.732 * _default_ * recrMagentaFluoriteSize ' type='normal' scaleTo='base' />
@@ -1891,7 +1891,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:4")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:4' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.613 * _default_ * recrGreenFluoriteFreq ' range=':= 0.613 * _default_ * recrGreenFluoriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * recrGreenFluoriteSize ' range=':= 0.922 * _default_ * recrGreenFluoriteSize ' type='normal' />
@@ -1924,7 +1924,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:4")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:4' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 1.000 * recrGreenFluoriteSize ' range=':= _default_ * recrGreenFluoriteSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 1.500 * recrGreenFluoriteFreq ' range=':= _default_ * recrGreenFluoriteFreq ' type='normal' scaleTo='base' />
@@ -1955,7 +1955,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:4")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:4' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.732 * _default_ * recrGreenFluoriteSize ' range=':= 0.732 * _default_ * recrGreenFluoriteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.732 * _default_ * recrGreenFluoriteSize ' range=':= 0.732 * _default_ * recrGreenFluoriteSize ' type='normal' scaleTo='base' />
@@ -2011,7 +2011,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:5")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:5' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.613 * _default_ * recrRedFluoriteFreq ' range=':= 0.613 * _default_ * recrRedFluoriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * recrRedFluoriteSize ' range=':= 0.922 * _default_ * recrRedFluoriteSize ' type='normal' />
@@ -2043,7 +2043,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:5")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:5' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 1.000 * recrRedFluoriteSize ' range=':= _default_ * recrRedFluoriteSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 1.500 * recrRedFluoriteFreq ' range=':= _default_ * recrRedFluoriteFreq ' type='normal' scaleTo='base' />
@@ -2074,7 +2074,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:5")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:5' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.732 * _default_ * recrRedFluoriteSize ' range=':= 0.732 * _default_ * recrRedFluoriteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.732 * _default_ * recrRedFluoriteSize ' range=':= 0.732 * _default_ * recrRedFluoriteSize ' type='normal' scaleTo='base' />
@@ -2130,7 +2130,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:6")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:6' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.613 * _default_ * recrWhiteFluoriteFreq ' range=':= 0.613 * _default_ * recrWhiteFluoriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * recrWhiteFluoriteSize ' range=':= 0.922 * _default_ * recrWhiteFluoriteSize ' type='normal' />
@@ -2163,7 +2163,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:6")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:6' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 1.000 * recrWhiteFluoriteSize ' range=':= _default_ * recrWhiteFluoriteSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 1.500 * recrWhiteFluoriteFreq ' range=':= _default_ * recrWhiteFluoriteFreq ' type='normal' scaleTo='base' />
@@ -2194,7 +2194,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:6")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:6' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.732 * _default_ * recrWhiteFluoriteSize ' range=':= 0.732 * _default_ * recrWhiteFluoriteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.732 * _default_ * recrWhiteFluoriteSize ' range=':= 0.732 * _default_ * recrWhiteFluoriteSize ' type='normal' scaleTo='base' />
@@ -2250,7 +2250,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:7")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:7' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.613 * _default_ * recrYellowFluoriteFreq ' range=':= 0.613 * _default_ * recrYellowFluoriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * recrYellowFluoriteSize ' range=':= 0.922 * _default_ * recrYellowFluoriteSize ' type='normal' />
@@ -2283,7 +2283,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:7")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:7' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 1.000 * recrYellowFluoriteSize ' range=':= _default_ * recrYellowFluoriteSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 1.500 * recrYellowFluoriteFreq ' range=':= _default_ * recrYellowFluoriteFreq ' type='normal' scaleTo='base' />
@@ -2314,7 +2314,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:7")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:7' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.732 * _default_ * recrYellowFluoriteSize ' range=':= 0.732 * _default_ * recrYellowFluoriteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.732 * _default_ * recrYellowFluoriteSize ' range=':= 0.732 * _default_ * recrYellowFluoriteSize ' type='normal' scaleTo='base' />
@@ -2411,7 +2411,7 @@
                                 their  direction while mining.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:6")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:6' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 3.001 * _default_ * recrAmmoniumChlorideFreq ' range=':= 3.001 * _default_ * recrAmmoniumChlorideFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * recrAmmoniumChlorideSize ' range=':= 0 * _default_ * recrAmmoniumChlorideSize ' type='normal' />
@@ -2444,7 +2444,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:6")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:6' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 8.000 * recrAmmoniumChlorideSize ' range=':= _default_ * recrAmmoniumChlorideSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 6.000 * recrAmmoniumChlorideFreq ' range=':= _default_ * recrAmmoniumChlorideFreq ' type='normal' scaleTo='base' />
@@ -2475,7 +2475,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:6")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:6' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.036 * _default_ * recrAmmoniumChlorideSize ' range=':= 1.036 * _default_ * recrAmmoniumChlorideSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.036 * _default_ * recrAmmoniumChlorideSize ' range=':= 1.036 * _default_ * recrAmmoniumChlorideSize ' type='normal' scaleTo='base' />
@@ -2531,7 +2531,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:9")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:9' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.122 * _default_ * recrThoriteFreq ' range=':= 2.122 * _default_ * recrThoriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * recrThoriteSize ' range=':= 0 * _default_ * recrThoriteSize ' type='normal' />
@@ -2563,7 +2563,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:9")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:9' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 24.000 * recrThoriteSize ' range=':= _default_ * recrThoriteSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 1.000 * recrThoriteFreq ' range=':= _default_ * recrThoriteFreq ' type='normal' scaleTo='base' />
@@ -2594,7 +2594,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:9")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:9' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.871 * _default_ * recrThoriteSize ' range=':= 0.871 * _default_ * recrThoriteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.871 * _default_ * recrThoriteSize ' range=':= 0.871 * _default_ * recrThoriteSize ' type='normal' scaleTo='base' />
@@ -2689,7 +2689,7 @@
                                 their  direction while mining.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:5")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:5' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 4.244 * _default_ * recrEndPitchblendeFreq ' range=':= 4.244 * _default_ * recrEndPitchblendeFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * recrEndPitchblendeSize ' range=':= 0 * _default_ * recrEndPitchblendeSize ' type='normal' />
@@ -2722,7 +2722,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:5")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:5' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 16.000 * recrEndPitchblendeSize ' range=':= _default_ * recrEndPitchblendeSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 6.000 * recrEndPitchblendeFreq ' range=':= _default_ * recrEndPitchblendeFreq ' type='normal' scaleTo='base' />
@@ -2753,7 +2753,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:5")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:5' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.232 * _default_ * recrEndPitchblendeSize ' range=':= 1.232 * _default_ * recrEndPitchblendeSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.232 * _default_ * recrEndPitchblendeSize ' range=':= 1.232 * _default_ * recrEndPitchblendeSize ' type='normal' scaleTo='base' />

--- a/src/main/resources/config/modules/SimpleOres.xml
+++ b/src/main/resources/config/modules/SimpleOres.xml
@@ -248,7 +248,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("simpleores:copper_ore")'> <OreBlock block='simpleores:copper_ore' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.770 * _default_ * smpoCopperFreq ' range=':= 2.770 * _default_ * smpoCopperFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.185 * _default_ * smpoCopperSize ' range=':= 1.185 * _default_ * smpoCopperSize ' type='normal' />
@@ -290,7 +290,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("simpleores:copper_ore")'> <OreBlock block='simpleores:copper_ore' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.557 * _default_ * smpoCopperSize ' range=':= 1.557 * _default_ * smpoCopperSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.557 * _default_ * smpoCopperSize ' range=':= 1.557 * _default_ * smpoCopperSize ' type='normal' scaleTo='base' />
@@ -342,7 +342,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("simpleores:copper_ore")'> <OreBlock block='simpleores:copper_ore' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 7.000 * smpoCopperSize ' range=':= _default_ * smpoCopperSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 35.000 * smpoCopperFreq ' range=':= _default_ * smpoCopperFreq ' type='normal' scaleTo='base' />
@@ -367,7 +367,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("simpleores:tin_ore")'> <OreBlock block='simpleores:tin_ore' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.564 * _default_ * smpoTinFreq ' range=':= 2.564 * _default_ * smpoTinFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.170 * _default_ * smpoTinSize ' range=':= 1.170 * _default_ * smpoTinSize ' type='normal' />
@@ -409,7 +409,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("simpleores:tin_ore")'> <OreBlock block='simpleores:tin_ore' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.498 * _default_ * smpoTinSize ' range=':= 1.498 * _default_ * smpoTinSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.498 * _default_ * smpoTinSize ' range=':= 1.498 * _default_ * smpoTinSize ' type='normal' scaleTo='base' />
@@ -461,7 +461,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("simpleores:tin_ore")'> <OreBlock block='simpleores:tin_ore' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 7.000 * smpoTinSize ' range=':= _default_ * smpoTinSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 30.000 * smpoTinFreq ' range=':= _default_ * smpoTinFreq ' type='normal' scaleTo='base' />
@@ -486,7 +486,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("simpleores:mythril_ore")'> <OreBlock block='simpleores:mythril_ore' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.001 * _default_ * smpoMythrilFreq ' range=':= 1.001 * _default_ * smpoMythrilFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.000 * _default_ * smpoMythrilSize ' range=':= 1.000 * _default_ * smpoMythrilSize ' type='normal' />
@@ -528,7 +528,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("simpleores:mythril_ore")'> <OreBlock block='simpleores:mythril_ore' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.936 * _default_ * smpoMythrilSize ' range=':= 0.936 * _default_ * smpoMythrilSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.936 * _default_ * smpoMythrilSize ' range=':= 0.936 * _default_ * smpoMythrilSize ' type='normal' scaleTo='base' />
@@ -580,7 +580,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("simpleores:mythril_ore")'> <OreBlock block='simpleores:mythril_ore' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * smpoMythrilSize ' range=':= _default_ * smpoMythrilSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 8.000 * smpoMythrilFreq ' range=':= _default_ * smpoMythrilFreq ' type='normal' scaleTo='base' />
@@ -605,7 +605,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("simpleores:adamantium_ore")'> <OreBlock block='simpleores:adamantium_ore' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.708 * _default_ * smpoAdamantiumFreq ' range=':= 0.708 * _default_ * smpoAdamantiumFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.944 * _default_ * smpoAdamantiumSize ' range=':= 0.944 * _default_ * smpoAdamantiumSize ' type='normal' />
@@ -647,7 +647,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("simpleores:adamantium_ore")'> <OreBlock block='simpleores:adamantium_ore' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.787 * _default_ * smpoAdamantiumSize ' range=':= 0.787 * _default_ * smpoAdamantiumSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.787 * _default_ * smpoAdamantiumSize ' range=':= 0.787 * _default_ * smpoAdamantiumSize ' type='normal' scaleTo='base' />
@@ -699,7 +699,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("simpleores:adamantium_ore")'> <OreBlock block='simpleores:adamantium_ore' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * smpoAdamantiumSize ' range=':= _default_ * smpoAdamantiumSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 4.000 * smpoAdamantiumFreq ' range=':= _default_ * smpoAdamantiumFreq ' type='normal' scaleTo='base' />

--- a/src/main/resources/config/modules/Thaumcraft4.xml
+++ b/src/main/resources/config/modules/Thaumcraft4.xml
@@ -362,7 +362,7 @@
                                 their  direction while mining.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:7")'> <OreBlock block='Thaumcraft:blockCustomOre:7' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.225 * _default_ * thm4AmberBearingStoneFreq ' range=':= 1.225 * _default_ * thm4AmberBearingStoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * thm4AmberBearingStoneSize ' range=':= 0 * _default_ * thm4AmberBearingStoneSize ' type='normal' />
@@ -405,7 +405,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:7")'> <OreBlock block='Thaumcraft:blockCustomOre:7' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.662 * _default_ * thm4AmberBearingStoneSize ' range=':= 0.662 * _default_ * thm4AmberBearingStoneSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.662 * _default_ * thm4AmberBearingStoneSize ' range=':= 0.662 * _default_ * thm4AmberBearingStoneSize ' type='normal' scaleTo='base' />
@@ -457,7 +457,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:7")'> <OreBlock block='Thaumcraft:blockCustomOre:7' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 1.000 * thm4AmberBearingStoneSize ' range=':= _default_ * thm4AmberBearingStoneSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 8.000 * thm4AmberBearingStoneFreq ' range=':= _default_ * thm4AmberBearingStoneFreq ' type='normal' scaleTo='base' />
@@ -490,7 +490,7 @@
                                 their  direction while mining.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre")'> <OreBlock block='Thaumcraft:blockCustomOre' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.500 * _default_ * thm4CinnabarFreq ' range=':= 1.500 * _default_ * thm4CinnabarFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * thm4CinnabarSize ' range=':= 0 * _default_ * thm4CinnabarSize ' type='normal' />
@@ -532,7 +532,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre")'> <OreBlock block='Thaumcraft:blockCustomOre' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.732 * _default_ * thm4CinnabarSize ' range=':= 0.732 * _default_ * thm4CinnabarSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.732 * _default_ * thm4CinnabarSize ' range=':= 0.732 * _default_ * thm4CinnabarSize ' type='normal' scaleTo='base' />
@@ -584,7 +584,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre")'> <OreBlock block='Thaumcraft:blockCustomOre' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 1.000 * thm4CinnabarSize ' range=':= _default_ * thm4CinnabarSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 12.000 * thm4CinnabarFreq ' range=':= _default_ * thm4CinnabarFreq ' type='normal' scaleTo='base' />
@@ -617,7 +617,7 @@
                                 their  direction while mining.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:1")'> <OreBlock block='Thaumcraft:blockCustomOre:1' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * thm4AirInfusedStoneFreq ' range=':= 0.969 * _default_ * thm4AirInfusedStoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * thm4AirInfusedStoneSize ' range=':= 0 * _default_ * thm4AirInfusedStoneSize ' type='normal' />
@@ -643,7 +643,7 @@
                                 preferred biomes.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:1")'> <OreBlock block='Thaumcraft:blockCustomOre:1' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Plains'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * thm4AirInfusedStoneFreq ' range=':= 0.969 * _default_ * thm4AirInfusedStoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * thm4AirInfusedStoneSize ' range=':= 0 * _default_ * thm4AirInfusedStoneSize ' type='normal' />
@@ -688,7 +688,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:1")'> <OreBlock block='Thaumcraft:blockCustomOre:1' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.588 * _default_ * thm4AirInfusedStoneSize ' range=':= 0.588 * _default_ * thm4AirInfusedStoneSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.588 * _default_ * thm4AirInfusedStoneSize ' range=':= 0.588 * _default_ * thm4AirInfusedStoneSize ' type='normal' scaleTo='base' />
@@ -734,7 +734,7 @@
                                 preferred biomes.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:1")'> <OreBlock block='Thaumcraft:blockCustomOre:1' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Plains'  />
                             <Setting name='CloudRadius' avg=':= 0.588 * _default_ * thm4AirInfusedStoneSize ' range=':= 0.588 * _default_ * thm4AirInfusedStoneSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.588 * _default_ * thm4AirInfusedStoneSize ' range=':= 0.588 * _default_ * thm4AirInfusedStoneSize ' type='normal' scaleTo='base' />
@@ -772,7 +772,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:1")'> <OreBlock block='Thaumcraft:blockCustomOre:1' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 5.000 * thm4AirInfusedStoneSize ' range=':= _default_ * thm4AirInfusedStoneSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 1.000 * thm4AirInfusedStoneFreq ' range=':= _default_ * thm4AirInfusedStoneFreq ' type='normal' scaleTo='base' />
@@ -805,7 +805,7 @@
                                 their  direction while mining.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:2")'> <OreBlock block='Thaumcraft:blockCustomOre:2' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * thm4FireInfusedStoneFreq ' range=':= 0.969 * _default_ * thm4FireInfusedStoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * thm4FireInfusedStoneSize ' range=':= 0 * _default_ * thm4FireInfusedStoneSize ' type='normal' />
@@ -831,7 +831,7 @@
                                 preferred biomes.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:2")'> <OreBlock block='Thaumcraft:blockCustomOre:2' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Desert'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * thm4FireInfusedStoneFreq ' range=':= 0.969 * _default_ * thm4FireInfusedStoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * thm4FireInfusedStoneSize ' range=':= 0 * _default_ * thm4FireInfusedStoneSize ' type='normal' />
@@ -876,7 +876,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:2")'> <OreBlock block='Thaumcraft:blockCustomOre:2' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.588 * _default_ * thm4FireInfusedStoneSize ' range=':= 0.588 * _default_ * thm4FireInfusedStoneSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.588 * _default_ * thm4FireInfusedStoneSize ' range=':= 0.588 * _default_ * thm4FireInfusedStoneSize ' type='normal' scaleTo='base' />
@@ -922,7 +922,7 @@
                                 preferred biomes.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:2")'> <OreBlock block='Thaumcraft:blockCustomOre:2' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Desert'  />
                             <Setting name='CloudRadius' avg=':= 0.588 * _default_ * thm4FireInfusedStoneSize ' range=':= 0.588 * _default_ * thm4FireInfusedStoneSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.588 * _default_ * thm4FireInfusedStoneSize ' range=':= 0.588 * _default_ * thm4FireInfusedStoneSize ' type='normal' scaleTo='base' />
@@ -960,7 +960,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:2")'> <OreBlock block='Thaumcraft:blockCustomOre:2' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 5.000 * thm4FireInfusedStoneSize ' range=':= _default_ * thm4FireInfusedStoneSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 1.000 * thm4FireInfusedStoneFreq ' range=':= _default_ * thm4FireInfusedStoneFreq ' type='normal' scaleTo='base' />
@@ -994,7 +994,7 @@
                                 their  direction while mining.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:3")'> <OreBlock block='Thaumcraft:blockCustomOre:3' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * thm4WaterInfusedStoneFreq ' range=':= 0.969 * _default_ * thm4WaterInfusedStoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * thm4WaterInfusedStoneSize ' range=':= 0 * _default_ * thm4WaterInfusedStoneSize ' type='normal' />
@@ -1020,7 +1020,7 @@
                                 preferred biomes.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:3")'> <OreBlock block='Thaumcraft:blockCustomOre:3' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Water'  />
                             <BiomeType name='Swamp'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * thm4WaterInfusedStoneFreq ' range=':= 0.969 * _default_ * thm4WaterInfusedStoneFreq ' type='normal' scaleTo='base' />
@@ -1066,7 +1066,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:3")'> <OreBlock block='Thaumcraft:blockCustomOre:3' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.588 * _default_ * thm4WaterInfusedStoneSize ' range=':= 0.588 * _default_ * thm4WaterInfusedStoneSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.588 * _default_ * thm4WaterInfusedStoneSize ' range=':= 0.588 * _default_ * thm4WaterInfusedStoneSize ' type='normal' scaleTo='base' />
@@ -1112,7 +1112,7 @@
                                 preferred biomes.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:3")'> <OreBlock block='Thaumcraft:blockCustomOre:3' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Water'  />
                             <BiomeType name='Swamp'  />
                             <Setting name='CloudRadius' avg=':= 0.588 * _default_ * thm4WaterInfusedStoneSize ' range=':= 0.588 * _default_ * thm4WaterInfusedStoneSize ' type='normal' />
@@ -1151,7 +1151,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:3")'> <OreBlock block='Thaumcraft:blockCustomOre:3' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 5.000 * thm4WaterInfusedStoneSize ' range=':= _default_ * thm4WaterInfusedStoneSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 1.000 * thm4WaterInfusedStoneFreq ' range=':= _default_ * thm4WaterInfusedStoneFreq ' type='normal' scaleTo='base' />
@@ -1185,7 +1185,7 @@
                                 their  direction while mining.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:4")'> <OreBlock block='Thaumcraft:blockCustomOre:4' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * thm4EarthInfusedStoneFreq ' range=':= 0.969 * _default_ * thm4EarthInfusedStoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * thm4EarthInfusedStoneSize ' range=':= 0 * _default_ * thm4EarthInfusedStoneSize ' type='normal' />
@@ -1211,7 +1211,7 @@
                                 preferred biomes.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:4")'> <OreBlock block='Thaumcraft:blockCustomOre:4' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Forest'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * thm4EarthInfusedStoneFreq ' range=':= 0.969 * _default_ * thm4EarthInfusedStoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * thm4EarthInfusedStoneSize ' range=':= 0 * _default_ * thm4EarthInfusedStoneSize ' type='normal' />
@@ -1256,7 +1256,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:4")'> <OreBlock block='Thaumcraft:blockCustomOre:4' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.588 * _default_ * thm4EarthInfusedStoneSize ' range=':= 0.588 * _default_ * thm4EarthInfusedStoneSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.588 * _default_ * thm4EarthInfusedStoneSize ' range=':= 0.588 * _default_ * thm4EarthInfusedStoneSize ' type='normal' scaleTo='base' />
@@ -1302,7 +1302,7 @@
                                 preferred biomes.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:4")'> <OreBlock block='Thaumcraft:blockCustomOre:4' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Forest'  />
                             <Setting name='CloudRadius' avg=':= 0.588 * _default_ * thm4EarthInfusedStoneSize ' range=':= 0.588 * _default_ * thm4EarthInfusedStoneSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.588 * _default_ * thm4EarthInfusedStoneSize ' range=':= 0.588 * _default_ * thm4EarthInfusedStoneSize ' type='normal' scaleTo='base' />
@@ -1340,7 +1340,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:4")'> <OreBlock block='Thaumcraft:blockCustomOre:4' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 5.000 * thm4EarthInfusedStoneSize ' range=':= _default_ * thm4EarthInfusedStoneSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 1.000 * thm4EarthInfusedStoneFreq ' range=':= _default_ * thm4EarthInfusedStoneFreq ' type='normal' scaleTo='base' />
@@ -1374,7 +1374,7 @@
                                 their  direction while mining.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:5")'> <OreBlock block='Thaumcraft:blockCustomOre:5' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * thm4OrderInfusedStoneFreq ' range=':= 0.969 * _default_ * thm4OrderInfusedStoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * thm4OrderInfusedStoneSize ' range=':= 0 * _default_ * thm4OrderInfusedStoneSize ' type='normal' />
@@ -1400,7 +1400,7 @@
                                 preferred biomes.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:5")'> <OreBlock block='Thaumcraft:blockCustomOre:5' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Mushroom'  />
                             <BiomeType name='Mountain'  />
                             <BiomeType name='Magical'  />
@@ -1447,7 +1447,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:5")'> <OreBlock block='Thaumcraft:blockCustomOre:5' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.588 * _default_ * thm4OrderInfusedStoneSize ' range=':= 0.588 * _default_ * thm4OrderInfusedStoneSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.588 * _default_ * thm4OrderInfusedStoneSize ' range=':= 0.588 * _default_ * thm4OrderInfusedStoneSize ' type='normal' scaleTo='base' />
@@ -1493,7 +1493,7 @@
                                 preferred biomes.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:5")'> <OreBlock block='Thaumcraft:blockCustomOre:5' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Mushroom'  />
                             <BiomeType name='Mountain'  />
                             <BiomeType name='Magical'  />
@@ -1533,7 +1533,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:5")'> <OreBlock block='Thaumcraft:blockCustomOre:5' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 5.000 * thm4OrderInfusedStoneSize ' range=':= _default_ * thm4OrderInfusedStoneSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 1.000 * thm4OrderInfusedStoneFreq ' range=':= _default_ * thm4OrderInfusedStoneFreq ' type='normal' scaleTo='base' />
@@ -1567,7 +1567,7 @@
                                 their  direction while mining.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:6")'> <OreBlock block='Thaumcraft:blockCustomOre:6' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * thm4EntropyInfusedStoneFreq ' range=':= 0.969 * _default_ * thm4EntropyInfusedStoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * thm4EntropyInfusedStoneSize ' range=':= 0 * _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
@@ -1593,7 +1593,7 @@
                                 preferred biomes.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:6")'> <OreBlock block='Thaumcraft:blockCustomOre:6' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Swamp'  />
                             <BiomeType name='Wasteland'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * thm4EntropyInfusedStoneFreq ' range=':= 0.969 * _default_ * thm4EntropyInfusedStoneFreq ' type='normal' scaleTo='base' />
@@ -1639,7 +1639,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:6")'> <OreBlock block='Thaumcraft:blockCustomOre:6' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.588 * _default_ * thm4EntropyInfusedStoneSize ' range=':= 0.588 * _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.588 * _default_ * thm4EntropyInfusedStoneSize ' range=':= 0.588 * _default_ * thm4EntropyInfusedStoneSize ' type='normal' scaleTo='base' />
@@ -1685,7 +1685,7 @@
                                 preferred biomes.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:6")'> <OreBlock block='Thaumcraft:blockCustomOre:6' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Swamp'  />
                             <BiomeType name='Wasteland'  />
                             <Setting name='CloudRadius' avg=':= 0.588 * _default_ * thm4EntropyInfusedStoneSize ' range=':= 0.588 * _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
@@ -1726,7 +1726,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:6")'> <OreBlock block='Thaumcraft:blockCustomOre:6' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 5.000 * thm4EntropyInfusedStoneSize ' range=':= _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 1.000 * thm4EntropyInfusedStoneFreq ' range=':= _default_ * thm4EntropyInfusedStoneFreq ' type='normal' scaleTo='base' />

--- a/src/main/resources/config/modules/ThermalFoundation.xml
+++ b/src/main/resources/config/modules/ThermalFoundation.xml
@@ -286,7 +286,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore")'> <OreBlock block='ThermalFoundation:Ore' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.583 * _default_ * thfoCopperFreq ' range=':= 1.583 * _default_ * thfoCopperFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.080 * _default_ * thfoCopperSize ' range=':= 1.080 * _default_ * thfoCopperSize ' type='normal' />
@@ -328,7 +328,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore")'> <OreBlock block='ThermalFoundation:Ore' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.177 * _default_ * thfoCopperSize ' range=':= 1.177 * _default_ * thfoCopperSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.177 * _default_ * thfoCopperSize ' range=':= 1.177 * _default_ * thfoCopperSize ' type='normal' scaleTo='base' />
@@ -380,7 +380,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore")'> <OreBlock block='ThermalFoundation:Ore' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 8.000 * thfoCopperSize ' range=':= _default_ * thfoCopperSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 10.000 * thfoCopperFreq ' range=':= _default_ * thfoCopperFreq ' type='normal' scaleTo='base' />
@@ -405,7 +405,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:1")'> <OreBlock block='ThermalFoundation:Ore:1' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.416 * _default_ * thfoTinFreq ' range=':= 1.416 * _default_ * thfoTinFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.060 * _default_ * thfoTinSize ' range=':= 1.060 * _default_ * thfoTinSize ' type='normal' />
@@ -447,7 +447,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:1")'> <OreBlock block='ThermalFoundation:Ore:1' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.113 * _default_ * thfoTinSize ' range=':= 1.113 * _default_ * thfoTinSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.113 * _default_ * thfoTinSize ' range=':= 1.113 * _default_ * thfoTinSize ' type='normal' scaleTo='base' />
@@ -499,7 +499,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:1")'> <OreBlock block='ThermalFoundation:Ore:1' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 8.000 * thfoTinSize ' range=':= _default_ * thfoTinSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 8.000 * thfoTinFreq ' range=':= _default_ * thfoTinFreq ' type='normal' scaleTo='base' />
@@ -524,7 +524,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:2")'> <OreBlock block='ThermalFoundation:Ore:2' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.821 * _default_ * thfoSilverFreq ' range=':= _default_ * thfoSilverFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.968 * _default_ * thfoSilverSize ' range=':= _default_ * thfoSilverSize ' type='normal' />
@@ -566,7 +566,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:2")'> <OreBlock block='ThermalFoundation:Ore:2' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.280 * _default_ * thfoSilverSize ' range=':= _default_ * thfoSilverSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.280 * _default_ * thfoSilverSize ' range=':= _default_ * thfoSilverSize ' type='normal' scaleTo='base' />
@@ -618,7 +618,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:2")'> <OreBlock block='ThermalFoundation:Ore:2' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 8 * thfoSilverSize ' range=':= _default_ * thfoSilverSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 6 * thfoSilverFreq ' range=':= _default_ * thfoSilverFreq ' type='normal' scaleTo='base' />
@@ -643,7 +643,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:3")'> <OreBlock block='ThermalFoundation:Ore:3' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.416 * _default_ * thfoLeadFreq ' range=':= 1.416 * _default_ * thfoLeadFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.060 * _default_ * thfoLeadSize ' range=':= 1.060 * _default_ * thfoLeadSize ' type='normal' />
@@ -685,7 +685,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:3")'> <OreBlock block='ThermalFoundation:Ore:3' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.113 * _default_ * thfoLeadSize ' range=':= 1.113 * _default_ * thfoLeadSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.113 * _default_ * thfoLeadSize ' range=':= 1.113 * _default_ * thfoLeadSize ' type='normal' scaleTo='base' />
@@ -737,7 +737,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:3")'> <OreBlock block='ThermalFoundation:Ore:3' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 8.000 * thfoLeadSize ' range=':= _default_ * thfoLeadSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 8.000 * thfoLeadFreq ' range=':= _default_ * thfoLeadFreq ' type='normal' scaleTo='base' />
@@ -762,7 +762,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:4")'> <OreBlock block='ThermalFoundation:Ore:4' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.613 * _default_ * thfoNickelFreq ' range=':= 0.613 * _default_ * thfoNickelFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * thfoNickelSize ' range=':= 0.922 * _default_ * thfoNickelSize ' type='normal' />
@@ -804,7 +804,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:4")'> <OreBlock block='ThermalFoundation:Ore:4' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.732 * _default_ * thfoNickelSize ' range=':= 0.732 * _default_ * thfoNickelSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.732 * _default_ * thfoNickelSize ' range=':= 0.732 * _default_ * thfoNickelSize ' type='normal' scaleTo='base' />
@@ -856,7 +856,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:4")'> <OreBlock block='ThermalFoundation:Ore:4' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * thfoNickelSize ' range=':= _default_ * thfoNickelSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 3.000 * thfoNickelFreq ' range=':= _default_ * thfoNickelFreq ' type='normal' scaleTo='base' />
@@ -881,7 +881,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:5")'> <OreBlock block='ThermalFoundation:Ore:5' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.306 * _default_ * thfoPlatinumFreq ' range=':= 0.306 * _default_ * thfoPlatinumFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.821 * _default_ * thfoPlatinumSize ' range=':= 0.821 * _default_ * thfoPlatinumSize ' type='normal' />
@@ -923,7 +923,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:5")'> <OreBlock block='ThermalFoundation:Ore:5' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.518 * _default_ * thfoPlatinumSize ' range=':= 0.518 * _default_ * thfoPlatinumSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.518 * _default_ * thfoPlatinumSize ' range=':= 0.518 * _default_ * thfoPlatinumSize ' type='normal' scaleTo='base' />
@@ -975,7 +975,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:5")'> <OreBlock block='ThermalFoundation:Ore:5' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.000 * thfoPlatinumSize ' range=':= _default_ * thfoPlatinumSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 1.000 * thfoPlatinumFreq ' range=':= _default_ * thfoPlatinumFreq ' type='normal' scaleTo='base' />

--- a/src/main/resources/config/modules/TinkersConstruct.xml
+++ b/src/main/resources/config/modules/TinkersConstruct.xml
@@ -473,7 +473,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:3")'> <OreBlock block='TConstruct:SearedBrick:3' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.708 * _default_ * ticoCopperFreq ' range=':= 0.708 * _default_ * ticoCopperFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.944 * _default_ * ticoCopperSize ' range=':= 0.944 * _default_ * ticoCopperSize ' type='normal' />
@@ -515,7 +515,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:3")'> <OreBlock block='TConstruct:SearedBrick:3' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.787 * _default_ * ticoCopperSize ' range=':= 0.787 * _default_ * ticoCopperSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.787 * _default_ * ticoCopperSize ' range=':= 0.787 * _default_ * ticoCopperSize ' type='normal' scaleTo='base' />
@@ -567,7 +567,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:3")'> <OreBlock block='TConstruct:SearedBrick:3' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 8.000 * ticoCopperSize ' range=':= _default_ * ticoCopperSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 2.000 * ticoCopperFreq ' range=':= _default_ * ticoCopperFreq ' type='normal' scaleTo='base' />
@@ -592,7 +592,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:4")'> <OreBlock block='TConstruct:SearedBrick:4' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.708 * _default_ * ticoTinFreq ' range=':= 0.708 * _default_ * ticoTinFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.944 * _default_ * ticoTinSize ' range=':= 0.944 * _default_ * ticoTinSize ' type='normal' />
@@ -634,7 +634,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:4")'> <OreBlock block='TConstruct:SearedBrick:4' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.787 * _default_ * ticoTinSize ' range=':= 0.787 * _default_ * ticoTinSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.787 * _default_ * ticoTinSize ' range=':= 0.787 * _default_ * ticoTinSize ' type='normal' scaleTo='base' />
@@ -686,7 +686,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:4")'> <OreBlock block='TConstruct:SearedBrick:4' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 8.000 * ticoTinSize ' range=':= _default_ * ticoTinSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 2.000 * ticoTinFreq ' range=':= _default_ * ticoTinFreq ' type='normal' scaleTo='base' />
@@ -711,7 +711,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:5")'> <OreBlock block='TConstruct:SearedBrick:5' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.751 * _default_ * ticoAluminumFreq ' range=':= 0.751 * _default_ * ticoAluminumFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.953 * _default_ * ticoAluminumSize ' range=':= 0.953 * _default_ * ticoAluminumSize ' type='normal' />
@@ -753,7 +753,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:5")'> <OreBlock block='TConstruct:SearedBrick:5' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.810 * _default_ * ticoAluminumSize ' range=':= 0.810 * _default_ * ticoAluminumSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.810 * _default_ * ticoAluminumSize ' range=':= 0.810 * _default_ * ticoAluminumSize ' type='normal' scaleTo='base' />
@@ -805,7 +805,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:5")'> <OreBlock block='TConstruct:SearedBrick:5' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 6.000 * ticoAluminumSize ' range=':= _default_ * ticoAluminumSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 3.000 * ticoAluminumFreq ' range=':= _default_ * ticoAluminumFreq ' type='normal' scaleTo='base' />
@@ -830,7 +830,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre")'> <OreBlock block='TConstruct:GravelOre' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("gravel")'> <ReplacesOre block='gravel' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.238 * _default_ * ticoIronGravelFreq ' range=':= 2.238 * _default_ * ticoIronGravelFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.144 * _default_ * ticoIronGravelSize ' range=':= 1.144 * _default_ * ticoIronGravelSize ' type='normal' />
@@ -872,7 +872,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre")'> <OreBlock block='TConstruct:GravelOre' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("gravel")'> <ReplacesOre block='gravel' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.399 * _default_ * ticoIronGravelSize ' range=':= 1.399 * _default_ * ticoIronGravelSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.399 * _default_ * ticoIronGravelSize ' range=':= 1.399 * _default_ * ticoIronGravelSize ' type='normal' scaleTo='base' />
@@ -924,7 +924,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre")'> <OreBlock block='TConstruct:GravelOre' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("gravel")'> <ReplacesOre block='gravel' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 8.000 * ticoIronGravelSize ' range=':= _default_ * ticoIronGravelSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 20.000 * ticoIronGravelFreq ' range=':= _default_ * ticoIronGravelFreq ' type='normal' scaleTo='base' />
@@ -949,7 +949,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:1")'> <OreBlock block='TConstruct:GravelOre:1' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("gravel")'> <ReplacesOre block='gravel' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.708 * _default_ * ticoGoldGravelFreq ' range=':= 0.708 * _default_ * ticoGoldGravelFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.944 * _default_ * ticoGoldGravelSize ' range=':= 0.944 * _default_ * ticoGoldGravelSize ' type='normal' />
@@ -991,7 +991,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:1")'> <OreBlock block='TConstruct:GravelOre:1' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("gravel")'> <ReplacesOre block='gravel' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.787 * _default_ * ticoGoldGravelSize ' range=':= 0.787 * _default_ * ticoGoldGravelSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.787 * _default_ * ticoGoldGravelSize ' range=':= 0.787 * _default_ * ticoGoldGravelSize ' type='normal' scaleTo='base' />
@@ -1043,7 +1043,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:1")'> <OreBlock block='TConstruct:GravelOre:1' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("gravel")'> <ReplacesOre block='gravel' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 8.000 * ticoGoldGravelSize ' range=':= _default_ * ticoGoldGravelSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 2.000 * ticoGoldGravelFreq ' range=':= _default_ * ticoGoldGravelFreq ' type='normal' scaleTo='base' />
@@ -1068,7 +1068,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:2")'> <OreBlock block='TConstruct:GravelOre:2' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("gravel")'> <ReplacesOre block='gravel' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.583 * _default_ * ticoCopperGravelFreq ' range=':= 1.583 * _default_ * ticoCopperGravelFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.080 * _default_ * ticoCopperGravelSize ' range=':= 1.080 * _default_ * ticoCopperGravelSize ' type='normal' />
@@ -1111,7 +1111,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:2")'> <OreBlock block='TConstruct:GravelOre:2' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("gravel")'> <ReplacesOre block='gravel' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.177 * _default_ * ticoCopperGravelSize ' range=':= 1.177 * _default_ * ticoCopperGravelSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.177 * _default_ * ticoCopperGravelSize ' range=':= 1.177 * _default_ * ticoCopperGravelSize ' type='normal' scaleTo='base' />
@@ -1163,7 +1163,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:2")'> <OreBlock block='TConstruct:GravelOre:2' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("gravel")'> <ReplacesOre block='gravel' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 8.000 * ticoCopperGravelSize ' range=':= _default_ * ticoCopperGravelSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 10.000 * ticoCopperGravelFreq ' range=':= _default_ * ticoCopperGravelFreq ' type='normal' scaleTo='base' />
@@ -1188,7 +1188,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:3")'> <OreBlock block='TConstruct:GravelOre:3' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("gravel")'> <ReplacesOre block='gravel' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.416 * _default_ * ticoTinGravelFreq ' range=':= 1.416 * _default_ * ticoTinGravelFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.060 * _default_ * ticoTinGravelSize ' range=':= 1.060 * _default_ * ticoTinGravelSize ' type='normal' />
@@ -1230,7 +1230,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:3")'> <OreBlock block='TConstruct:GravelOre:3' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("gravel")'> <ReplacesOre block='gravel' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.113 * _default_ * ticoTinGravelSize ' range=':= 1.113 * _default_ * ticoTinGravelSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.113 * _default_ * ticoTinGravelSize ' range=':= 1.113 * _default_ * ticoTinGravelSize ' type='normal' scaleTo='base' />
@@ -1282,7 +1282,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:3")'> <OreBlock block='TConstruct:GravelOre:3' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("gravel")'> <ReplacesOre block='gravel' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 8.000 * ticoTinGravelSize ' range=':= _default_ * ticoTinGravelSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 8.000 * ticoTinGravelFreq ' range=':= _default_ * ticoTinGravelFreq ' type='normal' scaleTo='base' />
@@ -1307,7 +1307,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:4")'> <OreBlock block='TConstruct:GravelOre:4' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("gravel")'> <ReplacesOre block='gravel' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.751 * _default_ * ticoAluminumGravelFreq ' range=':= 0.751 * _default_ * ticoAluminumGravelFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.953 * _default_ * ticoAluminumGravelSize ' range=':= 0.953 * _default_ * ticoAluminumGravelSize ' type='normal' />
@@ -1350,7 +1350,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:4")'> <OreBlock block='TConstruct:GravelOre:4' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("gravel")'> <ReplacesOre block='gravel' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.810 * _default_ * ticoAluminumGravelSize ' range=':= 0.810 * _default_ * ticoAluminumGravelSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.810 * _default_ * ticoAluminumGravelSize ' range=':= 0.810 * _default_ * ticoAluminumGravelSize ' type='normal' scaleTo='base' />
@@ -1402,7 +1402,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:4")'> <OreBlock block='TConstruct:GravelOre:4' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("gravel")'> <ReplacesOre block='gravel' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 6.000 * ticoAluminumGravelSize ' range=':= _default_ * ticoAluminumGravelSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 3.000 * ticoAluminumGravelFreq ' range=':= _default_ * ticoAluminumGravelFreq ' type='normal' scaleTo='base' />
@@ -1718,7 +1718,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:5")'> <OreBlock block='TConstruct:GravelOre:5' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("gravel")'> <ReplacesOre block='gravel' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.867 * _default_ * ticoNetherCobaltGravelFreq ' range=':= 0.867 * _default_ * ticoNetherCobaltGravelFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.976 * _default_ * ticoNetherCobaltGravelSize ' range=':= 0.976 * _default_ * ticoNetherCobaltGravelSize ' type='normal' />
@@ -1761,7 +1761,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:5")'> <OreBlock block='TConstruct:GravelOre:5' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("gravel")'> <ReplacesOre block='gravel' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.871 * _default_ * ticoNetherCobaltGravelSize ' range=':= 0.871 * _default_ * ticoNetherCobaltGravelSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.871 * _default_ * ticoNetherCobaltGravelSize ' range=':= 0.871 * _default_ * ticoNetherCobaltGravelSize ' type='normal' scaleTo='base' />
@@ -1814,7 +1814,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:5")'> <OreBlock block='TConstruct:GravelOre:5' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("gravel")'> <ReplacesOre block='gravel' weight='1.0' /> </IfCondition>
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.000 * ticoNetherCobaltGravelSize ' range=':= _default_ * ticoNetherCobaltGravelSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 8.000 * ticoNetherCobaltGravelFreq ' range=':= _default_ * ticoNetherCobaltGravelFreq ' type='normal' scaleTo='base' />

--- a/src/main/resources/config/modules/TinkersSteelworks.xml
+++ b/src/main/resources/config/modules/TinkersSteelworks.xml
@@ -97,7 +97,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("TSteelworks:Limestone")'> <OreBlock block='TSteelworks:Limestone' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 32.000 * tiswLimestoneSize ' range=':= _default_ * tiswLimestoneSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 2.000 * tiswLimestoneFreq ' range=':= _default_ * tiswLimestoneFreq ' type='normal' scaleTo='base' />

--- a/src/main/resources/config/modules/VanillaMinecraft.xml
+++ b/src/main/resources/config/modules/VanillaMinecraft.xml
@@ -387,9 +387,9 @@
                         StandardGen distributions.
                     </Description>
                     <IfCondition condition=':= ?blockExists("minecraft:clay")'> <OreBlock block='minecraft:clay' weight='1.0' /> </IfCondition>
-                    <IfCondition condition=':= ?blockExists("minecraft:sand")'> <Replaces block='minecraft:sand' weight='1.0' /> </IfCondition>
-                    <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
-                    <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                    <IfCondition condition=':= ?blockExists("sand")'> <ReplacesOre block='sand' weight='1.0' /> </IfCondition>
+                    <IfCondition condition=':= ?blockExists("gravel")'> <ReplacesOre block='gravel' weight='1.0' /> </IfCondition>
+                    <IfCondition condition=':= ?blockExists("dirt")'> <ReplacesOre block='dirt' weight='1.0' /> </IfCondition>
                     <Biome name='.*'  />
                     <Biome name='Ocean'  weight='-1' />
                     <Biome name='Desert'  weight='-1' />
@@ -418,9 +418,9 @@
                         biomes.
                     </Description>
                     <IfCondition condition=':= ?blockExists("minecraft:clay")'> <OreBlock block='minecraft:clay' weight='1.0' /> </IfCondition>
-                    <IfCondition condition=':= ?blockExists("minecraft:sand")'> <Replaces block='minecraft:sand' weight='1.0' /> </IfCondition>
-                    <IfCondition condition=':= ?blockExists("minecraft:gravel")'> <Replaces block='minecraft:gravel' weight='1.0' /> </IfCondition>
-                    <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
+                    <IfCondition condition=':= ?blockExists("sand")'> <ReplacesOre block='sand' weight='1.0' /> </IfCondition>
+                    <IfCondition condition=':= ?blockExists("gravel")'> <ReplacesOre block='gravel' weight='1.0' /> </IfCondition>
+                    <IfCondition condition=':= ?blockExists("dirt")'> <ReplacesOre block='dirt' weight='1.0' /> </IfCondition>
                     <BiomeType name='Swamp'  />
                     <BiomeType name='Beach'  />
                     <BiomeType name='River'  />
@@ -469,7 +469,7 @@
                         mining.
                     </Description>
                     <IfCondition condition=':= ?blockExists("minecraft:coal_ore")'> <OreBlock block='minecraft:coal_ore' weight='1.0' /> </IfCondition>
-                    <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                    <ReplacesOre block='stone' weight='1.0' />
                     <Biome name='.*'  />
                     <Setting name='MotherlodeFrequency' avg=':= 7.748 * _default_ * vnlaCoalFreq ' range=':= 7.748 * _default_ * vnlaCoalFreq ' type='normal' scaleTo='base' />
                     <Setting name='MotherlodeSize' avg=':= 0 * _default_ * vnlaCoalSize ' range=':= 0 * _default_ * vnlaCoalSize ' type='normal' />
@@ -509,7 +509,7 @@
                         time actually  mining the ore.
                     </Description>
                     <IfCondition condition=':= ?blockExists("minecraft:coal_ore")'> <OreBlock block='minecraft:coal_ore' weight='1.0' /> </IfCondition>
-                    <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                    <ReplacesOre block='stone' weight='1.0' />
                     <Biome name='.*'  />
                     <Setting name='CloudRadius' avg=':= 1.664 * _default_ * vnlaCoalSize ' range=':= 1.664 * _default_ * vnlaCoalSize ' type='normal' />
                     <Setting name='CloudThickness' avg=':= 1.664 * _default_ * vnlaCoalSize ' range=':= 1.664 * _default_ * vnlaCoalSize ' type='normal' scaleTo='base' />
@@ -558,7 +558,7 @@
                         distributions.
                     </Description>
                     <IfCondition condition=':= ?blockExists("minecraft:coal_ore")'> <OreBlock block='minecraft:coal_ore' weight='1.0' /> </IfCondition>
-                    <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                    <ReplacesOre block='stone' weight='1.0' />
                     <Biome name='.*'  />
                     <Setting name='Size' avg=':= 16.000 * vnlaCoalSize ' range=':= _default_ * vnlaCoalSize ' type='normal' />
                     <Setting name='Frequency' avg=':= 20.000 * vnlaCoalFreq ' range=':= _default_ * vnlaCoalFreq ' type='normal' scaleTo='base' />
@@ -587,7 +587,7 @@
                         time actually  mining the ore.
                     </Description>
                     <IfCondition condition=':= ?blockExists("minecraft:coal_ore")'> <OreBlock block='minecraft:coal_ore' weight='1.0' /> </IfCondition>
-                    <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                    <ReplacesOre block='stone' weight='1.0' />
                     <Biome name='.*'  />
                     <Setting name='CloudRadius' avg=':= 1.664 * _default_ * vnlaCoalSize ' range=':= 1.664 * _default_ * vnlaCoalSize ' type='normal' />
                     <Setting name='CloudThickness' avg=':= 1.664 * _default_ * vnlaCoalSize ' range=':= 1.664 * _default_ * vnlaCoalSize ' type='normal' scaleTo='base' />
@@ -640,7 +640,7 @@
                         horizontal veins each.
                     </Description>
                     <IfCondition condition=':= ?blockExists("minecraft:iron_ore")'> <OreBlock block='minecraft:iron_ore' weight='1.0' /> </IfCondition>
-                    <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                    <ReplacesOre block='stone' weight='1.0' />
                     <Biome name='.*'  />
                     <Setting name='MotherlodeFrequency' avg=':= 2.238 * _default_ * vnlaIronFreq ' range=':= 2.238 * _default_ * vnlaIronFreq ' type='normal' scaleTo='base' />
                     <Setting name='MotherlodeSize' avg=':= 1.144 * _default_ * vnlaIronSize ' range=':= 1.144 * _default_ * vnlaIronSize ' type='normal' />
@@ -672,7 +672,7 @@
                         distributions.
                     </Description>
                     <IfCondition condition=':= ?blockExists("minecraft:iron_ore")'> <OreBlock block='minecraft:iron_ore' weight='1.0' /> </IfCondition>
-                    <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                    <ReplacesOre block='stone' weight='1.0' />
                     <Biome name='.*'  />
                     <Setting name='Size' avg=':= 8.000 * vnlaIronSize ' range=':= _default_ * vnlaIronSize ' type='normal' />
                     <Setting name='Frequency' avg=':= 20.000 * vnlaIronFreq ' range=':= _default_ * vnlaIronFreq ' type='normal' scaleTo='base' />
@@ -701,7 +701,7 @@
                         time actually  mining the ore.
                     </Description>
                     <IfCondition condition=':= ?blockExists("minecraft:iron_ore")'> <OreBlock block='minecraft:iron_ore' weight='1.0' /> </IfCondition>
-                    <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                    <ReplacesOre block='stone' weight='1.0' />
                     <Biome name='.*'  />
                     <Setting name='CloudRadius' avg=':= 1.399 * _default_ * vnlaIronSize ' range=':= 1.399 * _default_ * vnlaIronSize ' type='normal' />
                     <Setting name='CloudThickness' avg=':= 1.399 * _default_ * vnlaIronSize ' range=':= 1.399 * _default_ * vnlaIronSize ' type='normal' scaleTo='base' />
@@ -754,7 +754,7 @@
                         horizontal veins each.
                     </Description>
                     <IfCondition condition=':= ?blockExists("minecraft:gold_ore")'> <OreBlock block='minecraft:gold_ore' weight='1.0' /> </IfCondition>
-                    <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                    <ReplacesOre block='stone' weight='1.0' />
                     <Biome name='.*'  />
                     <Setting name='MotherlodeFrequency' avg=':= 0.708 * _default_ * vnlaGoldFreq ' range=':= 0.708 * _default_ * vnlaGoldFreq ' type='normal' scaleTo='base' />
                     <Setting name='MotherlodeSize' avg=':= 0.944 * _default_ * vnlaGoldSize ' range=':= 0.944 * _default_ * vnlaGoldSize ' type='normal' />
@@ -786,7 +786,7 @@
                         distributions.
                     </Description>
                     <IfCondition condition=':= ?blockExists("minecraft:gold_ore")'> <OreBlock block='minecraft:gold_ore' weight='1.0' /> </IfCondition>
-                    <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                    <ReplacesOre block='stone' weight='1.0' />
                     <Biome name='.*'  />
                     <Setting name='Size' avg=':= 8.000 * vnlaGoldSize ' range=':= _default_ * vnlaGoldSize ' type='normal' />
                     <Setting name='Frequency' avg=':= 2.000 * vnlaGoldFreq ' range=':= _default_ * vnlaGoldFreq ' type='normal' scaleTo='base' />
@@ -815,7 +815,7 @@
                         time actually  mining the ore.
                     </Description>
                     <IfCondition condition=':= ?blockExists("minecraft:gold_ore")'> <OreBlock block='minecraft:gold_ore' weight='1.0' /> </IfCondition>
-                    <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                    <ReplacesOre block='stone' weight='1.0' />
                     <Biome name='.*'  />
                     <Setting name='CloudRadius' avg=':= 0.787 * _default_ * vnlaGoldSize ' range=':= 0.787 * _default_ * vnlaGoldSize ' type='normal' />
                     <Setting name='CloudThickness' avg=':= 0.787 * _default_ * vnlaGoldSize ' range=':= 0.787 * _default_ * vnlaGoldSize ' type='normal' scaleTo='base' />
@@ -868,7 +868,7 @@
                         motherlodes.
                     </Description>
                     <IfCondition condition=':= ?blockExists("minecraft:redstone_ore")'> <OreBlock block='minecraft:redstone_ore' weight='1.0' /> </IfCondition>
-                    <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                    <ReplacesOre block='stone' weight='1.0' />
                     <Biome name='.*'  />
                     <Setting name='MotherlodeFrequency' avg=':= 2.406 * _default_ * vnlaRedstoneFreq ' range=':= 2.406 * _default_ * vnlaRedstoneFreq ' type='normal' scaleTo='base' />
                     <Setting name='MotherlodeSize' avg=':= 0 * _default_ * vnlaRedstoneSize ' range=':= 0 * _default_ * vnlaRedstoneSize ' type='normal' />
@@ -894,7 +894,7 @@
                         biomes.
                     </Description>
                     <IfCondition condition=':= ?blockExists("minecraft:redstone_ore")'> <OreBlock block='minecraft:redstone_ore' weight='1.0' /> </IfCondition>
-                    <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                    <ReplacesOre block='stone' weight='1.0' />
                     <BiomeType name='Desert'  />
                     <Setting name='MotherlodeFrequency' avg=':= 2.406 * _default_ * vnlaRedstoneFreq ' range=':= 2.406 * _default_ * vnlaRedstoneFreq ' type='normal' scaleTo='base' />
                     <Setting name='MotherlodeSize' avg=':= 0 * _default_ * vnlaRedstoneSize ' range=':= 0 * _default_ * vnlaRedstoneSize ' type='normal' />
@@ -928,7 +928,7 @@
                         distributions.
                     </Description>
                     <IfCondition condition=':= ?blockExists("minecraft:redstone_ore")'> <OreBlock block='minecraft:redstone_ore' weight='1.0' /> </IfCondition>
-                    <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                    <ReplacesOre block='stone' weight='1.0' />
                     <Biome name='.*'  />
                     <Setting name='Size' avg=':= 7.000 * vnlaRedstoneSize ' range=':= _default_ * vnlaRedstoneSize ' type='normal' />
                     <Setting name='Frequency' avg=':= 8.000 * vnlaRedstoneFreq ' range=':= _default_ * vnlaRedstoneFreq ' type='normal' scaleTo='base' />
@@ -957,7 +957,7 @@
                         time actually  mining the ore.
                     </Description>
                     <IfCondition condition=':= ?blockExists("minecraft:redstone_ore")'> <OreBlock block='minecraft:redstone_ore' weight='1.0' /> </IfCondition>
-                    <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                    <ReplacesOre block='stone' weight='1.0' />
                     <Biome name='.*'  />
                     <Setting name='CloudRadius' avg=':= 1.076 * _default_ * vnlaRedstoneSize ' range=':= 1.076 * _default_ * vnlaRedstoneSize ' type='normal' />
                     <Setting name='CloudThickness' avg=':= 1.076 * _default_ * vnlaRedstoneSize ' range=':= 1.076 * _default_ * vnlaRedstoneSize ' type='normal' scaleTo='base' />
@@ -1000,7 +1000,7 @@
                         biomes.
                     </Description>
                     <IfCondition condition=':= ?blockExists("minecraft:redstone_ore")'> <OreBlock block='minecraft:redstone_ore' weight='1.0' /> </IfCondition>
-                    <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                    <ReplacesOre block='stone' weight='1.0' />
                     <BiomeType name='Desert'  />
                     <Setting name='CloudRadius' avg=':= 1.076 * _default_ * vnlaRedstoneSize ' range=':= 1.076 * _default_ * vnlaRedstoneSize ' type='normal' />
                     <Setting name='CloudThickness' avg=':= 1.076 * _default_ * vnlaRedstoneSize ' range=':= 1.076 * _default_ * vnlaRedstoneSize ' type='normal' scaleTo='base' />
@@ -1042,7 +1042,7 @@
                         near the bottom of the map.
                     </Description>
                     <IfCondition condition=':= ?blockExists("minecraft:diamond_ore")'> <OreBlock block='minecraft:diamond_ore' weight='1.0' /> </IfCondition>
-                    <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                    <ReplacesOre block='stone' weight='1.0' />
                     <Biome name='.*'  />
                     <Setting name='MotherlodeFrequency' avg=':= 0.714 * _default_ * vnlaDiamondFreq ' range=':= 0.714 * _default_ * vnlaDiamondFreq ' type='normal' scaleTo='base' />
                     <Setting name='MotherlodeSize' avg=':= 0 * _default_ * vnlaDiamondSize ' range=':= 0 * _default_ * vnlaDiamondSize ' type='normal' />
@@ -1064,7 +1064,7 @@
                 <!-- Configuring contained material. -->
                 <Veins name='vnlaDiamondVeinsPipe'  inherits='vnlaDiamondVeins' seed='0x197B' drawWireframe='true' wireframeColor='0x608BF4E3' drawBoundBox='false' boundBoxColor='0x608BF4E3'>
                     <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
-                    <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                    <ReplacesOre block='stone' weight='1.0' />
                     <IfCondition condition=':= ?blockExists("minecraft:diamond_ore")'> <Replaces block='minecraft:diamond_ore' weight='1.0' /> </IfCondition>
                     <Setting name='MotherlodeSize' avg=':= 0 * _default_ * vnlaDiamondSize  * 0.5 ' range=':= 0 * _default_ * vnlaDiamondSize  * 0.5 ' type='normal' />
                     <Setting name='SegmentRadius' avg=':= 0.919 * _default_ * vnlaDiamondSize  * 0.5 ' range=':= 0.919 * _default_ * vnlaDiamondSize  * 0.5 ' type='normal' />
@@ -1084,7 +1084,7 @@
                         distributions.
                     </Description>
                     <IfCondition condition=':= ?blockExists("minecraft:diamond_ore")'> <OreBlock block='minecraft:diamond_ore' weight='1.0' /> </IfCondition>
-                    <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                    <ReplacesOre block='stone' weight='1.0' />
                     <Biome name='.*'  />
                     <Setting name='Size' avg=':= 7.000 * vnlaDiamondSize ' range=':= _default_ * vnlaDiamondSize ' type='normal' />
                     <Setting name='Frequency' avg=':= 1.000 * vnlaDiamondFreq ' range=':= _default_ * vnlaDiamondFreq ' type='normal' scaleTo='base' />
@@ -1113,7 +1113,7 @@
                         time actually  mining the ore.
                     </Description>
                     <IfCondition condition=':= ?blockExists("minecraft:diamond_ore")'> <OreBlock block='minecraft:diamond_ore' weight='1.0' /> </IfCondition>
-                    <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                    <ReplacesOre block='stone' weight='1.0' />
                     <Biome name='.*'  />
                     <Setting name='CloudRadius' avg=':= 0.640 * _default_ * vnlaDiamondSize ' range=':= 0.640 * _default_ * vnlaDiamondSize ' type='normal' />
                     <Setting name='CloudThickness' avg=':= 0.640 * _default_ * vnlaDiamondSize ' range=':= 0.640 * _default_ * vnlaDiamondSize ' type='normal' scaleTo='base' />
@@ -1166,7 +1166,7 @@
                         motherlodes.
                     </Description>
                     <IfCondition condition=':= ?blockExists("minecraft:lapis_ore")'> <OreBlock block='minecraft:lapis_ore' weight='1.0' /> </IfCondition>
-                    <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                    <ReplacesOre block='stone' weight='1.0' />
                     <Biome name='.*'  />
                     <Setting name='MotherlodeFrequency' avg=':= 0.787 * _default_ * vnlaLapisLazuliFreq ' range=':= 0.787 * _default_ * vnlaLapisLazuliFreq ' type='normal' scaleTo='base' />
                     <Setting name='MotherlodeSize' avg=':= 0 * _default_ * vnlaLapisLazuliSize ' range=':= 0 * _default_ * vnlaLapisLazuliSize ' type='normal' />
@@ -1192,7 +1192,7 @@
                         biomes.
                     </Description>
                     <IfCondition condition=':= ?blockExists("minecraft:lapis_ore")'> <OreBlock block='minecraft:lapis_ore' weight='1.0' /> </IfCondition>
-                    <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                    <ReplacesOre block='stone' weight='1.0' />
                     <BiomeType name='Ocean'  />
                     <Setting name='MotherlodeFrequency' avg=':= 0.787 * _default_ * vnlaLapisLazuliFreq ' range=':= 0.787 * _default_ * vnlaLapisLazuliFreq ' type='normal' scaleTo='base' />
                     <Setting name='MotherlodeSize' avg=':= 0 * _default_ * vnlaLapisLazuliSize ' range=':= 0 * _default_ * vnlaLapisLazuliSize ' type='normal' />
@@ -1226,7 +1226,7 @@
                         distributions.
                     </Description>
                     <IfCondition condition=':= ?blockExists("minecraft:lapis_ore")'> <OreBlock block='minecraft:lapis_ore' weight='1.0' /> </IfCondition>
-                    <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                    <ReplacesOre block='stone' weight='1.0' />
                     <Biome name='.*'  />
                     <Setting name='Size' avg=':= 6.000 * vnlaLapisLazuliSize ' range=':= _default_ * vnlaLapisLazuliSize ' type='normal' />
                     <Setting name='Frequency' avg=':= 1.000 * vnlaLapisLazuliFreq ' range=':= _default_ * vnlaLapisLazuliFreq ' type='normal' scaleTo='base' />
@@ -1255,7 +1255,7 @@
                         time actually  mining the ore.
                     </Description>
                     <IfCondition condition=':= ?blockExists("minecraft:lapis_ore")'> <OreBlock block='minecraft:lapis_ore' weight='1.0' /> </IfCondition>
-                    <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                    <ReplacesOre block='stone' weight='1.0' />
                     <Biome name='.*'  />
                     <Setting name='CloudRadius' avg=':= 0.616 * _default_ * vnlaLapisLazuliSize ' range=':= 0.616 * _default_ * vnlaLapisLazuliSize ' type='normal' />
                     <Setting name='CloudThickness' avg=':= 0.616 * _default_ * vnlaLapisLazuliSize ' range=':= 0.616 * _default_ * vnlaLapisLazuliSize ' type='normal' scaleTo='base' />
@@ -1298,7 +1298,7 @@
                         biomes.
                     </Description>
                     <IfCondition condition=':= ?blockExists("minecraft:lapis_ore")'> <OreBlock block='minecraft:lapis_ore' weight='1.0' /> </IfCondition>
-                    <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                    <ReplacesOre block='stone' weight='1.0' />
                     <BiomeType name='Ocean'  />
                     <Setting name='CloudRadius' avg=':= 0.616 * _default_ * vnlaLapisLazuliSize ' range=':= 0.616 * _default_ * vnlaLapisLazuliSize ' type='normal' />
                     <Setting name='CloudThickness' avg=':= 0.616 * _default_ * vnlaLapisLazuliSize ' range=':= 0.616 * _default_ * vnlaLapisLazuliSize ' type='normal' scaleTo='base' />
@@ -1340,7 +1340,7 @@
                         near the bottom of the map.
                     </Description>
                     <IfCondition condition=':= ?blockExists("minecraft:emerald_ore")'> <OreBlock block='minecraft:emerald_ore' weight='1.0' /> </IfCondition>
-                    <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                    <ReplacesOre block='stone' weight='1.0' />
                     <BiomeType name='Mountain'  />
                     <Setting name='MotherlodeFrequency' avg=':= 1.145 * _default_ * vnlaEmeraldFreq ' range=':= 1.145 * _default_ * vnlaEmeraldFreq ' type='normal' scaleTo='base' />
                     <Setting name='MotherlodeSize' avg=':= 0 * _default_ * vnlaEmeraldSize ' range=':= 0 * _default_ * vnlaEmeraldSize ' type='normal' />
@@ -1362,7 +1362,7 @@
                 <!-- Configuring contained material. -->
                 <Veins name='vnlaEmeraldVeinsPipe'  inherits='vnlaEmeraldVeins' seed='0x54B3' drawWireframe='true' wireframeColor='0x606CE391' drawBoundBox='false' boundBoxColor='0x606CE391'>
                     <IfCondition condition=':= ?blockExists("minecraft:monster_egg")'> <OreBlock block='minecraft:monster_egg' weight='1.0' /> </IfCondition>
-                    <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                    <ReplacesOre block='stone' weight='1.0' />
                     <IfCondition condition=':= ?blockExists("minecraft:emerald_ore")'> <Replaces block='minecraft:emerald_ore' weight='1.0' /> </IfCondition>
                     <Setting name='MotherlodeSize' avg=':= 0 * _default_ * vnlaEmeraldSize  * 0.5 ' range=':= 0 * _default_ * vnlaEmeraldSize  * 0.5 ' type='normal' />
                     <Setting name='SegmentRadius' avg=':= 1.035 * _default_ * vnlaEmeraldSize  * 0.5 ' range=':= 1.035 * _default_ * vnlaEmeraldSize  * 0.5 ' type='normal' />
@@ -1382,7 +1382,7 @@
                         distributions.
                     </Description>
                     <IfCondition condition=':= ?blockExists("minecraft:emerald_ore")'> <OreBlock block='minecraft:emerald_ore' weight='1.0' /> </IfCondition>
-                    <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                    <ReplacesOre block='stone' weight='1.0' />
                     <BiomeType name='Mountain'  />
                     <Setting name='Size' avg=':= 2.000 * vnlaEmeraldSize ' range=':= _default_ * vnlaEmeraldSize ' type='normal' />
                     <Setting name='Frequency' avg=':= 9.000 * vnlaEmeraldFreq ' range=':= _default_ * vnlaEmeraldFreq ' type='normal' scaleTo='base' />
@@ -1411,7 +1411,7 @@
                         time actually  mining the ore.
                     </Description>
                     <IfCondition condition=':= ?blockExists("minecraft:emerald_ore")'> <OreBlock block='minecraft:emerald_ore' weight='1.0' /> </IfCondition>
-                    <IfCondition condition=':= ?blockExists("minecraft:stone")'> <Replaces block='minecraft:stone' weight='1.0' /> </IfCondition>
+                    <ReplacesOre block='stone' weight='1.0' />
                     <BiomeType name='Mountain'  />
                     <Setting name='CloudRadius' avg=':= 0.810 * _default_ * vnlaEmeraldSize ' range=':= 0.810 * _default_ * vnlaEmeraldSize ' type='normal' />
                     <Setting name='CloudThickness' avg=':= 0.810 * _default_ * vnlaEmeraldSize ' range=':= 0.810 * _default_ * vnlaEmeraldSize ' type='normal' scaleTo='base' />


### PR DESCRIPTION
In order to resolve issues with stone mods like Underground Biomes, all generated oregens now make use of the "stone," "dirt," "gravel," and "sand" ore dictionary entries.  In this way, the ore will spawn, regardless of the type of stone, sand, gravel, or dirt is being used in a world.  Thankfully, grass and mycelium are not oredicted to dirt, so hint veins and clay won't become painfully obvious.