### PR TITLE
Removed block check from replacement commands.

### DIFF
--- a/src/main/resources/config/modules/AppliedEnergistics.xml
+++ b/src/main/resources/config/modules/AppliedEnergistics.xml
@@ -7,7 +7,7 @@
 <!-- A high-end matter-to-data conversion mod that requires both
      certus quartz and nether quartz to do its thing.  Note, charged
      quartz is mixed in with the non-charged quartz at a ratio of
-     1:10. -->
+     1:10.  Configuration by Reteo. -->
 
 
 
@@ -92,8 +92,8 @@
                             must be large  enough to catch all ore
                             clusters (>=  32).
                         </Comment>
-                        <IfCondition condition=':= ?blockExists("appliedenergistics2:tile.OreQuartz")'> <Replaces block='appliedenergistics2:tile.OreQuartz' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("appliedenergistics2:tile.OreQuartzCharged")'> <Replaces block='appliedenergistics2:tile.OreQuartzCharged' weight='1.0' /> </IfCondition>
+                        <Replaces block='appliedenergistics2:tile.OreQuartz' weight='1.0' />
+                        <Replaces block='appliedenergistics2:tile.OreQuartzCharged' weight='1.0' />
                     </Substitute>
                 </IfCondition>
 
@@ -220,8 +220,8 @@
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("appliedenergistics2:tile.OreQuartz")'> <OreBlock block='appliedenergistics2:tile.OreQuartz' weight='0.90' /> </IfCondition>
                                 <IfCondition condition=':= ?blockExists("appliedenergistics2:tile.OreQuartzCharged")'> <OreBlock block='appliedenergistics2:tile.OreQuartzCharged' weight='0.10' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>

--- a/src/main/resources/config/modules/ArsMagica2.xml
+++ b/src/main/resources/config/modules/ArsMagica2.xml
@@ -4,6 +4,8 @@
      ================================================================= -->
 
 
+<!-- A mod that allows you to create your own spells.  Configuration
+     by Reteo. -->
 
 
 
@@ -156,9 +158,9 @@
                             must be large  enough to catch all ore
                             clusters (>=  32).
                         </Comment>
-                        <IfCondition condition=':= ?blockExists("arsmagica2:vinteumOre")'> <Replaces block='arsmagica2:vinteumOre' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("arsmagica2:vinteumOre:1")'> <Replaces block='arsmagica2:vinteumOre:1' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("arsmagica2:vinteumOre:2")'> <Replaces block='arsmagica2:vinteumOre:2' weight='1.0' /> </IfCondition>
+                        <Replaces block='arsmagica2:vinteumOre' weight='1.0' />
+                        <Replaces block='arsmagica2:vinteumOre:1' weight='1.0' />
+                        <Replaces block='arsmagica2:vinteumOre:2' weight='1.0' />
                     </Substitute>
                 </IfCondition>
 
@@ -260,8 +262,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("arsmagica2:vinteumOre")'> <OreBlock block='arsmagica2:vinteumOre' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -386,8 +388,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("arsmagica2:vinteumOre:1")'> <OreBlock block='arsmagica2:vinteumOre:1' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -512,8 +514,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("arsmagica2:vinteumOre:2")'> <OreBlock block='arsmagica2:vinteumOre:2' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>

--- a/src/main/resources/config/modules/BiomesOPlenty.xml
+++ b/src/main/resources/config/modules/BiomesOPlenty.xml
@@ -5,6 +5,8 @@
      ================================================================= -->
 
 
+<!-- A mod that adds a large collection of biomes to Minecraft.
+     Configuration by Reteo. -->
 
 
 
@@ -327,13 +329,13 @@
                             must be large  enough to catch all ore
                             clusters (>=  32).
                         </Comment>
-                        <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:10")'> <Replaces block='BiomesOPlenty:gemOre:10' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:12")'> <Replaces block='BiomesOPlenty:gemOre:12' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:14")'> <Replaces block='BiomesOPlenty:gemOre:14' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:2")'> <Replaces block='BiomesOPlenty:gemOre:2' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:4")'> <Replaces block='BiomesOPlenty:gemOre:4' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:6")'> <Replaces block='BiomesOPlenty:gemOre:6' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:8")'> <Replaces block='BiomesOPlenty:gemOre:8' weight='1.0' /> </IfCondition>
+                        <Replaces block='BiomesOPlenty:gemOre:10' weight='1.0' />
+                        <Replaces block='BiomesOPlenty:gemOre:12' weight='1.0' />
+                        <Replaces block='BiomesOPlenty:gemOre:14' weight='1.0' />
+                        <Replaces block='BiomesOPlenty:gemOre:2' weight='1.0' />
+                        <Replaces block='BiomesOPlenty:gemOre:4' weight='1.0' />
+                        <Replaces block='BiomesOPlenty:gemOre:6' weight='1.0' />
+                        <Replaces block='BiomesOPlenty:gemOre:8' weight='1.0' />
                     </Substitute>
                 </IfCondition>
 
@@ -375,7 +377,7 @@
                         <Veins name='boplRubyVeinsPipe'  inherits='boplRubyVeins' seed='0x706D' drawWireframe='true' wireframeColor='0x60C60031' drawBoundBox='false' boundBoxColor='0x60C60031'>
                             <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
-                            <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:2")'> <Replaces block='BiomesOPlenty:gemOre:2' weight='1.0' /> </IfCondition>
+                            <Replaces block='BiomesOPlenty:gemOre:2' weight='1.0' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * boplRubySize  * 0.5 ' range=':= 0 * _default_ * boplRubySize  * 0.5 ' type='normal' />
                             <Setting name='SegmentRadius' avg=':= 0.721 * _default_ * boplRubySize  * 0.5 ' range=':= 0.721 * _default_ * boplRubySize  * 0.5 ' type='normal' />
                             <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
@@ -438,8 +440,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:2")'> <OreBlock block='BiomesOPlenty:gemOre:2' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -504,7 +506,7 @@
                         <Veins name='boplPeridotVeinsPipe'  inherits='boplPeridotVeins' seed='0xA6AC' drawWireframe='true' wireframeColor='0x60076855' drawBoundBox='false' boundBoxColor='0x60076855'>
                             <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
-                            <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:4")'> <Replaces block='BiomesOPlenty:gemOre:4' weight='1.0' /> </IfCondition>
+                            <Replaces block='BiomesOPlenty:gemOre:4' weight='1.0' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * boplPeridotSize  * 0.5 ' range=':= 0 * _default_ * boplPeridotSize  * 0.5 ' type='normal' />
                             <Setting name='SegmentRadius' avg=':= 0.721 * _default_ * boplPeridotSize  * 0.5 ' range=':= 0.721 * _default_ * boplPeridotSize  * 0.5 ' type='normal' />
                             <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
@@ -567,8 +569,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:4")'> <OreBlock block='BiomesOPlenty:gemOre:4' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -633,7 +635,7 @@
                         <Veins name='boplTopazVeinsPipe'  inherits='boplTopazVeins' seed='0xB7E1' drawWireframe='true' wireframeColor='0x60D95A03' drawBoundBox='false' boundBoxColor='0x60D95A03'>
                             <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
-                            <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:6")'> <Replaces block='BiomesOPlenty:gemOre:6' weight='1.0' /> </IfCondition>
+                            <Replaces block='BiomesOPlenty:gemOre:6' weight='1.0' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * boplTopazSize  * 0.5 ' range=':= 0 * _default_ * boplTopazSize  * 0.5 ' type='normal' />
                             <Setting name='SegmentRadius' avg=':= 0.721 * _default_ * boplTopazSize  * 0.5 ' range=':= 0.721 * _default_ * boplTopazSize  * 0.5 ' type='normal' />
                             <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
@@ -696,8 +698,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:6")'> <OreBlock block='BiomesOPlenty:gemOre:6' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -764,7 +766,7 @@
                         <Veins name='boplTanzaniteVeinsPipe'  inherits='boplTanzaniteVeins' seed='0xA51A' drawWireframe='true' wireframeColor='0x607701B9' drawBoundBox='false' boundBoxColor='0x607701B9'>
                             <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
-                            <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:8")'> <Replaces block='BiomesOPlenty:gemOre:8' weight='1.0' /> </IfCondition>
+                            <Replaces block='BiomesOPlenty:gemOre:8' weight='1.0' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * boplTanzaniteSize  * 0.5 ' range=':= 0 * _default_ * boplTanzaniteSize  * 0.5 ' type='normal' />
                             <Setting name='SegmentRadius' avg=':= 0.721 * _default_ * boplTanzaniteSize  * 0.5 ' range=':= 0.721 * _default_ * boplTanzaniteSize  * 0.5 ' type='normal' />
                             <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
@@ -829,8 +831,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:8")'> <OreBlock block='BiomesOPlenty:gemOre:8' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -897,7 +899,7 @@
                         <Veins name='boplMalachiteVeinsPipe'  inherits='boplMalachiteVeins' seed='0x5A38' drawWireframe='true' wireframeColor='0x60109D81' drawBoundBox='false' boundBoxColor='0x60109D81'>
                             <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
-                            <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:10")'> <Replaces block='BiomesOPlenty:gemOre:10' weight='1.0' /> </IfCondition>
+                            <Replaces block='BiomesOPlenty:gemOre:10' weight='1.0' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * boplMalachiteSize  * 0.5 ' range=':= 0 * _default_ * boplMalachiteSize  * 0.5 ' type='normal' />
                             <Setting name='SegmentRadius' avg=':= 0.721 * _default_ * boplMalachiteSize  * 0.5 ' range=':= 0.721 * _default_ * boplMalachiteSize  * 0.5 ' type='normal' />
                             <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
@@ -960,8 +962,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:10")'> <OreBlock block='BiomesOPlenty:gemOre:10' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1032,7 +1034,7 @@
                         <Veins name='boplSapphireVeinsPipe'  inherits='boplSapphireVeins' seed='0x7474' drawWireframe='true' wireframeColor='0x603494C3' drawBoundBox='false' boundBoxColor='0x603494C3'>
                             <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
-                            <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:12")'> <Replaces block='BiomesOPlenty:gemOre:12' weight='1.0' /> </IfCondition>
+                            <Replaces block='BiomesOPlenty:gemOre:12' weight='1.0' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * boplSapphireSize  * 0.5 ' range=':= 0 * _default_ * boplSapphireSize  * 0.5 ' type='normal' />
                             <Setting name='SegmentRadius' avg=':= 0.721 * _default_ * boplSapphireSize  * 0.5 ' range=':= 0.721 * _default_ * boplSapphireSize  * 0.5 ' type='normal' />
                             <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
@@ -1101,8 +1103,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:12")'> <OreBlock block='BiomesOPlenty:gemOre:12' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1176,7 +1178,7 @@
                         <Veins name='boplAmberVeinsPipe'  inherits='boplAmberVeins' seed='0x1FEF' drawWireframe='true' wireframeColor='0x60FE9D1B' drawBoundBox='false' boundBoxColor='0x60FE9D1B'>
                             <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
-                            <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:14")'> <Replaces block='BiomesOPlenty:gemOre:14' weight='1.0' /> </IfCondition>
+                            <Replaces block='BiomesOPlenty:gemOre:14' weight='1.0' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * boplAmberSize  * 0.5 ' range=':= 0 * _default_ * boplAmberSize  * 0.5 ' type='normal' />
                             <Setting name='SegmentRadius' avg=':= 0.721 * _default_ * boplAmberSize  * 0.5 ' range=':= 0.721 * _default_ * boplAmberSize  * 0.5 ' type='normal' />
                             <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
@@ -1242,8 +1244,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:14")'> <OreBlock block='BiomesOPlenty:gemOre:14' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1302,7 +1304,7 @@
                             must be large  enough to catch all ore
                             clusters (>=  32).
                         </Comment>
-                        <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre")'> <Replaces block='BiomesOPlenty:gemOre' weight='1.0' /> </IfCondition>
+                        <Replaces block='BiomesOPlenty:gemOre' weight='1.0' />
                     </Substitute>
                 </IfCondition>
 
@@ -1344,7 +1346,7 @@
                         <Veins name='boplEnderAmathystVeinsPipe'  inherits='boplEnderAmathystVeins' seed='0x58D8' drawWireframe='true' wireframeColor='0x60DD4EEA' drawBoundBox='false' boundBoxColor='0x60DD4EEA'>
                             <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
-                            <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre")'> <Replaces block='BiomesOPlenty:gemOre' weight='1.0' /> </IfCondition>
+                            <Replaces block='BiomesOPlenty:gemOre' weight='1.0' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * boplEnderAmathystSize  * 0.5 ' range=':= 0 * _default_ * boplEnderAmathystSize  * 0.5 ' type='normal' />
                             <Setting name='SegmentRadius' avg=':= 0.721 * _default_ * boplEnderAmathystSize  * 0.5 ' range=':= 0.721 * _default_ * boplEnderAmathystSize  * 0.5 ' type='normal' />
                             <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
@@ -1407,8 +1409,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre")'> <OreBlock block='BiomesOPlenty:gemOre' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>

--- a/src/main/resources/config/modules/Chisel2.xml
+++ b/src/main/resources/config/modules/Chisel2.xml
@@ -5,7 +5,8 @@
 
 
 <!-- This mod adds 5 types of stone, and makes them, and many other
-     types of material, shapable into a large number of patterns. -->
+     types of material, shapable into a large number of patterns.
+     Configuration by Reteo. -->
 
 
 
@@ -201,11 +202,11 @@
                             must be large  enough to catch all ore
                             clusters (>=  32).
                         </Comment>
-                        <IfCondition condition=':= ?blockExists("chisel:andesite")'> <Replaces block='chisel:andesite' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("chisel:diorite")'> <Replaces block='chisel:diorite' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("chisel:granite")'> <Replaces block='chisel:granite' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("chisel:limestone")'> <Replaces block='chisel:limestone' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("chisel:marble")'> <Replaces block='chisel:marble' weight='1.0' /> </IfCondition>
+                        <Replaces block='chisel:andesite' weight='1.0' />
+                        <Replaces block='chisel:diorite' weight='1.0' />
+                        <Replaces block='chisel:granite' weight='1.0' />
+                        <Replaces block='chisel:limestone' weight='1.0' />
+                        <Replaces block='chisel:marble' weight='1.0' />
                     </Substitute>
                 </IfCondition>
 
@@ -300,8 +301,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("chisel:andesite")'> <OreBlock block='chisel:andesite' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -398,8 +399,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("chisel:diorite")'> <OreBlock block='chisel:diorite' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -496,8 +497,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("chisel:granite")'> <OreBlock block='chisel:granite' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -594,8 +595,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("chisel:limestone")'> <OreBlock block='chisel:limestone' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -692,8 +693,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("chisel:marble")'> <OreBlock block='chisel:marble' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>

--- a/src/main/resources/config/modules/DenseOres.xml
+++ b/src/main/resources/config/modules/DenseOres.xml
@@ -5,6 +5,8 @@
      ================================================================= -->
 
 
+<!-- A mod that adds dense forms of most vanilla ores. Configuration
+     by Reteo. -->
 
 
 
@@ -332,20 +334,20 @@
                             must be large  enough to catch all ore
                             clusters (>=  32).
                         </Comment>
-                        <IfCondition condition=':= ?blockExists("denseores:block0")'> <Replaces block='denseores:block0' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("denseores:block0:1")'> <Replaces block='denseores:block0:1' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("denseores:block0:2")'> <Replaces block='denseores:block0:2' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("denseores:block0:3")'> <Replaces block='denseores:block0:3' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("denseores:block0:4")'> <Replaces block='denseores:block0:4' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("denseores:block0:5")'> <Replaces block='denseores:block0:5' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("denseores:block0:6")'> <Replaces block='denseores:block0:6' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("minecraft:coal_ore")'> <Replaces block='minecraft:coal_ore' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("minecraft:diamond_ore")'> <Replaces block='minecraft:diamond_ore' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("minecraft:emerald_ore")'> <Replaces block='minecraft:emerald_ore' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("minecraft:gold_ore")'> <Replaces block='minecraft:gold_ore' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("minecraft:iron_ore")'> <Replaces block='minecraft:iron_ore' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("minecraft:lapis_ore")'> <Replaces block='minecraft:lapis_ore' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("minecraft:redstone_ore")'> <Replaces block='minecraft:redstone_ore' weight='1.0' /> </IfCondition>
+                        <Replaces block='denseores:block0' weight='1.0' />
+                        <Replaces block='denseores:block0:1' weight='1.0' />
+                        <Replaces block='denseores:block0:2' weight='1.0' />
+                        <Replaces block='denseores:block0:3' weight='1.0' />
+                        <Replaces block='denseores:block0:4' weight='1.0' />
+                        <Replaces block='denseores:block0:5' weight='1.0' />
+                        <Replaces block='denseores:block0:6' weight='1.0' />
+                        <Replaces block='minecraft:coal_ore' weight='1.0' />
+                        <Replaces block='minecraft:diamond_ore' weight='1.0' />
+                        <Replaces block='minecraft:emerald_ore' weight='1.0' />
+                        <Replaces block='minecraft:gold_ore' weight='1.0' />
+                        <Replaces block='minecraft:iron_ore' weight='1.0' />
+                        <Replaces block='minecraft:lapis_ore' weight='1.0' />
+                        <Replaces block='minecraft:redstone_ore' weight='1.0' />
                     </Substitute>
                 </IfCondition>
 
@@ -465,8 +467,8 @@
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("minecraft:iron_ore")'> <OreBlock block='minecraft:iron_ore' weight='0.9' /> </IfCondition>
                                 <IfCondition condition=':= ?blockExists("denseores:block0")'> <OreBlock block='denseores:block0' weight='0.1' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -588,8 +590,8 @@
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("minecraft:gold_ore")'> <OreBlock block='minecraft:gold_ore' weight='0.9' /> </IfCondition>
                                 <IfCondition condition=':= ?blockExists("denseores:block0:1")'> <OreBlock block='denseores:block0:1' weight='0.1' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -740,8 +742,8 @@
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("minecraft:lapis_ore")'> <OreBlock block='minecraft:lapis_ore' weight='0.9' /> </IfCondition>
                                 <IfCondition condition=':= ?blockExists("denseores:block0:2")'> <OreBlock block='denseores:block0:2' weight='0.1' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
 
@@ -772,8 +774,8 @@
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("minecraft:lapis_ore")'> <OreBlock block='minecraft:lapis_ore' weight='0.9' /> </IfCondition>
                                 <IfCondition condition=':= ?blockExists("denseores:block0:2")'> <OreBlock block='denseores:block0:2' weight='0.1' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                         <!-- "Preferred" configuration complete. -->
@@ -820,8 +822,8 @@
                         <Veins name='dnsoDiamondVeinsPipe'  inherits='dnsoDiamondVeins' seed='0x197B' drawWireframe='true' wireframeColor='0x608BF4E3' drawBoundBox='false' boundBoxColor='0x608BF4E3'>
                             <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
-                            <IfCondition condition=':= ?blockExists("minecraft:diamond_ore")'> <Replaces block='minecraft:diamond_ore' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("denseores:block0:3")'> <Replaces block='denseores:block0:3' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:diamond_ore' weight='1.0' />
+                            <Replaces block='denseores:block0:3' weight='1.0' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * dnsoDiamondSize  * 0.5 ' range=':= 0 * _default_ * dnsoDiamondSize  * 0.5 ' type='normal' />
                             <Setting name='SegmentRadius' avg=':= 0.843 * _default_ * dnsoDiamondSize  * 0.5 ' range=':= 0.843 * _default_ * dnsoDiamondSize  * 0.5 ' type='normal' />
                             <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
@@ -908,8 +910,8 @@
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("minecraft:diamond_ore")'> <OreBlock block='minecraft:diamond_ore' weight='0.9' /> </IfCondition>
                                 <IfCondition condition=':= ?blockExists("denseores:block0:3")'> <OreBlock block='denseores:block0:3' weight='0.1' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -954,8 +956,8 @@
                         <Veins name='dnsoEmeraldVeinsPipe'  inherits='dnsoEmeraldVeins' seed='0x81E5' drawWireframe='true' wireframeColor='0x606CE391' drawBoundBox='false' boundBoxColor='0x606CE391'>
                             <IfCondition condition=':= ?blockExists("minecraft:monster_egg")'> <OreBlock block='minecraft:monster_egg' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
-                            <IfCondition condition=':= ?blockExists("minecraft:emerald_ore")'> <Replaces block='minecraft:emerald_ore' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("denseores:block0:4")'> <Replaces block='denseores:block0:4' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:emerald_ore' weight='1.0' />
+                            <Replaces block='denseores:block0:4' weight='1.0' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * dnsoEmeraldSize  * 0.5 ' range=':= 0 * _default_ * dnsoEmeraldSize  * 0.5 ' type='normal' />
                             <Setting name='SegmentRadius' avg=':= 0.589 * _default_ * dnsoEmeraldSize  * 0.5 ' range=':= 0.589 * _default_ * dnsoEmeraldSize  * 0.5 ' type='normal' />
                             <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
@@ -1042,8 +1044,8 @@
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("minecraft:emerald_ore")'> <OreBlock block='minecraft:emerald_ore' weight='0.9' /> </IfCondition>
                                 <IfCondition condition=':= ?blockExists("denseores:block0:4")'> <OreBlock block='denseores:block0:4' weight='0.1' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1194,8 +1196,8 @@
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("minecraft:redstone_ore")'> <OreBlock block='minecraft:redstone_ore' weight='0.9' /> </IfCondition>
                                 <IfCondition condition=':= ?blockExists("denseores:block0:5")'> <OreBlock block='denseores:block0:5' weight='0.1' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
 
@@ -1226,8 +1228,8 @@
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("minecraft:redstone_ore")'> <OreBlock block='minecraft:redstone_ore' weight='0.9' /> </IfCondition>
                                 <IfCondition condition=':= ?blockExists("denseores:block0:5")'> <OreBlock block='denseores:block0:5' weight='0.1' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                         <!-- "Preferred" configuration complete. -->
@@ -1336,8 +1338,8 @@
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("minecraft:coal_ore")'> <OreBlock block='minecraft:coal_ore' weight='0.9' /> </IfCondition>
                                 <IfCondition condition=':= ?blockExists("denseores:block0:6")'> <OreBlock block='denseores:block0:6' weight='0.1' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1422,8 +1424,8 @@
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("minecraft:coal_ore")'> <OreBlock block='minecraft:coal_ore' weight='0.9' /> </IfCondition>
                                 <IfCondition condition=':= ?blockExists("denseores:block0:6")'> <OreBlock block='denseores:block0:6' weight='0.1' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1457,8 +1459,8 @@
                             must be large  enough to catch all ore
                             clusters (>=  32).
                         </Comment>
-                        <IfCondition condition=':= ?blockExists("denseores:block0:7")'> <Replaces block='denseores:block0:7' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("minecraft:quartz_ore")'> <Replaces block='minecraft:quartz_ore' weight='1.0' /> </IfCondition>
+                        <Replaces block='denseores:block0:7' weight='1.0' />
+                        <Replaces block='minecraft:quartz_ore' weight='1.0' />
                     </Substitute>
                 </IfCondition>
 
@@ -1478,7 +1480,7 @@
                             </Description>
                             <IfCondition condition=':= ?blockExists("minecraft:quartz_ore")'> <OreBlock block='minecraft:quartz_ore' weight='0.9' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("denseores:block0:7")'> <OreBlock block='denseores:block0:7' weight='0.1' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 6.247 * _default_ * dnsoNetherQuartzFreq ' range=':= 6.247 * _default_ * dnsoNetherQuartzFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * dnsoNetherQuartzSize ' range=':= 0 * _default_ * dnsoNetherQuartzSize ' type='normal' />
@@ -1512,7 +1514,7 @@
                             </Description>
                             <IfCondition condition=':= ?blockExists("minecraft:quartz_ore")'> <OreBlock block='minecraft:quartz_ore' weight='0.9' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("denseores:block0:7")'> <OreBlock block='denseores:block0:7' weight='0.1' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 13.000 * dnsoNetherQuartzSize ' range=':= _default_ * dnsoNetherQuartzSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 16.000 * dnsoNetherQuartzFreq ' range=':= _default_ * dnsoNetherQuartzFreq ' type='normal' scaleTo='base' />
@@ -1544,7 +1546,7 @@
                             </Description>
                             <IfCondition condition=':= ?blockExists("minecraft:quartz_ore")'> <OreBlock block='minecraft:quartz_ore' weight='0.9' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("denseores:block0:7")'> <OreBlock block='denseores:block0:7' weight='0.1' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.494 * _default_ * dnsoNetherQuartzSize ' range=':= 1.494 * _default_ * dnsoNetherQuartzSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.494 * _default_ * dnsoNetherQuartzSize ' range=':= 1.494 * _default_ * dnsoNetherQuartzSize ' type='normal' scaleTo='base' />
@@ -1579,8 +1581,8 @@
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("minecraft:quartz_ore")'> <OreBlock block='minecraft:quartz_ore' weight='0.9' /> </IfCondition>
                                 <IfCondition condition=':= ?blockExists("denseores:block0:7")'> <OreBlock block='denseores:block0:7' weight='0.1' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>

--- a/src/main/resources/config/modules/ElectriCraft.xml
+++ b/src/main/resources/config/modules/ElectriCraft.xml
@@ -6,7 +6,7 @@
 
 <!-- An expansion to Rotarycraft, this mod adds oregen appropriate to
      the formation of various wires with different electrical
-     advantages/disadvantages. -->
+     advantages/disadvantages.  Configuration by Reteo. -->
 
 
 
@@ -261,12 +261,12 @@
                             must be large  enough to catch all ore
                             clusters (>=  32).
                         </Comment>
-                        <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore")'> <Replaces block='ElectriCraft:electricraft_block_ore' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:1")'> <Replaces block='ElectriCraft:electricraft_block_ore:1' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:2")'> <Replaces block='ElectriCraft:electricraft_block_ore:2' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:3")'> <Replaces block='ElectriCraft:electricraft_block_ore:3' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:4")'> <Replaces block='ElectriCraft:electricraft_block_ore:4' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:5")'> <Replaces block='ElectriCraft:electricraft_block_ore:5' weight='1.0' /> </IfCondition>
+                        <Replaces block='ElectriCraft:electricraft_block_ore' weight='1.0' />
+                        <Replaces block='ElectriCraft:electricraft_block_ore:1' weight='1.0' />
+                        <Replaces block='ElectriCraft:electricraft_block_ore:2' weight='1.0' />
+                        <Replaces block='ElectriCraft:electricraft_block_ore:3' weight='1.0' />
+                        <Replaces block='ElectriCraft:electricraft_block_ore:4' weight='1.0' />
+                        <Replaces block='ElectriCraft:electricraft_block_ore:5' weight='1.0' />
                     </Substitute>
                 </IfCondition>
 
@@ -382,8 +382,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore")'> <OreBlock block='ElectriCraft:electricraft_block_ore' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -501,8 +501,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:1")'> <OreBlock block='ElectriCraft:electricraft_block_ore:1' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -620,8 +620,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:2")'> <OreBlock block='ElectriCraft:electricraft_block_ore:2' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -739,8 +739,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:3")'> <OreBlock block='ElectriCraft:electricraft_block_ore:3' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -858,8 +858,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:4")'> <OreBlock block='ElectriCraft:electricraft_block_ore:4' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -977,8 +977,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:5")'> <OreBlock block='ElectriCraft:electricraft_block_ore:5' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>

--- a/src/main/resources/config/modules/Factorization.xml
+++ b/src/main/resources/config/modules/Factorization.xml
@@ -4,6 +4,8 @@
      ================================================================= -->
 
 
+<!-- A mod that has several features, such as barrels and routers, as
+     well as its own power system. Configuration by Reteo. -->
 
 
 
@@ -122,8 +124,8 @@
                             must be large  enough to catch all ore
                             clusters (>=  32).
                         </Comment>
-                        <IfCondition condition=':= ?blockExists("factorization:DarkIronOre")'> <Replaces block='factorization:DarkIronOre' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("factorization:ResourceBlock")'> <Replaces block='factorization:ResourceBlock' weight='1.0' /> </IfCondition>
+                        <Replaces block='factorization:DarkIronOre' weight='1.0' />
+                        <Replaces block='factorization:ResourceBlock' weight='1.0' />
                     </Substitute>
                 </IfCondition>
 
@@ -218,8 +220,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("factorization:ResourceBlock")'> <OreBlock block='factorization:ResourceBlock' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -269,8 +271,8 @@
                             </Description>
                             <IfCondition condition=':= ?blockExists("factorization:DarkIronOre")'> <OreBlock block='factorization:DarkIronOre' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
-                            <IfCondition condition=':= ?blockExists("dirt")'> <ReplacesOre block='dirt' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("gravel")'> <ReplacesOre block='gravel' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='dirt' weight='1.0' />
+                            <ReplacesOre block='gravel' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.433 * _default_ * fctrDarkIronFreq ' range=':= 0.433 * _default_ * fctrDarkIronFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * fctrDarkIronSize ' range=':= 0 * _default_ * fctrDarkIronSize ' type='normal' />
@@ -313,8 +315,8 @@
                             </Description>
                             <IfCondition condition=':= ?blockExists("factorization:DarkIronOre")'> <OreBlock block='factorization:DarkIronOre' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
-                            <IfCondition condition=':= ?blockExists("dirt")'> <ReplacesOre block='dirt' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("gravel")'> <ReplacesOre block='gravel' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='dirt' weight='1.0' />
+                            <ReplacesOre block='gravel' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.393 * _default_ * fctrDarkIronSize ' range=':= 0.393 * _default_ * fctrDarkIronSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.393 * _default_ * fctrDarkIronSize ' range=':= 0.393 * _default_ * fctrDarkIronSize ' type='normal' scaleTo='base' />
@@ -348,8 +350,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("factorization:DarkIronOre")'> <OreBlock block='factorization:DarkIronOre' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -367,8 +369,8 @@
                             </Description>
                             <IfCondition condition=':= ?blockExists("factorization:DarkIronOre")'> <OreBlock block='factorization:DarkIronOre' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
-                            <IfCondition condition=':= ?blockExists("dirt")'> <ReplacesOre block='dirt' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("gravel")'> <ReplacesOre block='gravel' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='dirt' weight='1.0' />
+                            <ReplacesOre block='gravel' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 1.000 * fctrDarkIronSize ' range=':= _default_ * fctrDarkIronSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 1.000 * fctrDarkIronFreq ' range=':= _default_ * fctrDarkIronFreq ' type='normal' scaleTo='base' />

--- a/src/main/resources/config/modules/FlaxbeardsSteamcraft.xml
+++ b/src/main/resources/config/modules/FlaxbeardsSteamcraft.xml
@@ -4,6 +4,7 @@
      ================================================================= -->
 
 
+<!-- A mod centered around steam power. Configuration by Reteo. -->
 
 
 
@@ -123,8 +124,8 @@
                             must be large  enough to catch all ore
                             clusters (>=  32).
                         </Comment>
-                        <IfCondition condition=':= ?blockExists("Steamcraft:steamcraftOre")'> <Replaces block='Steamcraft:steamcraftOre' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("Steamcraft:steamcraftOre:1")'> <Replaces block='Steamcraft:steamcraftOre:1' weight='1.0' /> </IfCondition>
+                        <Replaces block='Steamcraft:steamcraftOre' weight='1.0' />
+                        <Replaces block='Steamcraft:steamcraftOre:1' weight='1.0' />
                     </Substitute>
                 </IfCondition>
 
@@ -219,8 +220,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("Steamcraft:steamcraftOre")'> <OreBlock block='Steamcraft:steamcraftOre' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -338,8 +339,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("Steamcraft:steamcraftOre:1")'> <OreBlock block='Steamcraft:steamcraftOre:1' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>

--- a/src/main/resources/config/modules/Forestry.xml
+++ b/src/main/resources/config/modules/Forestry.xml
@@ -4,6 +4,8 @@
      ================================================================= -->
 
 
+<!-- A mod focused on breeding of trees and bees. Configuration by
+     Reteo. -->
 
 
 
@@ -156,9 +158,9 @@
                             must be large  enough to catch all ore
                             clusters (>=  32).
                         </Comment>
-                        <IfCondition condition=':= ?blockExists("Forestry:resources")'> <Replaces block='Forestry:resources' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("Forestry:resources:1")'> <Replaces block='Forestry:resources:1' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("Forestry:resources:2")'> <Replaces block='Forestry:resources:2' weight='1.0' /> </IfCondition>
+                        <Replaces block='Forestry:resources' weight='1.0' />
+                        <Replaces block='Forestry:resources:1' weight='1.0' />
+                        <Replaces block='Forestry:resources:2' weight='1.0' />
                     </Substitute>
                 </IfCondition>
 
@@ -260,8 +262,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("Forestry:resources")'> <OreBlock block='Forestry:resources' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -379,8 +381,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("Forestry:resources:1")'> <OreBlock block='Forestry:resources:1' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -498,8 +500,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("Forestry:resources:2")'> <OreBlock block='Forestry:resources:2' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>

--- a/src/main/resources/config/modules/FossilsandArchaeology.xml
+++ b/src/main/resources/config/modules/FossilsandArchaeology.xml
@@ -4,6 +4,8 @@
      ================================================================= -->
 
 
+<!-- A mod focused around the science of archaeology (and genetics).
+     Configuration by Reteo. -->
 
 
 
@@ -123,8 +125,8 @@
                             must be large  enough to catch all ore
                             clusters (>=  32).
                         </Comment>
-                        <IfCondition condition=':= ?blockExists("fossil:fossil")'> <Replaces block='fossil:fossil' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("fossil:permafrost")'> <Replaces block='fossil:permafrost' weight='1.0' /> </IfCondition>
+                        <Replaces block='fossil:fossil' weight='1.0' />
+                        <Replaces block='fossil:permafrost' weight='1.0' />
                     </Substitute>
                 </IfCondition>
 
@@ -255,8 +257,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("fossil:fossil")'> <OreBlock block='fossil:fossil' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
 
@@ -286,8 +288,8 @@
                                     preferred biomes.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("fossil:fossil")'> <OreBlock block='fossil:fossil' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                         <!-- "Preferred" configuration complete. -->
@@ -416,8 +418,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("fossil:permafrost")'> <OreBlock block='fossil:permafrost' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>

--- a/src/main/resources/config/modules/Galacticraft.xml
+++ b/src/main/resources/config/modules/Galacticraft.xml
@@ -4,6 +4,9 @@
      ================================================================= -->
 
 
+<!-- A mod focused on spaceflight.  Only the overworld ores are
+     configured; other worlds' ores are untouched. Configuration by
+     Reteo. -->
 
 
 
@@ -190,10 +193,10 @@
                             must be large  enough to catch all ore
                             clusters (>=  32).
                         </Comment>
-                        <IfCondition condition=':= ?blockExists("GalacticraftCore:tile.gcBlockCore:5")'> <Replaces block='GalacticraftCore:tile.gcBlockCore:5' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("GalacticraftCore:tile.gcBlockCore:6")'> <Replaces block='GalacticraftCore:tile.gcBlockCore:6' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("GalacticraftCore:tile.gcBlockCore:7")'> <Replaces block='GalacticraftCore:tile.gcBlockCore:7' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("GalacticraftCore:tile.gcBlockCore:8")'> <Replaces block='GalacticraftCore:tile.gcBlockCore:8' weight='1.0' /> </IfCondition>
+                        <Replaces block='GalacticraftCore:tile.gcBlockCore:5' weight='1.0' />
+                        <Replaces block='GalacticraftCore:tile.gcBlockCore:6' weight='1.0' />
+                        <Replaces block='GalacticraftCore:tile.gcBlockCore:7' weight='1.0' />
+                        <Replaces block='GalacticraftCore:tile.gcBlockCore:8' weight='1.0' />
                     </Substitute>
                 </IfCondition>
 
@@ -288,8 +291,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("GalacticraftCore:tile.gcBlockCore:5")'> <OreBlock block='GalacticraftCore:tile.gcBlockCore:5' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -407,8 +410,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("GalacticraftCore:tile.gcBlockCore:6")'> <OreBlock block='GalacticraftCore:tile.gcBlockCore:6' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -526,8 +529,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("GalacticraftCore:tile.gcBlockCore:7")'> <OreBlock block='GalacticraftCore:tile.gcBlockCore:7' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -645,8 +648,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("GalacticraftCore:tile.gcBlockCore:8")'> <OreBlock block='GalacticraftCore:tile.gcBlockCore:8' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>

--- a/src/main/resources/config/modules/GeoStrata.xml
+++ b/src/main/resources/config/modules/GeoStrata.xml
@@ -6,6 +6,8 @@
      ================================================================= -->
 
 
+<!-- A mod focused on adding multiple types of stone to the game,
+     with varying strengths.  Configuration by Reteo. -->
 
 
 
@@ -634,23 +636,23 @@
                             must be large  enough to catch all ore
                             clusters (>=  32).
                         </Comment>
-                        <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_basalt_smooth")'> <Replaces block='GeoStrata:geostrata_rock_basalt_smooth' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_gneiss_smooth")'> <Replaces block='GeoStrata:geostrata_rock_gneiss_smooth' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_granite_smooth")'> <Replaces block='GeoStrata:geostrata_rock_granite_smooth' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_granulite_smooth")'> <Replaces block='GeoStrata:geostrata_rock_granulite_smooth' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_hornfel_smooth")'> <Replaces block='GeoStrata:geostrata_rock_hornfel_smooth' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_limestone_smooth")'> <Replaces block='GeoStrata:geostrata_rock_limestone_smooth' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_marble_smooth")'> <Replaces block='GeoStrata:geostrata_rock_marble_smooth' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_migmatite_smooth")'> <Replaces block='GeoStrata:geostrata_rock_migmatite_smooth' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_onyx_smooth")'> <Replaces block='GeoStrata:geostrata_rock_onyx_smooth' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_opal_smooth")'> <Replaces block='GeoStrata:geostrata_rock_opal_smooth' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_peridotite_smooth")'> <Replaces block='GeoStrata:geostrata_rock_peridotite_smooth' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_pumice_smooth")'> <Replaces block='GeoStrata:geostrata_rock_pumice_smooth' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_quartz_smooth")'> <Replaces block='GeoStrata:geostrata_rock_quartz_smooth' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_sandstone_smooth")'> <Replaces block='GeoStrata:geostrata_rock_sandstone_smooth' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_schist_smooth")'> <Replaces block='GeoStrata:geostrata_rock_schist_smooth' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_shale_smooth")'> <Replaces block='GeoStrata:geostrata_rock_shale_smooth' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_slate_smooth")'> <Replaces block='GeoStrata:geostrata_rock_slate_smooth' weight='1.0' /> </IfCondition>
+                        <Replaces block='GeoStrata:geostrata_rock_basalt_smooth' weight='1.0' />
+                        <Replaces block='GeoStrata:geostrata_rock_gneiss_smooth' weight='1.0' />
+                        <Replaces block='GeoStrata:geostrata_rock_granite_smooth' weight='1.0' />
+                        <Replaces block='GeoStrata:geostrata_rock_granulite_smooth' weight='1.0' />
+                        <Replaces block='GeoStrata:geostrata_rock_hornfel_smooth' weight='1.0' />
+                        <Replaces block='GeoStrata:geostrata_rock_limestone_smooth' weight='1.0' />
+                        <Replaces block='GeoStrata:geostrata_rock_marble_smooth' weight='1.0' />
+                        <Replaces block='GeoStrata:geostrata_rock_migmatite_smooth' weight='1.0' />
+                        <Replaces block='GeoStrata:geostrata_rock_onyx_smooth' weight='1.0' />
+                        <Replaces block='GeoStrata:geostrata_rock_opal_smooth' weight='1.0' />
+                        <Replaces block='GeoStrata:geostrata_rock_peridotite_smooth' weight='1.0' />
+                        <Replaces block='GeoStrata:geostrata_rock_pumice_smooth' weight='1.0' />
+                        <Replaces block='GeoStrata:geostrata_rock_quartz_smooth' weight='1.0' />
+                        <Replaces block='GeoStrata:geostrata_rock_sandstone_smooth' weight='1.0' />
+                        <Replaces block='GeoStrata:geostrata_rock_schist_smooth' weight='1.0' />
+                        <Replaces block='GeoStrata:geostrata_rock_shale_smooth' weight='1.0' />
+                        <Replaces block='GeoStrata:geostrata_rock_slate_smooth' weight='1.0' />
                     </Substitute>
                 </IfCondition>
 
@@ -745,8 +747,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_shale_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_shale_smooth' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -864,8 +866,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_sandstone_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_sandstone_smooth' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -983,8 +985,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_limestone_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_limestone_smooth' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1102,8 +1104,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_pumice_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_pumice_smooth' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1221,8 +1223,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_opal_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_opal_smooth' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1340,8 +1342,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_slate_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_slate_smooth' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1459,8 +1461,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_gneiss_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_gneiss_smooth' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1578,8 +1580,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_peridotite_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_peridotite_smooth' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1697,8 +1699,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_granulite_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_granulite_smooth' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1816,8 +1818,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_migmatite_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_migmatite_smooth' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1935,8 +1937,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_schist_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_schist_smooth' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -2054,8 +2056,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_basalt_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_basalt_smooth' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -2173,8 +2175,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_onyx_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_onyx_smooth' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -2292,8 +2294,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_quartz_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_quartz_smooth' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -2411,8 +2413,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_marble_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_marble_smooth' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -2530,8 +2532,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_granite_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_granite_smooth' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -2649,8 +2651,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_hornfel_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_hornfel_smooth' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>

--- a/src/main/resources/config/modules/ImmersiveEngineering.xml
+++ b/src/main/resources/config/modules/ImmersiveEngineering.xml
@@ -4,6 +4,7 @@
      ================================================================= -->
 
 
+<!-- Configuration by Reteo. -->
 
 
 
@@ -225,11 +226,11 @@
                             must be large  enough to catch all ore
                             clusters (>=  32).
                         </Comment>
-                        <IfCondition condition=':= ?blockExists("ImmersiveEngineering:ore:0")'> <Replaces block='ImmersiveEngineering:ore:0' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("ImmersiveEngineering:ore:1")'> <Replaces block='ImmersiveEngineering:ore:1' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("ImmersiveEngineering:ore:2")'> <Replaces block='ImmersiveEngineering:ore:2' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("ImmersiveEngineering:ore:3")'> <Replaces block='ImmersiveEngineering:ore:3' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("ImmersiveEngineering:ore:4")'> <Replaces block='ImmersiveEngineering:ore:4' weight='1.0' /> </IfCondition>
+                        <Replaces block='ImmersiveEngineering:ore:0' weight='1.0' />
+                        <Replaces block='ImmersiveEngineering:ore:1' weight='1.0' />
+                        <Replaces block='ImmersiveEngineering:ore:2' weight='1.0' />
+                        <Replaces block='ImmersiveEngineering:ore:3' weight='1.0' />
+                        <Replaces block='ImmersiveEngineering:ore:4' weight='1.0' />
                     </Substitute>
                 </IfCondition>
 
@@ -324,8 +325,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("ImmersiveEngineering:ore:0")'> <OreBlock block='ImmersiveEngineering:ore:0' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -443,8 +444,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("ImmersiveEngineering:ore:1")'> <OreBlock block='ImmersiveEngineering:ore:1' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -562,8 +563,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("ImmersiveEngineering:ore:2")'> <OreBlock block='ImmersiveEngineering:ore:2' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -681,8 +682,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("ImmersiveEngineering:ore:3")'> <OreBlock block='ImmersiveEngineering:ore:3' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -800,8 +801,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("ImmersiveEngineering:ore:4")'> <OreBlock block='ImmersiveEngineering:ore:4' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>

--- a/src/main/resources/config/modules/Mekanism.xml
+++ b/src/main/resources/config/modules/Mekanism.xml
@@ -4,6 +4,7 @@
      ================================================================= -->
 
 
+<!-- Configuration by Reteo. -->
 
 
 
@@ -156,9 +157,9 @@
                             must be large  enough to catch all ore
                             clusters (>=  32).
                         </Comment>
-                        <IfCondition condition=':= ?blockExists("Mekanism:OreBlock")'> <Replaces block='Mekanism:OreBlock' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("Mekanism:OreBlock:1")'> <Replaces block='Mekanism:OreBlock:1' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("Mekanism:OreBlock:2")'> <Replaces block='Mekanism:OreBlock:2' weight='1.0' /> </IfCondition>
+                        <Replaces block='Mekanism:OreBlock' weight='1.0' />
+                        <Replaces block='Mekanism:OreBlock:1' weight='1.0' />
+                        <Replaces block='Mekanism:OreBlock:2' weight='1.0' />
                     </Substitute>
                 </IfCondition>
 
@@ -253,8 +254,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("Mekanism:OreBlock")'> <OreBlock block='Mekanism:OreBlock' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -372,8 +373,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("Mekanism:OreBlock:1")'> <OreBlock block='Mekanism:OreBlock:1' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -491,8 +492,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("Mekanism:OreBlock:2")'> <OreBlock block='Mekanism:OreBlock:2' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>

--- a/src/main/resources/config/modules/Metallurgy4.xml
+++ b/src/main/resources/config/modules/Metallurgy4.xml
@@ -11,7 +11,8 @@
 
 
 <!-- This mod includes a huge number of ores to make minecraft far
-     more interesting, especially when involving tool progression. -->
+     more interesting, especially when involving tool progression.
+     Configuration by Reteo. -->
 
 
 
@@ -1252,29 +1253,29 @@
                             must be large  enough to catch all ore
                             clusters (>=  32).
                         </Comment>
-                        <IfCondition condition=':= ?blockExists("Metallurgy:base.ore")'> <Replaces block='Metallurgy:base.ore' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("Metallurgy:base.ore:1")'> <Replaces block='Metallurgy:base.ore:1' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("Metallurgy:base.ore:2")'> <Replaces block='Metallurgy:base.ore:2' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore")'> <Replaces block='Metallurgy:fantasy.ore' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:1")'> <Replaces block='Metallurgy:fantasy.ore:1' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:11")'> <Replaces block='Metallurgy:fantasy.ore:11' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:13")'> <Replaces block='Metallurgy:fantasy.ore:13' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:14")'> <Replaces block='Metallurgy:fantasy.ore:14' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:2")'> <Replaces block='Metallurgy:fantasy.ore:2' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:4")'> <Replaces block='Metallurgy:fantasy.ore:4' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:5")'> <Replaces block='Metallurgy:fantasy.ore:5' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:6")'> <Replaces block='Metallurgy:fantasy.ore:6' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:7")'> <Replaces block='Metallurgy:fantasy.ore:7' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:8")'> <Replaces block='Metallurgy:fantasy.ore:8' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("Metallurgy:precious.ore")'> <Replaces block='Metallurgy:precious.ore' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("Metallurgy:precious.ore:1")'> <Replaces block='Metallurgy:precious.ore:1' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("Metallurgy:precious.ore:2")'> <Replaces block='Metallurgy:precious.ore:2' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore")'> <Replaces block='Metallurgy:utility.ore' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:1")'> <Replaces block='Metallurgy:utility.ore:1' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:2")'> <Replaces block='Metallurgy:utility.ore:2' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:3")'> <Replaces block='Metallurgy:utility.ore:3' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:4")'> <Replaces block='Metallurgy:utility.ore:4' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:5")'> <Replaces block='Metallurgy:utility.ore:5' weight='1.0' /> </IfCondition>
+                        <Replaces block='Metallurgy:base.ore' weight='1.0' />
+                        <Replaces block='Metallurgy:base.ore:1' weight='1.0' />
+                        <Replaces block='Metallurgy:base.ore:2' weight='1.0' />
+                        <Replaces block='Metallurgy:fantasy.ore' weight='1.0' />
+                        <Replaces block='Metallurgy:fantasy.ore:1' weight='1.0' />
+                        <Replaces block='Metallurgy:fantasy.ore:11' weight='1.0' />
+                        <Replaces block='Metallurgy:fantasy.ore:13' weight='1.0' />
+                        <Replaces block='Metallurgy:fantasy.ore:14' weight='1.0' />
+                        <Replaces block='Metallurgy:fantasy.ore:2' weight='1.0' />
+                        <Replaces block='Metallurgy:fantasy.ore:4' weight='1.0' />
+                        <Replaces block='Metallurgy:fantasy.ore:5' weight='1.0' />
+                        <Replaces block='Metallurgy:fantasy.ore:6' weight='1.0' />
+                        <Replaces block='Metallurgy:fantasy.ore:7' weight='1.0' />
+                        <Replaces block='Metallurgy:fantasy.ore:8' weight='1.0' />
+                        <Replaces block='Metallurgy:precious.ore' weight='1.0' />
+                        <Replaces block='Metallurgy:precious.ore:1' weight='1.0' />
+                        <Replaces block='Metallurgy:precious.ore:2' weight='1.0' />
+                        <Replaces block='Metallurgy:utility.ore' weight='1.0' />
+                        <Replaces block='Metallurgy:utility.ore:1' weight='1.0' />
+                        <Replaces block='Metallurgy:utility.ore:2' weight='1.0' />
+                        <Replaces block='Metallurgy:utility.ore:3' weight='1.0' />
+                        <Replaces block='Metallurgy:utility.ore:4' weight='1.0' />
+                        <Replaces block='Metallurgy:utility.ore:5' weight='1.0' />
                     </Substitute>
                 </IfCondition>
 
@@ -1376,8 +1377,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore")'> <OreBlock block='Metallurgy:utility.ore' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1502,8 +1503,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:1")'> <OreBlock block='Metallurgy:utility.ore:1' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1628,8 +1629,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:2")'> <OreBlock block='Metallurgy:utility.ore:2' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1754,8 +1755,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:3")'> <OreBlock block='Metallurgy:utility.ore:3' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1880,8 +1881,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:4")'> <OreBlock block='Metallurgy:utility.ore:4' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -2006,8 +2007,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:5")'> <OreBlock block='Metallurgy:utility.ore:5' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -2125,8 +2126,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("Metallurgy:base.ore")'> <OreBlock block='Metallurgy:base.ore' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -2244,8 +2245,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("Metallurgy:base.ore:1")'> <OreBlock block='Metallurgy:base.ore:1' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -2363,8 +2364,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("Metallurgy:base.ore:2")'> <OreBlock block='Metallurgy:base.ore:2' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -2482,8 +2483,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("Metallurgy:precious.ore")'> <OreBlock block='Metallurgy:precious.ore' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -2601,8 +2602,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("Metallurgy:precious.ore:1")'> <OreBlock block='Metallurgy:precious.ore:1' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -2720,8 +2721,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("Metallurgy:precious.ore:2")'> <OreBlock block='Metallurgy:precious.ore:2' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -2839,8 +2840,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore")'> <OreBlock block='Metallurgy:fantasy.ore' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -2958,8 +2959,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:1")'> <OreBlock block='Metallurgy:fantasy.ore:1' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -3077,8 +3078,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:2")'> <OreBlock block='Metallurgy:fantasy.ore:2' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -3196,8 +3197,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:4")'> <OreBlock block='Metallurgy:fantasy.ore:4' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -3316,8 +3317,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:5")'> <OreBlock block='Metallurgy:fantasy.ore:5' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -3435,8 +3436,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:6")'> <OreBlock block='Metallurgy:fantasy.ore:6' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -3554,8 +3555,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:7")'> <OreBlock block='Metallurgy:fantasy.ore:7' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -3673,8 +3674,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:8")'> <OreBlock block='Metallurgy:fantasy.ore:8' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -3792,8 +3793,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:11")'> <OreBlock block='Metallurgy:fantasy.ore:11' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -3911,8 +3912,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:13")'> <OreBlock block='Metallurgy:fantasy.ore:13' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -4030,8 +4031,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:14")'> <OreBlock block='Metallurgy:fantasy.ore:14' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -4086,16 +4087,16 @@
                             must be large  enough to catch all ore
                             clusters (>=  32).
                         </Comment>
-                        <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <Replaces block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:1")'> <Replaces block='Metallurgy:nether.ore:1' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:2")'> <Replaces block='Metallurgy:nether.ore:2' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:3")'> <Replaces block='Metallurgy:nether.ore:3' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:4")'> <Replaces block='Metallurgy:nether.ore:4' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:5")'> <Replaces block='Metallurgy:nether.ore:5' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:6")'> <Replaces block='Metallurgy:nether.ore:6' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:7")'> <Replaces block='Metallurgy:nether.ore:7' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:8")'> <Replaces block='Metallurgy:nether.ore:8' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:9")'> <Replaces block='Metallurgy:nether.ore:9' weight='1.0' /> </IfCondition>
+                        <Replaces block='Metallurgy:nether.ore' weight='1.0' />
+                        <Replaces block='Metallurgy:nether.ore:1' weight='1.0' />
+                        <Replaces block='Metallurgy:nether.ore:2' weight='1.0' />
+                        <Replaces block='Metallurgy:nether.ore:3' weight='1.0' />
+                        <Replaces block='Metallurgy:nether.ore:4' weight='1.0' />
+                        <Replaces block='Metallurgy:nether.ore:5' weight='1.0' />
+                        <Replaces block='Metallurgy:nether.ore:6' weight='1.0' />
+                        <Replaces block='Metallurgy:nether.ore:7' weight='1.0' />
+                        <Replaces block='Metallurgy:nether.ore:8' weight='1.0' />
+                        <Replaces block='Metallurgy:nether.ore:9' weight='1.0' />
                     </Substitute>
                 </IfCondition>
 
@@ -4190,8 +4191,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -4309,8 +4310,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:1")'> <OreBlock block='Metallurgy:nether.ore:1' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -4428,8 +4429,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:2")'> <OreBlock block='Metallurgy:nether.ore:2' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -4547,8 +4548,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:3")'> <OreBlock block='Metallurgy:nether.ore:3' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -4666,8 +4667,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:4")'> <OreBlock block='Metallurgy:nether.ore:4' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -4785,8 +4786,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:5")'> <OreBlock block='Metallurgy:nether.ore:5' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -4904,8 +4905,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:6")'> <OreBlock block='Metallurgy:nether.ore:6' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -5023,8 +5024,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:7")'> <OreBlock block='Metallurgy:nether.ore:7' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -5142,8 +5143,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:8")'> <OreBlock block='Metallurgy:nether.ore:8' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -5261,8 +5262,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:9")'> <OreBlock block='Metallurgy:nether.ore:9' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -5317,8 +5318,8 @@
                             must be large  enough to catch all ore
                             clusters (>=  32).
                         </Comment>
-                        <IfCondition condition=':= ?blockExists("Metallurgy:ender.ore")'> <Replaces block='Metallurgy:ender.ore' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("Metallurgy:ender.ore:1")'> <Replaces block='Metallurgy:ender.ore:1' weight='1.0' /> </IfCondition>
+                        <Replaces block='Metallurgy:ender.ore' weight='1.0' />
+                        <Replaces block='Metallurgy:ender.ore:1' weight='1.0' />
                     </Substitute>
                 </IfCondition>
 
@@ -5413,8 +5414,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("Metallurgy:ender.ore")'> <OreBlock block='Metallurgy:ender.ore' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -5532,8 +5533,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("Metallurgy:ender.ore:1")'> <OreBlock block='Metallurgy:ender.ore:1' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>

--- a/src/main/resources/config/modules/MineChem.xml
+++ b/src/main/resources/config/modules/MineChem.xml
@@ -5,7 +5,7 @@
 
 
 <!-- Minechem includes uranium ore in the case it's installed without
-     IC2 or Atomic Science also installed. -->
+     IC2 or Atomic Science also installed.  Configuration by Reteo. -->
 
 
 
@@ -90,7 +90,7 @@
                             must be large  enough to catch all ore
                             clusters (>=  32).
                         </Comment>
-                        <IfCondition condition=':= ?blockExists("minechem:tile.oreUranium")'> <Replaces block='minechem:tile.oreUranium' weight='1.0' /> </IfCondition>
+                        <Replaces block='minechem:tile.oreUranium' weight='1.0' />
                     </Substitute>
                 </IfCondition>
 
@@ -185,8 +185,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("minechem:tile.oreUranium")'> <OreBlock block='minechem:tile.oreUranium' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>

--- a/src/main/resources/config/modules/MinecraftComesAlive.xml
+++ b/src/main/resources/config/modules/MinecraftComesAlive.xml
@@ -6,7 +6,7 @@
 
 <!-- Minecraft Comes Alive is a mod focusing around villager
      interactions.  However, it does introduce a new ore for "Rose
-     Gold." -->
+     Gold."  Configuration by Reteo. -->
 
 
 
@@ -92,7 +92,7 @@
                             must be large  enough to catch all ore
                             clusters (>=  32).
                         </Comment>
-                        <IfCondition condition=':= ?blockExists("MCA:tile.roseGoldOre")'> <Replaces block='MCA:tile.roseGoldOre' weight='1.0' /> </IfCondition>
+                        <Replaces block='MCA:tile.roseGoldOre' weight='1.0' />
                     </Substitute>
                 </IfCondition>
 
@@ -187,8 +187,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("MCA:tile.roseGoldOre")'> <OreBlock block='MCA:tile.roseGoldOre' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>

--- a/src/main/resources/config/modules/NetherOres.xml
+++ b/src/main/resources/config/modules/NetherOres.xml
@@ -8,6 +8,8 @@
      ================================================================= -->
 
 
+<!-- Provides a huge number of ores to mine from the Nether.
+     Configuration by Reteo. -->
 
 
 
@@ -1147,38 +1149,38 @@
                             must be large  enough to catch all ore
                             clusters (>=  32).
                         </Comment>
-                        <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0")'> <Replaces block='NetherOres:tile.netherores.ore.0' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:1")'> <Replaces block='NetherOres:tile.netherores.ore.0:1' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:10")'> <Replaces block='NetherOres:tile.netherores.ore.0:10' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:11")'> <Replaces block='NetherOres:tile.netherores.ore.0:11' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:12")'> <Replaces block='NetherOres:tile.netherores.ore.0:12' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:13")'> <Replaces block='NetherOres:tile.netherores.ore.0:13' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:14")'> <Replaces block='NetherOres:tile.netherores.ore.0:14' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:15")'> <Replaces block='NetherOres:tile.netherores.ore.0:15' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:2")'> <Replaces block='NetherOres:tile.netherores.ore.0:2' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:3")'> <Replaces block='NetherOres:tile.netherores.ore.0:3' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:4")'> <Replaces block='NetherOres:tile.netherores.ore.0:4' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:5")'> <Replaces block='NetherOres:tile.netherores.ore.0:5' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:6")'> <Replaces block='NetherOres:tile.netherores.ore.0:6' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:7")'> <Replaces block='NetherOres:tile.netherores.ore.0:7' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:8")'> <Replaces block='NetherOres:tile.netherores.ore.0:8' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:9")'> <Replaces block='NetherOres:tile.netherores.ore.0:9' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:0")'> <Replaces block='NetherOres:tile.netherores.ore.1:0' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:1")'> <Replaces block='NetherOres:tile.netherores.ore.1:1' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:10")'> <Replaces block='NetherOres:tile.netherores.ore.1:10' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:11")'> <Replaces block='NetherOres:tile.netherores.ore.1:11' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:12")'> <Replaces block='NetherOres:tile.netherores.ore.1:12' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:13")'> <Replaces block='NetherOres:tile.netherores.ore.1:13' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:14")'> <Replaces block='NetherOres:tile.netherores.ore.1:14' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:15")'> <Replaces block='NetherOres:tile.netherores.ore.1:15' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:2")'> <Replaces block='NetherOres:tile.netherores.ore.1:2' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:3")'> <Replaces block='NetherOres:tile.netherores.ore.1:3' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:4")'> <Replaces block='NetherOres:tile.netherores.ore.1:4' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:5")'> <Replaces block='NetherOres:tile.netherores.ore.1:5' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:6")'> <Replaces block='NetherOres:tile.netherores.ore.1:6' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:7")'> <Replaces block='NetherOres:tile.netherores.ore.1:7' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:8")'> <Replaces block='NetherOres:tile.netherores.ore.1:8' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:9")'> <Replaces block='NetherOres:tile.netherores.ore.1:9' weight='1.0' /> </IfCondition>
+                        <Replaces block='NetherOres:tile.netherores.ore.0' weight='1.0' />
+                        <Replaces block='NetherOres:tile.netherores.ore.0:1' weight='1.0' />
+                        <Replaces block='NetherOres:tile.netherores.ore.0:10' weight='1.0' />
+                        <Replaces block='NetherOres:tile.netherores.ore.0:11' weight='1.0' />
+                        <Replaces block='NetherOres:tile.netherores.ore.0:12' weight='1.0' />
+                        <Replaces block='NetherOres:tile.netherores.ore.0:13' weight='1.0' />
+                        <Replaces block='NetherOres:tile.netherores.ore.0:14' weight='1.0' />
+                        <Replaces block='NetherOres:tile.netherores.ore.0:15' weight='1.0' />
+                        <Replaces block='NetherOres:tile.netherores.ore.0:2' weight='1.0' />
+                        <Replaces block='NetherOres:tile.netherores.ore.0:3' weight='1.0' />
+                        <Replaces block='NetherOres:tile.netherores.ore.0:4' weight='1.0' />
+                        <Replaces block='NetherOres:tile.netherores.ore.0:5' weight='1.0' />
+                        <Replaces block='NetherOres:tile.netherores.ore.0:6' weight='1.0' />
+                        <Replaces block='NetherOres:tile.netherores.ore.0:7' weight='1.0' />
+                        <Replaces block='NetherOres:tile.netherores.ore.0:8' weight='1.0' />
+                        <Replaces block='NetherOres:tile.netherores.ore.0:9' weight='1.0' />
+                        <Replaces block='NetherOres:tile.netherores.ore.1:0' weight='1.0' />
+                        <Replaces block='NetherOres:tile.netherores.ore.1:1' weight='1.0' />
+                        <Replaces block='NetherOres:tile.netherores.ore.1:10' weight='1.0' />
+                        <Replaces block='NetherOres:tile.netherores.ore.1:11' weight='1.0' />
+                        <Replaces block='NetherOres:tile.netherores.ore.1:12' weight='1.0' />
+                        <Replaces block='NetherOres:tile.netherores.ore.1:13' weight='1.0' />
+                        <Replaces block='NetherOres:tile.netherores.ore.1:14' weight='1.0' />
+                        <Replaces block='NetherOres:tile.netherores.ore.1:15' weight='1.0' />
+                        <Replaces block='NetherOres:tile.netherores.ore.1:2' weight='1.0' />
+                        <Replaces block='NetherOres:tile.netherores.ore.1:3' weight='1.0' />
+                        <Replaces block='NetherOres:tile.netherores.ore.1:4' weight='1.0' />
+                        <Replaces block='NetherOres:tile.netherores.ore.1:5' weight='1.0' />
+                        <Replaces block='NetherOres:tile.netherores.ore.1:6' weight='1.0' />
+                        <Replaces block='NetherOres:tile.netherores.ore.1:7' weight='1.0' />
+                        <Replaces block='NetherOres:tile.netherores.ore.1:8' weight='1.0' />
+                        <Replaces block='NetherOres:tile.netherores.ore.1:9' weight='1.0' />
                     </Substitute>
                 </IfCondition>
 
@@ -1204,7 +1206,7 @@
                                 their  direction while mining.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0")'> <OreBlock block='NetherOres:tile.netherores.ore.0' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 4.900 * _default_ * nthoCoalFreq ' range=':= 4.900 * _default_ * nthoCoalFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoCoalSize ' range=':= 0 * _default_ * nthoCoalSize ' type='normal' />
@@ -1246,7 +1248,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0")'> <OreBlock block='NetherOres:tile.netherores.ore.0' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.323 * _default_ * nthoCoalSize ' range=':= 1.323 * _default_ * nthoCoalSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.323 * _default_ * nthoCoalSize ' range=':= 1.323 * _default_ * nthoCoalSize ' type='normal' scaleTo='base' />
@@ -1280,8 +1282,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0")'> <OreBlock block='NetherOres:tile.netherores.ore.0' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1298,7 +1300,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0")'> <OreBlock block='NetherOres:tile.netherores.ore.0' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 16.000 * nthoCoalSize ' range=':= _default_ * nthoCoalSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 8.000 * nthoCoalFreq ' range=':= _default_ * nthoCoalFreq ' type='normal' scaleTo='base' />
@@ -1323,7 +1325,7 @@
                                 up from near the bottom  of the map.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:1")'> <OreBlock block='NetherOres:tile.netherores.ore.0:1' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.935 * _default_ * nthoDiamondFreq ' range=':= 0.935 * _default_ * nthoDiamondFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoDiamondSize ' range=':= 0 * _default_ * nthoDiamondSize ' type='normal' />
@@ -1345,8 +1347,8 @@
                         <!-- Configuring contained material. -->
                         <Veins name='nthoDiamondVeinsPipe'  inherits='nthoDiamondVeins' seed='0xAA9C' drawWireframe='true' wireframeColor='0x608BF4E3' drawBoundBox='false' boundBoxColor='0x608BF4E3'>
                             <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:1")'> <Replaces block='NetherOres:tile.netherores.ore.0:1' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
+                            <Replaces block='NetherOres:tile.netherores.ore.0:1' weight='1.0' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoDiamondSize  * 0.5 ' range=':= 0 * _default_ * nthoDiamondSize  * 0.5 ' type='normal' />
                             <Setting name='SegmentRadius' avg=':= 0.983 * _default_ * nthoDiamondSize  * 0.5 ' range=':= 0.983 * _default_ * nthoDiamondSize  * 0.5 ' type='normal' />
                             <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
@@ -1375,7 +1377,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:1")'> <OreBlock block='NetherOres:tile.netherores.ore.0:1' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.732 * _default_ * nthoDiamondSize ' range=':= 0.732 * _default_ * nthoDiamondSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.732 * _default_ * nthoDiamondSize ' range=':= 0.732 * _default_ * nthoDiamondSize ' type='normal' scaleTo='base' />
@@ -1409,8 +1411,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:1")'> <OreBlock block='NetherOres:tile.netherores.ore.0:1' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1427,7 +1429,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:1")'> <OreBlock block='NetherOres:tile.netherores.ore.0:1' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.000 * nthoDiamondSize ' range=':= _default_ * nthoDiamondSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 4.000 * nthoDiamondFreq ' range=':= _default_ * nthoDiamondFreq ' type='normal' scaleTo='base' />
@@ -1452,7 +1454,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:2")'> <OreBlock block='NetherOres:tile.netherores.ore.0:2' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.226 * _default_ * nthoGoldFreq ' range=':= 1.226 * _default_ * nthoGoldFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.035 * _default_ * nthoGoldSize ' range=':= 1.035 * _default_ * nthoGoldSize ' type='normal' />
@@ -1494,7 +1496,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:2")'> <OreBlock block='NetherOres:tile.netherores.ore.0:2' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.036 * _default_ * nthoGoldSize ' range=':= 1.036 * _default_ * nthoGoldSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.036 * _default_ * nthoGoldSize ' range=':= 1.036 * _default_ * nthoGoldSize ' type='normal' scaleTo='base' />
@@ -1528,8 +1530,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:2")'> <OreBlock block='NetherOres:tile.netherores.ore.0:2' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1546,7 +1548,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:2")'> <OreBlock block='NetherOres:tile.netherores.ore.0:2' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 6.000 * nthoGoldSize ' range=':= _default_ * nthoGoldSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 8.000 * nthoGoldFreq ' range=':= _default_ * nthoGoldFreq ' type='normal' scaleTo='base' />
@@ -1571,7 +1573,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:3")'> <OreBlock block='NetherOres:tile.netherores.ore.0:3' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.416 * _default_ * nthoIronFreq ' range=':= 1.416 * _default_ * nthoIronFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.060 * _default_ * nthoIronSize ' range=':= 1.060 * _default_ * nthoIronSize ' type='normal' />
@@ -1613,7 +1615,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:3")'> <OreBlock block='NetherOres:tile.netherores.ore.0:3' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.113 * _default_ * nthoIronSize ' range=':= 1.113 * _default_ * nthoIronSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.113 * _default_ * nthoIronSize ' range=':= 1.113 * _default_ * nthoIronSize ' type='normal' scaleTo='base' />
@@ -1647,8 +1649,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:3")'> <OreBlock block='NetherOres:tile.netherores.ore.0:3' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1665,7 +1667,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:3")'> <OreBlock block='NetherOres:tile.netherores.ore.0:3' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 8.000 * nthoIronSize ' range=':= _default_ * nthoIronSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 8.000 * nthoIronFreq ' range=':= _default_ * nthoIronFreq ' type='normal' scaleTo='base' />
@@ -1690,7 +1692,7 @@
                                 no motherlodes.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:4")'> <OreBlock block='NetherOres:tile.netherores.ore.0:4' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.929 * _default_ * nthoLapisLazuliFreq ' range=':= 1.929 * _default_ * nthoLapisLazuliFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoLapisLazuliSize ' range=':= 0 * _default_ * nthoLapisLazuliSize ' type='normal' />
@@ -1733,7 +1735,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:4")'> <OreBlock block='NetherOres:tile.netherores.ore.0:4' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.964 * _default_ * nthoLapisLazuliSize ' range=':= 0.964 * _default_ * nthoLapisLazuliSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.964 * _default_ * nthoLapisLazuliSize ' range=':= 0.964 * _default_ * nthoLapisLazuliSize ' type='normal' scaleTo='base' />
@@ -1767,8 +1769,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:4")'> <OreBlock block='NetherOres:tile.netherores.ore.0:4' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1785,7 +1787,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:4")'> <OreBlock block='NetherOres:tile.netherores.ore.0:4' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 6.000 * nthoLapisLazuliSize ' range=':= _default_ * nthoLapisLazuliSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 6.000 * nthoLapisLazuliFreq ' range=':= _default_ * nthoLapisLazuliFreq ' type='normal' scaleTo='base' />
@@ -1810,7 +1812,7 @@
                                 no motherlodes.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:5")'> <OreBlock block='NetherOres:tile.netherores.ore.0:5' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.227 * _default_ * nthoRedstoneFreq ' range=':= 2.227 * _default_ * nthoRedstoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoRedstoneSize ' range=':= 0 * _default_ * nthoRedstoneSize ' type='normal' />
@@ -1852,7 +1854,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:5")'> <OreBlock block='NetherOres:tile.netherores.ore.0:5' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.036 * _default_ * nthoRedstoneSize ' range=':= 1.036 * _default_ * nthoRedstoneSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.036 * _default_ * nthoRedstoneSize ' range=':= 1.036 * _default_ * nthoRedstoneSize ' type='normal' scaleTo='base' />
@@ -1886,8 +1888,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:5")'> <OreBlock block='NetherOres:tile.netherores.ore.0:5' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1904,7 +1906,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:5")'> <OreBlock block='NetherOres:tile.netherores.ore.0:5' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 8.000 * nthoRedstoneSize ' range=':= _default_ * nthoRedstoneSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 6.000 * nthoRedstoneFreq ' range=':= _default_ * nthoRedstoneFreq ' type='normal' scaleTo='base' />
@@ -1929,7 +1931,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:6")'> <OreBlock block='NetherOres:tile.netherores.ore.0:6' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.416 * _default_ * nthoCopperFreq ' range=':= 1.416 * _default_ * nthoCopperFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.060 * _default_ * nthoCopperSize ' range=':= 1.060 * _default_ * nthoCopperSize ' type='normal' />
@@ -1971,7 +1973,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:6")'> <OreBlock block='NetherOres:tile.netherores.ore.0:6' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.113 * _default_ * nthoCopperSize ' range=':= 1.113 * _default_ * nthoCopperSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.113 * _default_ * nthoCopperSize ' range=':= 1.113 * _default_ * nthoCopperSize ' type='normal' scaleTo='base' />
@@ -2005,8 +2007,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:6")'> <OreBlock block='NetherOres:tile.netherores.ore.0:6' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -2023,7 +2025,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:6")'> <OreBlock block='NetherOres:tile.netherores.ore.0:6' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 8.000 * nthoCopperSize ' range=':= _default_ * nthoCopperSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 8.000 * nthoCopperFreq ' range=':= _default_ * nthoCopperFreq ' type='normal' scaleTo='base' />
@@ -2048,7 +2050,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:7")'> <OreBlock block='NetherOres:tile.netherores.ore.0:7' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.416 * _default_ * nthoTinFreq ' range=':= 1.416 * _default_ * nthoTinFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.060 * _default_ * nthoTinSize ' range=':= 1.060 * _default_ * nthoTinSize ' type='normal' />
@@ -2090,7 +2092,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:7")'> <OreBlock block='NetherOres:tile.netherores.ore.0:7' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.113 * _default_ * nthoTinSize ' range=':= 1.113 * _default_ * nthoTinSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.113 * _default_ * nthoTinSize ' range=':= 1.113 * _default_ * nthoTinSize ' type='normal' scaleTo='base' />
@@ -2124,8 +2126,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:7")'> <OreBlock block='NetherOres:tile.netherores.ore.0:7' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -2142,7 +2144,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:7")'> <OreBlock block='NetherOres:tile.netherores.ore.0:7' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 8.000 * nthoTinSize ' range=':= _default_ * nthoTinSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 8.000 * nthoTinFreq ' range=':= _default_ * nthoTinFreq ' type='normal' scaleTo='base' />
@@ -2167,7 +2169,7 @@
                                 up from near the bottom  of the map.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:8")'> <OreBlock block='NetherOres:tile.netherores.ore.0:8' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.661 * _default_ * nthoEmeraldFreq ' range=':= 0.661 * _default_ * nthoEmeraldFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoEmeraldSize ' range=':= 0 * _default_ * nthoEmeraldSize ' type='normal' />
@@ -2189,8 +2191,8 @@
                         <!-- Configuring contained material. -->
                         <Veins name='nthoEmeraldVeinsPipe'  inherits='nthoEmeraldVeins' seed='0x907F' drawWireframe='true' wireframeColor='0x606CE391' drawBoundBox='false' boundBoxColor='0x606CE391'>
                             <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:8")'> <Replaces block='NetherOres:tile.netherores.ore.0:8' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
+                            <Replaces block='NetherOres:tile.netherores.ore.0:8' weight='1.0' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoEmeraldSize  * 0.5 ' range=':= 0 * _default_ * nthoEmeraldSize  * 0.5 ' type='normal' />
                             <Setting name='SegmentRadius' avg=':= 0.902 * _default_ * nthoEmeraldSize  * 0.5 ' range=':= 0.902 * _default_ * nthoEmeraldSize  * 0.5 ' type='normal' />
                             <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
@@ -2219,7 +2221,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:8")'> <OreBlock block='NetherOres:tile.netherores.ore.0:8' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.616 * _default_ * nthoEmeraldSize ' range=':= 0.616 * _default_ * nthoEmeraldSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.616 * _default_ * nthoEmeraldSize ' range=':= 0.616 * _default_ * nthoEmeraldSize ' type='normal' scaleTo='base' />
@@ -2253,8 +2255,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:8")'> <OreBlock block='NetherOres:tile.netherores.ore.0:8' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -2271,7 +2273,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:8")'> <OreBlock block='NetherOres:tile.netherores.ore.0:8' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 2.000 * nthoEmeraldSize ' range=':= _default_ * nthoEmeraldSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 3.000 * nthoEmeraldFreq ' range=':= _default_ * nthoEmeraldFreq ' type='normal' scaleTo='base' />
@@ -2296,7 +2298,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:9")'> <OreBlock block='NetherOres:tile.netherores.ore.0:9' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.867 * _default_ * nthoSilverFreq ' range=':= 0.867 * _default_ * nthoSilverFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.976 * _default_ * nthoSilverSize ' range=':= 0.976 * _default_ * nthoSilverSize ' type='normal' />
@@ -2338,7 +2340,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:9")'> <OreBlock block='NetherOres:tile.netherores.ore.0:9' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.871 * _default_ * nthoSilverSize ' range=':= 0.871 * _default_ * nthoSilverSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.871 * _default_ * nthoSilverSize ' range=':= 0.871 * _default_ * nthoSilverSize ' type='normal' scaleTo='base' />
@@ -2372,8 +2374,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:9")'> <OreBlock block='NetherOres:tile.netherores.ore.0:9' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -2390,7 +2392,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:9")'> <OreBlock block='NetherOres:tile.netherores.ore.0:9' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * nthoSilverSize ' range=':= _default_ * nthoSilverSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 6.000 * nthoSilverFreq ' range=':= _default_ * nthoSilverFreq ' type='normal' scaleTo='base' />
@@ -2415,7 +2417,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:10")'> <OreBlock block='NetherOres:tile.netherores.ore.0:10' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.062 * _default_ * nthoLeadFreq ' range=':= 1.062 * _default_ * nthoLeadFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.010 * _default_ * nthoLeadSize ' range=':= 1.010 * _default_ * nthoLeadSize ' type='normal' />
@@ -2457,7 +2459,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:10")'> <OreBlock block='NetherOres:tile.netherores.ore.0:10' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.964 * _default_ * nthoLeadSize ' range=':= 0.964 * _default_ * nthoLeadSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.964 * _default_ * nthoLeadSize ' range=':= 0.964 * _default_ * nthoLeadSize ' type='normal' scaleTo='base' />
@@ -2491,8 +2493,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:10")'> <OreBlock block='NetherOres:tile.netherores.ore.0:10' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -2509,7 +2511,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:10")'> <OreBlock block='NetherOres:tile.netherores.ore.0:10' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 6.000 * nthoLeadSize ' range=':= _default_ * nthoLeadSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 6.000 * nthoLeadFreq ' range=':= _default_ * nthoLeadFreq ' type='normal' scaleTo='base' />
@@ -2541,7 +2543,7 @@
                                 their  direction while mining.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:11")'> <OreBlock block='NetherOres:tile.netherores.ore.0:11' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.061 * _default_ * nthoUraniumFreq ' range=':= 1.061 * _default_ * nthoUraniumFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoUraniumSize ' range=':= 0 * _default_ * nthoUraniumSize ' type='normal' />
@@ -2583,7 +2585,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:11")'> <OreBlock block='NetherOres:tile.netherores.ore.0:11' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.616 * _default_ * nthoUraniumSize ' range=':= 0.616 * _default_ * nthoUraniumSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.616 * _default_ * nthoUraniumSize ' range=':= 0.616 * _default_ * nthoUraniumSize ' type='normal' scaleTo='base' />
@@ -2617,8 +2619,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:11")'> <OreBlock block='NetherOres:tile.netherores.ore.0:11' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -2635,7 +2637,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:11")'> <OreBlock block='NetherOres:tile.netherores.ore.0:11' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 2.000 * nthoUraniumSize ' range=':= _default_ * nthoUraniumSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 3.000 * nthoUraniumFreq ' range=':= _default_ * nthoUraniumFreq ' type='normal' scaleTo='base' />
@@ -2660,7 +2662,7 @@
                                 no motherlodes.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:12")'> <OreBlock block='NetherOres:tile.netherores.ore.0:12' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.818 * _default_ * nthoNikoliteFreq ' range=':= 1.818 * _default_ * nthoNikoliteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoNikoliteSize ' range=':= 0 * _default_ * nthoNikoliteSize ' type='normal' />
@@ -2702,7 +2704,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:12")'> <OreBlock block='NetherOres:tile.netherores.ore.0:12' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.936 * _default_ * nthoNikoliteSize ' range=':= 0.936 * _default_ * nthoNikoliteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.936 * _default_ * nthoNikoliteSize ' range=':= 0.936 * _default_ * nthoNikoliteSize ' type='normal' scaleTo='base' />
@@ -2736,8 +2738,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:12")'> <OreBlock block='NetherOres:tile.netherores.ore.0:12' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -2754,7 +2756,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:12")'> <OreBlock block='NetherOres:tile.netherores.ore.0:12' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * nthoNikoliteSize ' range=':= _default_ * nthoNikoliteSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 8.000 * nthoNikoliteFreq ' range=':= _default_ * nthoNikoliteFreq ' type='normal' scaleTo='base' />
@@ -2779,7 +2781,7 @@
                                 up from near the bottom  of the map.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:13")'> <OreBlock block='NetherOres:tile.netherores.ore.0:13' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.145 * _default_ * nthoRubyFreq ' range=':= 1.145 * _default_ * nthoRubyFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoRubySize ' range=':= 0 * _default_ * nthoRubySize ' type='normal' />
@@ -2801,8 +2803,8 @@
                         <!-- Configuring contained material. -->
                         <Veins name='nthoRubyVeinsPipe'  inherits='nthoRubyVeins' seed='0xD0DC' drawWireframe='true' wireframeColor='0x60D10415' drawBoundBox='false' boundBoxColor='0x60D10415'>
                             <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:13")'> <Replaces block='NetherOres:tile.netherores.ore.0:13' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
+                            <Replaces block='NetherOres:tile.netherores.ore.0:13' weight='1.0' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoRubySize  * 0.5 ' range=':= 0 * _default_ * nthoRubySize  * 0.5 ' type='normal' />
                             <Setting name='SegmentRadius' avg=':= 1.035 * _default_ * nthoRubySize  * 0.5 ' range=':= 1.035 * _default_ * nthoRubySize  * 0.5 ' type='normal' />
                             <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
@@ -2831,7 +2833,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:13")'> <OreBlock block='NetherOres:tile.netherores.ore.0:13' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.810 * _default_ * nthoRubySize ' range=':= 0.810 * _default_ * nthoRubySize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.810 * _default_ * nthoRubySize ' range=':= 0.810 * _default_ * nthoRubySize ' type='normal' scaleTo='base' />
@@ -2865,8 +2867,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:13")'> <OreBlock block='NetherOres:tile.netherores.ore.0:13' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -2883,7 +2885,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:13")'> <OreBlock block='NetherOres:tile.netherores.ore.0:13' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.000 * nthoRubySize ' range=':= _default_ * nthoRubySize ' type='normal' />
                             <Setting name='Frequency' avg=':= 6.000 * nthoRubyFreq ' range=':= _default_ * nthoRubyFreq ' type='normal' scaleTo='base' />
@@ -2908,7 +2910,7 @@
                                 up from near the bottom  of the map.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:14")'> <OreBlock block='NetherOres:tile.netherores.ore.0:14' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.145 * _default_ * nthoPeridotFreq ' range=':= 1.145 * _default_ * nthoPeridotFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoPeridotSize ' range=':= 0 * _default_ * nthoPeridotSize ' type='normal' />
@@ -2930,8 +2932,8 @@
                         <!-- Configuring contained material. -->
                         <Veins name='nthoPeridotVeinsPipe'  inherits='nthoPeridotVeins' seed='0x6CA7' drawWireframe='true' wireframeColor='0x6054A228' drawBoundBox='false' boundBoxColor='0x6054A228'>
                             <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:14")'> <Replaces block='NetherOres:tile.netherores.ore.0:14' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
+                            <Replaces block='NetherOres:tile.netherores.ore.0:14' weight='1.0' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoPeridotSize  * 0.5 ' range=':= 0 * _default_ * nthoPeridotSize  * 0.5 ' type='normal' />
                             <Setting name='SegmentRadius' avg=':= 1.035 * _default_ * nthoPeridotSize  * 0.5 ' range=':= 1.035 * _default_ * nthoPeridotSize  * 0.5 ' type='normal' />
                             <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
@@ -2960,7 +2962,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:14")'> <OreBlock block='NetherOres:tile.netherores.ore.0:14' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.810 * _default_ * nthoPeridotSize ' range=':= 0.810 * _default_ * nthoPeridotSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.810 * _default_ * nthoPeridotSize ' range=':= 0.810 * _default_ * nthoPeridotSize ' type='normal' scaleTo='base' />
@@ -2994,8 +2996,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:14")'> <OreBlock block='NetherOres:tile.netherores.ore.0:14' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -3012,7 +3014,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:14")'> <OreBlock block='NetherOres:tile.netherores.ore.0:14' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.000 * nthoPeridotSize ' range=':= _default_ * nthoPeridotSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 6.000 * nthoPeridotFreq ' range=':= _default_ * nthoPeridotFreq ' type='normal' scaleTo='base' />
@@ -3037,7 +3039,7 @@
                                 up from near the bottom  of the map.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:15")'> <OreBlock block='NetherOres:tile.netherores.ore.0:15' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.145 * _default_ * nthoSapphireFreq ' range=':= 1.145 * _default_ * nthoSapphireFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoSapphireSize ' range=':= 0 * _default_ * nthoSapphireSize ' type='normal' />
@@ -3059,8 +3061,8 @@
                         <!-- Configuring contained material. -->
                         <Veins name='nthoSapphireVeinsPipe'  inherits='nthoSapphireVeins' seed='0x83DD' drawWireframe='true' wireframeColor='0x60554DB4' drawBoundBox='false' boundBoxColor='0x60554DB4'>
                             <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:15")'> <Replaces block='NetherOres:tile.netherores.ore.0:15' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
+                            <Replaces block='NetherOres:tile.netherores.ore.0:15' weight='1.0' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoSapphireSize  * 0.5 ' range=':= 0 * _default_ * nthoSapphireSize  * 0.5 ' type='normal' />
                             <Setting name='SegmentRadius' avg=':= 1.035 * _default_ * nthoSapphireSize  * 0.5 ' range=':= 1.035 * _default_ * nthoSapphireSize  * 0.5 ' type='normal' />
                             <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
@@ -3089,7 +3091,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:15")'> <OreBlock block='NetherOres:tile.netherores.ore.0:15' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.810 * _default_ * nthoSapphireSize ' range=':= 0.810 * _default_ * nthoSapphireSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.810 * _default_ * nthoSapphireSize ' range=':= 0.810 * _default_ * nthoSapphireSize ' type='normal' scaleTo='base' />
@@ -3123,8 +3125,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:15")'> <OreBlock block='NetherOres:tile.netherores.ore.0:15' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -3141,7 +3143,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:15")'> <OreBlock block='NetherOres:tile.netherores.ore.0:15' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.000 * nthoSapphireSize ' range=':= _default_ * nthoSapphireSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 6.000 * nthoSapphireFreq ' range=':= _default_ * nthoSapphireFreq ' type='normal' scaleTo='base' />
@@ -3166,7 +3168,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:0")'> <OreBlock block='NetherOres:tile.netherores.ore.1:0' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.306 * _default_ * nthoPlatinumFreq ' range=':= 0.306 * _default_ * nthoPlatinumFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.821 * _default_ * nthoPlatinumSize ' range=':= 0.821 * _default_ * nthoPlatinumSize ' type='normal' />
@@ -3208,7 +3210,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:0")'> <OreBlock block='NetherOres:tile.netherores.ore.1:0' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.518 * _default_ * nthoPlatinumSize ' range=':= 0.518 * _default_ * nthoPlatinumSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.518 * _default_ * nthoPlatinumSize ' range=':= 0.518 * _default_ * nthoPlatinumSize ' type='normal' scaleTo='base' />
@@ -3242,8 +3244,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:0")'> <OreBlock block='NetherOres:tile.netherores.ore.1:0' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -3260,7 +3262,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:0")'> <OreBlock block='NetherOres:tile.netherores.ore.1:0' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.000 * nthoPlatinumSize ' range=':= _default_ * nthoPlatinumSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 1.000 * nthoPlatinumFreq ' range=':= _default_ * nthoPlatinumFreq ' type='normal' scaleTo='base' />
@@ -3285,7 +3287,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:1")'> <OreBlock block='NetherOres:tile.netherores.ore.1:1' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.867 * _default_ * nthoNickelFreq ' range=':= 0.867 * _default_ * nthoNickelFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.976 * _default_ * nthoNickelSize ' range=':= 0.976 * _default_ * nthoNickelSize ' type='normal' />
@@ -3327,7 +3329,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:1")'> <OreBlock block='NetherOres:tile.netherores.ore.1:1' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.871 * _default_ * nthoNickelSize ' range=':= 0.871 * _default_ * nthoNickelSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.871 * _default_ * nthoNickelSize ' range=':= 0.871 * _default_ * nthoNickelSize ' type='normal' scaleTo='base' />
@@ -3361,8 +3363,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:1")'> <OreBlock block='NetherOres:tile.netherores.ore.1:1' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -3379,7 +3381,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:1")'> <OreBlock block='NetherOres:tile.netherores.ore.1:1' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 6.000 * nthoNickelSize ' range=':= _default_ * nthoNickelSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 4.000 * nthoNickelFreq ' range=':= _default_ * nthoNickelFreq ' type='normal' scaleTo='base' />
@@ -3404,7 +3406,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:2")'> <OreBlock block='NetherOres:tile.netherores.ore.1:2' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.613 * _default_ * nthoSteelFreq ' range=':= 0.613 * _default_ * nthoSteelFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * nthoSteelSize ' range=':= 0.922 * _default_ * nthoSteelSize ' type='normal' />
@@ -3446,7 +3448,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:2")'> <OreBlock block='NetherOres:tile.netherores.ore.1:2' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.732 * _default_ * nthoSteelSize ' range=':= 0.732 * _default_ * nthoSteelSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.732 * _default_ * nthoSteelSize ' range=':= 0.732 * _default_ * nthoSteelSize ' type='normal' scaleTo='base' />
@@ -3480,8 +3482,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:2")'> <OreBlock block='NetherOres:tile.netherores.ore.1:2' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -3498,7 +3500,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:2")'> <OreBlock block='NetherOres:tile.netherores.ore.1:2' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * nthoSteelSize ' range=':= _default_ * nthoSteelSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 3.000 * nthoSteelFreq ' range=':= _default_ * nthoSteelFreq ' type='normal' scaleTo='base' />
@@ -3525,7 +3527,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:3")'> <OreBlock block='NetherOres:tile.netherores.ore.1:3' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.313 * _default_ * nthoIridiumFreq ' range=':= 0.313 * _default_ * nthoIridiumFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.824 * _default_ * nthoIridiumSize ' range=':= 0.824 * _default_ * nthoIridiumSize ' type='normal' />
@@ -3567,7 +3569,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:3")'> <OreBlock block='NetherOres:tile.netherores.ore.1:3' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.468 * _default_ * nthoIridiumSize ' range=':= 0.468 * _default_ * nthoIridiumSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.468 * _default_ * nthoIridiumSize ' range=':= 0.468 * _default_ * nthoIridiumSize ' type='normal' scaleTo='base' />
@@ -3601,8 +3603,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:3")'> <OreBlock block='NetherOres:tile.netherores.ore.1:3' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -3619,7 +3621,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:3")'> <OreBlock block='NetherOres:tile.netherores.ore.1:3' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 2.000 * nthoIridiumSize ' range=':= _default_ * nthoIridiumSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 1.000 * nthoIridiumFreq ' range=':= _default_ * nthoIridiumFreq ' type='normal' scaleTo='base' />
@@ -3644,7 +3646,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:4")'> <OreBlock block='NetherOres:tile.netherores.ore.1:4' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.324 * _default_ * nthoOsmiumFreq ' range=':= 1.324 * _default_ * nthoOsmiumFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.048 * _default_ * nthoOsmiumSize ' range=':= 1.048 * _default_ * nthoOsmiumSize ' type='normal' />
@@ -3686,7 +3688,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:4")'> <OreBlock block='NetherOres:tile.netherores.ore.1:4' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.076 * _default_ * nthoOsmiumSize ' range=':= 1.076 * _default_ * nthoOsmiumSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.076 * _default_ * nthoOsmiumSize ' range=':= 1.076 * _default_ * nthoOsmiumSize ' type='normal' scaleTo='base' />
@@ -3720,8 +3722,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:4")'> <OreBlock block='NetherOres:tile.netherores.ore.1:4' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -3738,7 +3740,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:4")'> <OreBlock block='NetherOres:tile.netherores.ore.1:4' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 7.000 * nthoOsmiumSize ' range=':= _default_ * nthoOsmiumSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 8.000 * nthoOsmiumFreq ' range=':= _default_ * nthoOsmiumFreq ' type='normal' scaleTo='base' />
@@ -3763,7 +3765,7 @@
                                 up from near the bottom  of the map.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:5")'> <OreBlock block='NetherOres:tile.netherores.ore.1:5' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 3.240 * _default_ * nthoSulfurFreq ' range=':= 3.240 * _default_ * nthoSulfurFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoSulfurSize ' range=':= 0 * _default_ * nthoSulfurSize ' type='normal' />
@@ -3785,8 +3787,8 @@
                         <!-- Configuring contained material. -->
                         <Veins name='nthoSulfurVeinsPipe'  inherits='nthoSulfurVeins' seed='0xCB5E' drawWireframe='true' wireframeColor='0x60FDFD11' drawBoundBox='false' boundBoxColor='0x60FDFD11'>
                             <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:5")'> <Replaces block='NetherOres:tile.netherores.ore.1:5' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
+                            <Replaces block='NetherOres:tile.netherores.ore.1:5' weight='1.0' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoSulfurSize  * 0.5 ' range=':= 0 * _default_ * nthoSulfurSize  * 0.5 ' type='normal' />
                             <Setting name='SegmentRadius' avg=':= 1.342 * _default_ * nthoSulfurSize  * 0.5 ' range=':= 1.342 * _default_ * nthoSulfurSize  * 0.5 ' type='normal' />
                             <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
@@ -3815,7 +3817,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:5")'> <OreBlock block='NetherOres:tile.netherores.ore.1:5' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.363 * _default_ * nthoSulfurSize ' range=':= 1.363 * _default_ * nthoSulfurSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.363 * _default_ * nthoSulfurSize ' range=':= 1.363 * _default_ * nthoSulfurSize ' type='normal' scaleTo='base' />
@@ -3849,8 +3851,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:5")'> <OreBlock block='NetherOres:tile.netherores.ore.1:5' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -3867,7 +3869,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:5")'> <OreBlock block='NetherOres:tile.netherores.ore.1:5' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 12.000 * nthoSulfurSize ' range=':= _default_ * nthoSulfurSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 12.000 * nthoSulfurFreq ' range=':= _default_ * nthoSulfurFreq ' type='normal' scaleTo='base' />
@@ -3892,7 +3894,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:6")'> <OreBlock block='NetherOres:tile.netherores.ore.1:6' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.433 * _default_ * nthoTitaniumFreq ' range=':= 0.433 * _default_ * nthoTitaniumFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.870 * _default_ * nthoTitaniumSize ' range=':= 0.870 * _default_ * nthoTitaniumSize ' type='normal' />
@@ -3934,7 +3936,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:6")'> <OreBlock block='NetherOres:tile.netherores.ore.1:6' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.616 * _default_ * nthoTitaniumSize ' range=':= 0.616 * _default_ * nthoTitaniumSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.616 * _default_ * nthoTitaniumSize ' range=':= 0.616 * _default_ * nthoTitaniumSize ' type='normal' scaleTo='base' />
@@ -3968,8 +3970,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:6")'> <OreBlock block='NetherOres:tile.netherores.ore.1:6' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -3986,7 +3988,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:6")'> <OreBlock block='NetherOres:tile.netherores.ore.1:6' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 2.000 * nthoTitaniumSize ' range=':= _default_ * nthoTitaniumSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 3.000 * nthoTitaniumFreq ' range=':= _default_ * nthoTitaniumFreq ' type='normal' scaleTo='base' />
@@ -4011,7 +4013,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:7")'> <OreBlock block='NetherOres:tile.netherores.ore.1:7' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.062 * _default_ * nthoMithrilFreq ' range=':= 1.062 * _default_ * nthoMithrilFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.010 * _default_ * nthoMithrilSize ' range=':= 1.010 * _default_ * nthoMithrilSize ' type='normal' />
@@ -4053,7 +4055,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:7")'> <OreBlock block='NetherOres:tile.netherores.ore.1:7' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.964 * _default_ * nthoMithrilSize ' range=':= 0.964 * _default_ * nthoMithrilSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.964 * _default_ * nthoMithrilSize ' range=':= 0.964 * _default_ * nthoMithrilSize ' type='normal' scaleTo='base' />
@@ -4087,8 +4089,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:7")'> <OreBlock block='NetherOres:tile.netherores.ore.1:7' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -4105,7 +4107,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:7")'> <OreBlock block='NetherOres:tile.netherores.ore.1:7' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 6.000 * nthoMithrilSize ' range=':= _default_ * nthoMithrilSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 6.000 * nthoMithrilFreq ' range=':= _default_ * nthoMithrilFreq ' type='normal' scaleTo='base' />
@@ -4130,7 +4132,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:8")'> <OreBlock block='NetherOres:tile.netherores.ore.1:8' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.791 * _default_ * nthoAdamantiumFreq ' range=':= 0.791 * _default_ * nthoAdamantiumFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.962 * _default_ * nthoAdamantiumSize ' range=':= 0.962 * _default_ * nthoAdamantiumSize ' type='normal' />
@@ -4172,7 +4174,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:8")'> <OreBlock block='NetherOres:tile.netherores.ore.1:8' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.832 * _default_ * nthoAdamantiumSize ' range=':= 0.832 * _default_ * nthoAdamantiumSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.832 * _default_ * nthoAdamantiumSize ' range=':= 0.832 * _default_ * nthoAdamantiumSize ' type='normal' scaleTo='base' />
@@ -4206,8 +4208,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:8")'> <OreBlock block='NetherOres:tile.netherores.ore.1:8' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -4224,7 +4226,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:8")'> <OreBlock block='NetherOres:tile.netherores.ore.1:8' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * nthoAdamantiumSize ' range=':= _default_ * nthoAdamantiumSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 5.000 * nthoAdamantiumFreq ' range=':= _default_ * nthoAdamantiumFreq ' type='normal' scaleTo='base' />
@@ -4249,7 +4251,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:9")'> <OreBlock block='NetherOres:tile.netherores.ore.1:9' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.613 * _default_ * nthoRutileFreq ' range=':= 0.613 * _default_ * nthoRutileFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * nthoRutileSize ' range=':= 0.922 * _default_ * nthoRutileSize ' type='normal' />
@@ -4291,7 +4293,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:9")'> <OreBlock block='NetherOres:tile.netherores.ore.1:9' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.732 * _default_ * nthoRutileSize ' range=':= 0.732 * _default_ * nthoRutileSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.732 * _default_ * nthoRutileSize ' range=':= 0.732 * _default_ * nthoRutileSize ' type='normal' scaleTo='base' />
@@ -4325,8 +4327,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:9")'> <OreBlock block='NetherOres:tile.netherores.ore.1:9' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -4343,7 +4345,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:9")'> <OreBlock block='NetherOres:tile.netherores.ore.1:9' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * nthoRutileSize ' range=':= _default_ * nthoRutileSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 3.000 * nthoRutileFreq ' range=':= _default_ * nthoRutileFreq ' type='normal' scaleTo='base' />
@@ -4368,7 +4370,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:10")'> <OreBlock block='NetherOres:tile.netherores.ore.1:10' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.416 * _default_ * nthoTungstenFreq ' range=':= 1.416 * _default_ * nthoTungstenFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.060 * _default_ * nthoTungstenSize ' range=':= 1.060 * _default_ * nthoTungstenSize ' type='normal' />
@@ -4410,7 +4412,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:10")'> <OreBlock block='NetherOres:tile.netherores.ore.1:10' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.113 * _default_ * nthoTungstenSize ' range=':= 1.113 * _default_ * nthoTungstenSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.113 * _default_ * nthoTungstenSize ' range=':= 1.113 * _default_ * nthoTungstenSize ' type='normal' scaleTo='base' />
@@ -4444,8 +4446,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:10")'> <OreBlock block='NetherOres:tile.netherores.ore.1:10' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -4462,7 +4464,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:10")'> <OreBlock block='NetherOres:tile.netherores.ore.1:10' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 8.000 * nthoTungstenSize ' range=':= _default_ * nthoTungstenSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 8.000 * nthoTungstenFreq ' range=':= _default_ * nthoTungstenFreq ' type='normal' scaleTo='base' />
@@ -4494,7 +4496,7 @@
                                 their  direction while mining.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:11")'> <OreBlock block='NetherOres:tile.netherores.ore.1:11' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.372 * _default_ * nthoAmberFreq ' range=':= 2.372 * _default_ * nthoAmberFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoAmberSize ' range=':= 0 * _default_ * nthoAmberSize ' type='normal' />
@@ -4536,7 +4538,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:11")'> <OreBlock block='NetherOres:tile.netherores.ore.1:11' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.921 * _default_ * nthoAmberSize ' range=':= 0.921 * _default_ * nthoAmberSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.921 * _default_ * nthoAmberSize ' range=':= 0.921 * _default_ * nthoAmberSize ' type='normal' scaleTo='base' />
@@ -4570,8 +4572,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:11")'> <OreBlock block='NetherOres:tile.netherores.ore.1:11' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -4588,7 +4590,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:11")'> <OreBlock block='NetherOres:tile.netherores.ore.1:11' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 6.000 * nthoAmberSize ' range=':= _default_ * nthoAmberSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 5.000 * nthoAmberFreq ' range=':= _default_ * nthoAmberFreq ' type='normal' scaleTo='base' />
@@ -4613,7 +4615,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:12")'> <OreBlock block='NetherOres:tile.netherores.ore.1:12' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.416 * _default_ * nthoTennantiteFreq ' range=':= 1.416 * _default_ * nthoTennantiteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.060 * _default_ * nthoTennantiteSize ' range=':= 1.060 * _default_ * nthoTennantiteSize ' type='normal' />
@@ -4655,7 +4657,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:12")'> <OreBlock block='NetherOres:tile.netherores.ore.1:12' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.113 * _default_ * nthoTennantiteSize ' range=':= 1.113 * _default_ * nthoTennantiteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.113 * _default_ * nthoTennantiteSize ' range=':= 1.113 * _default_ * nthoTennantiteSize ' type='normal' scaleTo='base' />
@@ -4689,8 +4691,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:12")'> <OreBlock block='NetherOres:tile.netherores.ore.1:12' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -4707,7 +4709,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:12")'> <OreBlock block='NetherOres:tile.netherores.ore.1:12' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 8.000 * nthoTennantiteSize ' range=':= _default_ * nthoTennantiteSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 8.000 * nthoTennantiteFreq ' range=':= _default_ * nthoTennantiteFreq ' type='normal' scaleTo='base' />
@@ -4739,7 +4741,7 @@
                                 their  direction while mining.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:13")'> <OreBlock block='NetherOres:tile.netherores.ore.1:13' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.166 * _default_ * nthoSaltFreq ' range=':= 2.166 * _default_ * nthoSaltFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoSaltSize ' range=':= 0 * _default_ * nthoSaltSize ' type='normal' />
@@ -4781,7 +4783,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:13")'> <OreBlock block='NetherOres:tile.netherores.ore.1:13' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.880 * _default_ * nthoSaltSize ' range=':= 0.880 * _default_ * nthoSaltSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.880 * _default_ * nthoSaltSize ' range=':= 0.880 * _default_ * nthoSaltSize ' type='normal' scaleTo='base' />
@@ -4815,8 +4817,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:13")'> <OreBlock block='NetherOres:tile.netherores.ore.1:13' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -4833,7 +4835,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:13")'> <OreBlock block='NetherOres:tile.netherores.ore.1:13' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 5.000 * nthoSaltSize ' range=':= _default_ * nthoSaltSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 5.000 * nthoSaltFreq ' range=':= _default_ * nthoSaltFreq ' type='normal' scaleTo='base' />
@@ -4865,7 +4867,7 @@
                                 their  direction while mining.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:14")'> <OreBlock block='NetherOres:tile.netherores.ore.1:14' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.122 * _default_ * nthoSaltpeterFreq ' range=':= 2.122 * _default_ * nthoSaltpeterFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoSaltpeterSize ' range=':= 0 * _default_ * nthoSaltpeterSize ' type='normal' />
@@ -4907,7 +4909,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:14")'> <OreBlock block='NetherOres:tile.netherores.ore.1:14' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.871 * _default_ * nthoSaltpeterSize ' range=':= 0.871 * _default_ * nthoSaltpeterSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.871 * _default_ * nthoSaltpeterSize ' range=':= 0.871 * _default_ * nthoSaltpeterSize ' type='normal' scaleTo='base' />
@@ -4941,8 +4943,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:14")'> <OreBlock block='NetherOres:tile.netherores.ore.1:14' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -4959,7 +4961,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:14")'> <OreBlock block='NetherOres:tile.netherores.ore.1:14' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * nthoSaltpeterSize ' range=':= _default_ * nthoSaltpeterSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 6.000 * nthoSaltpeterFreq ' range=':= _default_ * nthoSaltpeterFreq ' type='normal' scaleTo='base' />
@@ -4991,7 +4993,7 @@
                                 their  direction while mining.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:15")'> <OreBlock block='NetherOres:tile.netherores.ore.1:15' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.937 * _default_ * nthoMagnesiumFreq ' range=':= 1.937 * _default_ * nthoMagnesiumFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoMagnesiumSize ' range=':= 0 * _default_ * nthoMagnesiumSize ' type='normal' />
@@ -5033,7 +5035,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:15")'> <OreBlock block='NetherOres:tile.netherores.ore.1:15' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.832 * _default_ * nthoMagnesiumSize ' range=':= 0.832 * _default_ * nthoMagnesiumSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.832 * _default_ * nthoMagnesiumSize ' range=':= 0.832 * _default_ * nthoMagnesiumSize ' type='normal' scaleTo='base' />
@@ -5067,8 +5069,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:15")'> <OreBlock block='NetherOres:tile.netherores.ore.1:15' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -5085,7 +5087,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:15")'> <OreBlock block='NetherOres:tile.netherores.ore.1:15' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 5.000 * nthoMagnesiumSize ' range=':= _default_ * nthoMagnesiumSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 4.000 * nthoMagnesiumFreq ' range=':= _default_ * nthoMagnesiumFreq ' type='normal' scaleTo='base' />

--- a/src/main/resources/config/modules/Netherrocks.xml
+++ b/src/main/resources/config/modules/Netherrocks.xml
@@ -5,6 +5,8 @@
      ================================================================= -->
 
 
+<!-- Adds a few additional ores for the Nether. Configuration by
+     Reteo. -->
 
 
 
@@ -250,7 +252,7 @@
                             must be large  enough to catch all ore
                             clusters (>=  32).
                         </Comment>
-                        <IfCondition condition=':= ?blockExists("netherrocks:illumenite_ore")'> <Replaces block='netherrocks:illumenite_ore' weight='1.0' /> </IfCondition>
+                        <Replaces block='netherrocks:illumenite_ore' weight='1.0' />
                     </Substitute>
                 </IfCondition>
 
@@ -265,11 +267,11 @@
                             must be large  enough to catch all ore
                             clusters (>=  32).
                         </Comment>
-                        <IfCondition condition=':= ?blockExists("netherrocks:argonite_ore")'> <Replaces block='netherrocks:argonite_ore' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("netherrocks:ashstone_ore")'> <Replaces block='netherrocks:ashstone_ore' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("netherrocks:dragonstone_ore")'> <Replaces block='netherrocks:dragonstone_ore' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("netherrocks:fyrite_ore")'> <Replaces block='netherrocks:fyrite_ore' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("netherrocks:malachite_ore")'> <Replaces block='netherrocks:malachite_ore' weight='1.0' /> </IfCondition>
+                        <Replaces block='netherrocks:argonite_ore' weight='1.0' />
+                        <Replaces block='netherrocks:ashstone_ore' weight='1.0' />
+                        <Replaces block='netherrocks:dragonstone_ore' weight='1.0' />
+                        <Replaces block='netherrocks:fyrite_ore' weight='1.0' />
+                        <Replaces block='netherrocks:malachite_ore' weight='1.0' />
                     </Substitute>
                 </IfCondition>
 
@@ -288,7 +290,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("netherrocks:fyrite_ore")'> <OreBlock block='netherrocks:fyrite_ore' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.371 * _default_ * nthrFyriteFreq ' range=':= 1.371 * _default_ * nthrFyriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.054 * _default_ * nthrFyriteSize ' range=':= 1.054 * _default_ * nthrFyriteSize ' type='normal' />
@@ -330,7 +332,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("netherrocks:fyrite_ore")'> <OreBlock block='netherrocks:fyrite_ore' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.095 * _default_ * nthrFyriteSize ' range=':= 1.095 * _default_ * nthrFyriteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.095 * _default_ * nthrFyriteSize ' range=':= 1.095 * _default_ * nthrFyriteSize ' type='normal' scaleTo='base' />
@@ -364,8 +366,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("netherrocks:fyrite_ore")'> <OreBlock block='netherrocks:fyrite_ore' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -382,7 +384,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("netherrocks:fyrite_ore")'> <OreBlock block='netherrocks:fyrite_ore' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 6.000 * nthrFyriteSize ' range=':= _default_ * nthrFyriteSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 10.000 * nthrFyriteFreq ' range=':= _default_ * nthrFyriteFreq ' type='normal' scaleTo='base' />
@@ -407,7 +409,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("netherrocks:malachite_ore")'> <OreBlock block='netherrocks:malachite_ore' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.480 * _default_ * nthrMalachiteFreq ' range=':= 1.480 * _default_ * nthrMalachiteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.068 * _default_ * nthrMalachiteSize ' range=':= 1.068 * _default_ * nthrMalachiteSize ' type='normal' />
@@ -449,7 +451,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("netherrocks:malachite_ore")'> <OreBlock block='netherrocks:malachite_ore' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.138 * _default_ * nthrMalachiteSize ' range=':= 1.138 * _default_ * nthrMalachiteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.138 * _default_ * nthrMalachiteSize ' range=':= 1.138 * _default_ * nthrMalachiteSize ' type='normal' scaleTo='base' />
@@ -483,8 +485,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("netherrocks:malachite_ore")'> <OreBlock block='netherrocks:malachite_ore' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -501,7 +503,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("netherrocks:malachite_ore")'> <OreBlock block='netherrocks:malachite_ore' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 7.000 * nthrMalachiteSize ' range=':= _default_ * nthrMalachiteSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 10.000 * nthrMalachiteFreq ' range=':= _default_ * nthrMalachiteFreq ' type='normal' scaleTo='base' />
@@ -526,7 +528,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("netherrocks:ashstone_ore")'> <OreBlock block='netherrocks:ashstone_ore' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.251 * _default_ * nthrAshtoneFreq ' range=':= 1.251 * _default_ * nthrAshtoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.038 * _default_ * nthrAshtoneSize ' range=':= 1.038 * _default_ * nthrAshtoneSize ' type='normal' />
@@ -568,7 +570,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("netherrocks:ashstone_ore")'> <OreBlock block='netherrocks:ashstone_ore' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.046 * _default_ * nthrAshtoneSize ' range=':= 1.046 * _default_ * nthrAshtoneSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.046 * _default_ * nthrAshtoneSize ' range=':= 1.046 * _default_ * nthrAshtoneSize ' type='normal' scaleTo='base' />
@@ -602,8 +604,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("netherrocks:ashstone_ore")'> <OreBlock block='netherrocks:ashstone_ore' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -620,7 +622,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("netherrocks:ashstone_ore")'> <OreBlock block='netherrocks:ashstone_ore' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 5.000 * nthrAshtoneSize ' range=':= _default_ * nthrAshtoneSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 10.000 * nthrAshtoneFreq ' range=':= _default_ * nthrAshtoneFreq ' type='normal' scaleTo='base' />
@@ -645,7 +647,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("netherrocks:illumenite_ore")'> <OreBlock block='netherrocks:illumenite_ore' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:glowstone")'> <Replaces block='minecraft:glowstone' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:glowstone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 15.000 * nthrIllumeniteSize ' range=':= _default_ * nthrIllumeniteSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 350.000 * nthrIllumeniteFreq ' range=':= _default_ * nthrIllumeniteFreq ' type='normal' scaleTo='base' />
@@ -670,7 +672,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("netherrocks:dragonstone_ore")'> <OreBlock block='netherrocks:dragonstone_ore' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * nthrDragonstoneFreq ' range=':= 0.969 * _default_ * nthrDragonstoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.995 * _default_ * nthrDragonstoneSize ' range=':= 0.995 * _default_ * nthrDragonstoneSize ' type='normal' />
@@ -712,7 +714,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("netherrocks:dragonstone_ore")'> <OreBlock block='netherrocks:dragonstone_ore' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.921 * _default_ * nthrDragonstoneSize ' range=':= 0.921 * _default_ * nthrDragonstoneSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.921 * _default_ * nthrDragonstoneSize ' range=':= 0.921 * _default_ * nthrDragonstoneSize ' type='normal' scaleTo='base' />
@@ -746,8 +748,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("netherrocks:dragonstone_ore")'> <OreBlock block='netherrocks:dragonstone_ore' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -764,7 +766,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("netherrocks:dragonstone_ore")'> <OreBlock block='netherrocks:dragonstone_ore' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 5.000 * nthrDragonstoneSize ' range=':= _default_ * nthrDragonstoneSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 6.000 * nthrDragonstoneFreq ' range=':= _default_ * nthrDragonstoneFreq ' type='normal' scaleTo='base' />
@@ -789,7 +791,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("netherrocks:argonite_ore")'> <OreBlock block='netherrocks:argonite_ore' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.371 * _default_ * nthrArgoniteFreq ' range=':= 1.371 * _default_ * nthrArgoniteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.054 * _default_ * nthrArgoniteSize ' range=':= 1.054 * _default_ * nthrArgoniteSize ' type='normal' />
@@ -831,7 +833,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("netherrocks:argonite_ore")'> <OreBlock block='netherrocks:argonite_ore' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.095 * _default_ * nthrArgoniteSize ' range=':= 1.095 * _default_ * nthrArgoniteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.095 * _default_ * nthrArgoniteSize ' range=':= 1.095 * _default_ * nthrArgoniteSize ' type='normal' scaleTo='base' />
@@ -865,8 +867,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("netherrocks:argonite_ore")'> <OreBlock block='netherrocks:argonite_ore' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -883,7 +885,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("netherrocks:argonite_ore")'> <OreBlock block='netherrocks:argonite_ore' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 6.000 * nthrArgoniteSize ' range=':= _default_ * nthrArgoniteSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 10.000 * nthrArgoniteFreq ' range=':= _default_ * nthrArgoniteFreq ' type='normal' scaleTo='base' />

--- a/src/main/resources/config/modules/PamsHarvestCraft.xml
+++ b/src/main/resources/config/modules/PamsHarvestCraft.xml
@@ -4,6 +4,9 @@
      ================================================================= -->
 
 
+<!-- A mod centered around the farming and collection of crops, and
+     the extensive arrays of edible recipes you can make from them.
+     Oregen is for salt. Configuration by Reteo. -->
 
 
 
@@ -88,7 +91,7 @@
                             must be large  enough to catch all ore
                             clusters (>=  32).
                         </Comment>
-                        <IfCondition condition=':= ?blockExists("harvestcraft:salt")'> <Replaces block='harvestcraft:salt' weight='1.0' /> </IfCondition>
+                        <Replaces block='harvestcraft:salt' weight='1.0' />
                     </Substitute>
                 </IfCondition>
 
@@ -190,8 +193,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("harvestcraft:salt")'> <OreBlock block='harvestcraft:salt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>

--- a/src/main/resources/config/modules/ProjectRed.xml
+++ b/src/main/resources/config/modules/ProjectRed.xml
@@ -5,6 +5,8 @@
      ================================================================= -->
 
 
+<!-- Project Red adds a lot of redstone logic, as well as several
+     other materials.  Configuration by Reteo. -->
 
 
 
@@ -327,14 +329,14 @@
                             must be large  enough to catch all ore
                             clusters (>=  32).
                         </Comment>
-                        <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore")'> <Replaces block='ProjRed|Exploration:projectred.exploration.ore' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:1")'> <Replaces block='ProjRed|Exploration:projectred.exploration.ore:1' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:2")'> <Replaces block='ProjRed|Exploration:projectred.exploration.ore:2' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:3")'> <Replaces block='ProjRed|Exploration:projectred.exploration.ore:3' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:4")'> <Replaces block='ProjRed|Exploration:projectred.exploration.ore:4' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:5")'> <Replaces block='ProjRed|Exploration:projectred.exploration.ore:5' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:6")'> <Replaces block='ProjRed|Exploration:projectred.exploration.ore:6' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.stone")'> <Replaces block='ProjRed|Exploration:projectred.exploration.stone' weight='1.0' /> </IfCondition>
+                        <Replaces block='ProjRed|Exploration:projectred.exploration.ore' weight='1.0' />
+                        <Replaces block='ProjRed|Exploration:projectred.exploration.ore:1' weight='1.0' />
+                        <Replaces block='ProjRed|Exploration:projectred.exploration.ore:2' weight='1.0' />
+                        <Replaces block='ProjRed|Exploration:projectred.exploration.ore:3' weight='1.0' />
+                        <Replaces block='ProjRed|Exploration:projectred.exploration.ore:4' weight='1.0' />
+                        <Replaces block='ProjRed|Exploration:projectred.exploration.ore:5' weight='1.0' />
+                        <Replaces block='ProjRed|Exploration:projectred.exploration.ore:6' weight='1.0' />
+                        <Replaces block='ProjRed|Exploration:projectred.exploration.stone' weight='1.0' />
                     </Substitute>
                 </IfCondition>
 
@@ -376,7 +378,7 @@
                         <Veins name='predRubyVeinsPipe'  inherits='predRubyVeins' seed='0xE23A' drawWireframe='true' wireframeColor='0x60900113' drawBoundBox='false' boundBoxColor='0x60900113'>
                             <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
-                            <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore")'> <Replaces block='ProjRed|Exploration:projectred.exploration.ore' weight='1.0' /> </IfCondition>
+                            <Replaces block='ProjRed|Exploration:projectred.exploration.ore' weight='1.0' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * predRubySize  * 0.5 ' range=':= 0 * _default_ * predRubySize  * 0.5 ' type='normal' />
                             <Setting name='SegmentRadius' avg=':= 0.721 * _default_ * predRubySize  * 0.5 ' range=':= 0.721 * _default_ * predRubySize  * 0.5 ' type='normal' />
                             <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
@@ -439,8 +441,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -505,7 +507,7 @@
                         <Veins name='predSapphireVeinsPipe'  inherits='predSapphireVeins' seed='0x5196' drawWireframe='true' wireframeColor='0x600011C8' drawBoundBox='false' boundBoxColor='0x600011C8'>
                             <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
-                            <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:1")'> <Replaces block='ProjRed|Exploration:projectred.exploration.ore:1' weight='1.0' /> </IfCondition>
+                            <Replaces block='ProjRed|Exploration:projectred.exploration.ore:1' weight='1.0' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * predSapphireSize  * 0.5 ' range=':= 0 * _default_ * predSapphireSize  * 0.5 ' type='normal' />
                             <Setting name='SegmentRadius' avg=':= 0.721 * _default_ * predSapphireSize  * 0.5 ' range=':= 0.721 * _default_ * predSapphireSize  * 0.5 ' type='normal' />
                             <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
@@ -568,8 +570,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:1")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:1' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -634,7 +636,7 @@
                         <Veins name='predPeridotVeinsPipe'  inherits='predPeridotVeins' seed='0x8759' drawWireframe='true' wireframeColor='0x60057529' drawBoundBox='false' boundBoxColor='0x60057529'>
                             <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
-                            <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:2")'> <Replaces block='ProjRed|Exploration:projectred.exploration.ore:2' weight='1.0' /> </IfCondition>
+                            <Replaces block='ProjRed|Exploration:projectred.exploration.ore:2' weight='1.0' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * predPeridotSize  * 0.5 ' range=':= 0 * _default_ * predPeridotSize  * 0.5 ' type='normal' />
                             <Setting name='SegmentRadius' avg=':= 0.721 * _default_ * predPeridotSize  * 0.5 ' range=':= 0.721 * _default_ * predPeridotSize  * 0.5 ' type='normal' />
                             <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
@@ -697,8 +699,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:2")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:2' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -816,8 +818,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:3")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:3' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -935,8 +937,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:4")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:4' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1054,8 +1056,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:5")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:5' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1173,8 +1175,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:6")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:6' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1292,8 +1294,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.stone")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.stone' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>

--- a/src/main/resources/config/modules/RailCraft.xml
+++ b/src/main/resources/config/modules/RailCraft.xml
@@ -5,6 +5,8 @@
      ================================================================= -->
 
 
+<!-- Expands the minecart system in Minecraft into a full-fledged
+     train set. Configuration by Reteo. -->
 
 
 
@@ -351,7 +353,7 @@
                             must be large  enough to catch all ore
                             clusters (>=  32).
                         </Comment>
-                        <IfCondition condition=':= ?blockExists("Railcraft:ore:1")'> <Replaces block='Railcraft:ore:1' weight='1.0' /> </IfCondition>
+                        <Replaces block='Railcraft:ore:1' weight='1.0' />
                     </Substitute>
                 </IfCondition>
 
@@ -366,16 +368,16 @@
                             must be large  enough to catch all ore
                             clusters (>=  32).
                         </Comment>
-                        <IfCondition condition=':= ?blockExists("Railcraft:cube:6")'> <Replaces block='Railcraft:cube:6' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("Railcraft:ore")'> <Replaces block='Railcraft:ore' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("Railcraft:ore:10")'> <Replaces block='Railcraft:ore:10' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("Railcraft:ore:11")'> <Replaces block='Railcraft:ore:11' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("Railcraft:ore:2")'> <Replaces block='Railcraft:ore:2' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("Railcraft:ore:3")'> <Replaces block='Railcraft:ore:3' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("Railcraft:ore:4")'> <Replaces block='Railcraft:ore:4' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("Railcraft:ore:7")'> <Replaces block='Railcraft:ore:7' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("Railcraft:ore:8")'> <Replaces block='Railcraft:ore:8' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("Railcraft:ore:9")'> <Replaces block='Railcraft:ore:9' weight='1.0' /> </IfCondition>
+                        <Replaces block='Railcraft:cube:6' weight='1.0' />
+                        <Replaces block='Railcraft:ore' weight='1.0' />
+                        <Replaces block='Railcraft:ore:10' weight='1.0' />
+                        <Replaces block='Railcraft:ore:11' weight='1.0' />
+                        <Replaces block='Railcraft:ore:2' weight='1.0' />
+                        <Replaces block='Railcraft:ore:3' weight='1.0' />
+                        <Replaces block='Railcraft:ore:4' weight='1.0' />
+                        <Replaces block='Railcraft:ore:7' weight='1.0' />
+                        <Replaces block='Railcraft:ore:8' weight='1.0' />
+                        <Replaces block='Railcraft:ore:9' weight='1.0' />
                     </Substitute>
                 </IfCondition>
 
@@ -400,12 +402,12 @@
                             </Description>
                             <IfCondition condition=':= ?blockExists("Railcraft:cube:6")'> <OreBlock block='Railcraft:cube:6' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
-                            <IfCondition condition=':= ?blockExists("dirt")'> <ReplacesOre block='dirt' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("gravel")'> <ReplacesOre block='gravel' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("sand")'> <ReplacesOre block='sand' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:lava")'> <Replaces block='minecraft:lava' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:water")'> <Replaces block='minecraft:water' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:air")'> <Replaces block='minecraft:air' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='dirt' weight='1.0' />
+                            <ReplacesOre block='gravel' weight='1.0' />
+                            <ReplacesOre block='sand' weight='1.0' />
+                            <Replaces block='minecraft:lava' weight='1.0' />
+                            <Replaces block='minecraft:water' weight='1.0' />
+                            <Replaces block='minecraft:air' weight='1.0' />
                             <Biome name='Ocean'  />
                             <Biome name='Deep Ocean'  />
                             <Setting name='MotherlodeFrequency' avg=':= _default_ * 0.5 * rlcrAbyssalOresFreq ' range=':= _default_ * rlcrAbyssalOresFreq ' type='normal' scaleTo='base' />
@@ -429,13 +431,13 @@
                             <IfCondition condition=':= ?blockExists("Railcraft:ore:3")'> <OreBlock block='Railcraft:ore:3' weight='0.0167' /> </IfCondition>
                             <IfCondition condition=':= ?blockExists("Railcraft:ore:4")'> <OreBlock block='Railcraft:ore:4' weight='0.05' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
-                            <IfCondition condition=':= ?blockExists("dirt")'> <ReplacesOre block='dirt' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("gravel")'> <ReplacesOre block='gravel' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("sand")'> <ReplacesOre block='sand' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:lava")'> <Replaces block='minecraft:lava' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:water")'> <Replaces block='minecraft:water' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:air")'> <Replaces block='minecraft:air' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("Railcraft:cube:6")'> <Replaces block='Railcraft:cube:6' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='dirt' weight='1.0' />
+                            <ReplacesOre block='gravel' weight='1.0' />
+                            <ReplacesOre block='sand' weight='1.0' />
+                            <Replaces block='minecraft:lava' weight='1.0' />
+                            <Replaces block='minecraft:water' weight='1.0' />
+                            <Replaces block='minecraft:air' weight='1.0' />
+                            <Replaces block='Railcraft:cube:6' weight='1.0' />
                             <Setting name='MotherlodeSize' avg=':= _default_ * 0.5' range=':= _default_ * 0.5' type='uniform' />
                         </Veins>
                         <Veins name='rlcrAbyssalOresGeodeBubble'  inherits='rlcrAbyssalOresGeodeOre' seed='0x9668' drawWireframe='true' wireframeColor='0x60000000' drawBoundBox='false' boundBoxColor='0x60000000'>
@@ -449,17 +451,17 @@
                                 contained ores.
                             </Description>
                             <IfCondition condition=':= ?blockExists("minecraft:air")'> <OreBlock block='minecraft:air' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("Railcraft:cube:6")'> <Replaces block='Railcraft:cube:6' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("Railcraft:ore:2")'> <Replaces block='Railcraft:ore:2' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("Railcraft:ore:3")'> <Replaces block='Railcraft:ore:3' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("Railcraft:ore:4")'> <Replaces block='Railcraft:ore:4' weight='1.0' /> </IfCondition>
+                            <Replaces block='Railcraft:cube:6' weight='1.0' />
+                            <Replaces block='Railcraft:ore:2' weight='1.0' />
+                            <Replaces block='Railcraft:ore:3' weight='1.0' />
+                            <Replaces block='Railcraft:ore:4' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
-                            <IfCondition condition=':= ?blockExists("dirt")'> <ReplacesOre block='dirt' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("gravel")'> <ReplacesOre block='gravel' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("sand")'> <ReplacesOre block='sand' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:lava")'> <Replaces block='minecraft:lava' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:water")'> <Replaces block='minecraft:water' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:air")'> <Replaces block='minecraft:air' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='dirt' weight='1.0' />
+                            <ReplacesOre block='gravel' weight='1.0' />
+                            <ReplacesOre block='sand' weight='1.0' />
+                            <Replaces block='minecraft:lava' weight='1.0' />
+                            <Replaces block='minecraft:water' weight='1.0' />
+                            <Replaces block='minecraft:air' weight='1.0' />
                             <Setting name='MotherlodeSize' avg=':= _default_ * 0.5' range=':= _default_ * 0.5' type='uniform' />
                         </Veins>
 
@@ -565,8 +567,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("Railcraft:ore:7")'> <OreBlock block='Railcraft:ore:7' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -691,8 +693,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("Railcraft:ore:8")'> <OreBlock block='Railcraft:ore:8' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -817,8 +819,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("Railcraft:ore:9")'> <OreBlock block='Railcraft:ore:9' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -943,8 +945,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("Railcraft:ore:10")'> <OreBlock block='Railcraft:ore:10' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1069,8 +1071,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("Railcraft:ore:11")'> <OreBlock block='Railcraft:ore:11' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1119,8 +1121,8 @@
                                 their  direction while mining.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Railcraft:ore:1")'> <OreBlock block='Railcraft:ore:1' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("sand")'> <ReplacesOre block='sand' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='sand' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
                             <BiomeType name='Desert'  minRainfall='0' maxRainfall='0.1' minTemperature='1.5' maxTemperature='2.0' />
                             <Setting name='MotherlodeFrequency' avg=':= 3.465 * _default_ * rlcrSaltpeterFreq ' range=':= 3.465 * _default_ * rlcrSaltpeterFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * rlcrSaltpeterSize ' range=':= 0 * _default_ * rlcrSaltpeterSize ' type='normal' />
@@ -1162,8 +1164,8 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Railcraft:ore:1")'> <OreBlock block='Railcraft:ore:1' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("sand")'> <ReplacesOre block='sand' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='sand' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
                             <BiomeType name='Desert'  minRainfall='0' maxRainfall='0.1' minTemperature='1.5' maxTemperature='2.0' />
                             <Setting name='CloudRadius' avg=':= 1.113 * _default_ * rlcrSaltpeterSize ' range=':= 1.113 * _default_ * rlcrSaltpeterSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.113 * _default_ * rlcrSaltpeterSize ' range=':= 1.113 * _default_ * rlcrSaltpeterSize ' type='normal' scaleTo='base' />
@@ -1197,8 +1199,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("Railcraft:ore:1")'> <OreBlock block='Railcraft:ore:1' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1215,8 +1217,8 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Railcraft:ore:1")'> <OreBlock block='Railcraft:ore:1' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("sand")'> <ReplacesOre block='sand' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='sand' weight='1.0' />
+                            <Replaces block='minecraft:sandstone' weight='1.0' />
                             <BiomeType name='Desert'  minRainfall='0' maxRainfall='0.1' minTemperature='1.5' maxTemperature='2.0' />
                             <Setting name='Size' avg=':= 1.000 * rlcrSaltpeterSize ' range=':= _default_ * rlcrSaltpeterSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 64.000 * rlcrSaltpeterFreq ' range=':= _default_ * rlcrSaltpeterFreq ' type='normal' scaleTo='base' />
@@ -1264,7 +1266,7 @@
                         <Veins name='rlcrSulfurVeinsPipe'  inherits='rlcrSulfurVeins' seed='0xEE54' drawWireframe='true' wireframeColor='0x60FFE25C' drawBoundBox='false' boundBoxColor='0x60FFE25C'>
                             <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
-                            <IfCondition condition=':= ?blockExists("Railcraft:ore")'> <Replaces block='Railcraft:ore' weight='1.0' /> </IfCondition>
+                            <Replaces block='Railcraft:ore' weight='1.0' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * rlcrSulfurSize  * 0.5 ' range=':= 0 * _default_ * rlcrSulfurSize  * 0.5 ' type='normal' />
                             <Setting name='SegmentRadius' avg=':= 1.143 * _default_ * rlcrSulfurSize  * 0.5 ' range=':= 1.143 * _default_ * rlcrSulfurSize  * 0.5 ' type='normal' />
                             <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
@@ -1327,8 +1329,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("Railcraft:ore")'> <OreBlock block='Railcraft:ore' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1383,7 +1385,7 @@
                             must be large  enough to catch all ore
                             clusters (>=  32).
                         </Comment>
-                        <IfCondition condition=':= ?blockExists("Railcraft:ore:5")'> <Replaces block='Railcraft:ore:5' weight='1.0' /> </IfCondition>
+                        <Replaces block='Railcraft:ore:5' weight='1.0' />
                     </Substitute>
                 </IfCondition>
 
@@ -1480,8 +1482,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("Railcraft:ore:5")'> <OreBlock block='Railcraft:ore:5' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>

--- a/src/main/resources/config/modules/ReactorCraft.xml
+++ b/src/main/resources/config/modules/ReactorCraft.xml
@@ -8,7 +8,8 @@
 
 
 <!-- An expansion to RotaryCraft, this mod adds oregen necessary for
-     managing nuclear reactions in various useful ways. -->
+     managing nuclear reactions in various useful ways.  Configuration
+     by Reteo. -->
 
 
 
@@ -637,20 +638,20 @@
                             must be large  enough to catch all ore
                             clusters (>=  32).
                         </Comment>
-                        <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore")'> <Replaces block='ReactorCraft:reactorcraft_block_fluoriteore' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:1")'> <Replaces block='ReactorCraft:reactorcraft_block_fluoriteore:1' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:2")'> <Replaces block='ReactorCraft:reactorcraft_block_fluoriteore:2' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:3")'> <Replaces block='ReactorCraft:reactorcraft_block_fluoriteore:3' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:4")'> <Replaces block='ReactorCraft:reactorcraft_block_fluoriteore:4' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:5")'> <Replaces block='ReactorCraft:reactorcraft_block_fluoriteore:5' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:6")'> <Replaces block='ReactorCraft:reactorcraft_block_fluoriteore:6' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:7")'> <Replaces block='ReactorCraft:reactorcraft_block_fluoriteore:7' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:1")'> <Replaces block='ReactorCraft:reactorcraft_block_ore:1' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:2")'> <Replaces block='ReactorCraft:reactorcraft_block_ore:2' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:3")'> <Replaces block='ReactorCraft:reactorcraft_block_ore:3' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:4")'> <Replaces block='ReactorCraft:reactorcraft_block_ore:4' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:7")'> <Replaces block='ReactorCraft:reactorcraft_block_ore:7' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:8")'> <Replaces block='ReactorCraft:reactorcraft_block_ore:8' weight='1.0' /> </IfCondition>
+                        <Replaces block='ReactorCraft:reactorcraft_block_fluoriteore' weight='1.0' />
+                        <Replaces block='ReactorCraft:reactorcraft_block_fluoriteore:1' weight='1.0' />
+                        <Replaces block='ReactorCraft:reactorcraft_block_fluoriteore:2' weight='1.0' />
+                        <Replaces block='ReactorCraft:reactorcraft_block_fluoriteore:3' weight='1.0' />
+                        <Replaces block='ReactorCraft:reactorcraft_block_fluoriteore:4' weight='1.0' />
+                        <Replaces block='ReactorCraft:reactorcraft_block_fluoriteore:5' weight='1.0' />
+                        <Replaces block='ReactorCraft:reactorcraft_block_fluoriteore:6' weight='1.0' />
+                        <Replaces block='ReactorCraft:reactorcraft_block_fluoriteore:7' weight='1.0' />
+                        <Replaces block='ReactorCraft:reactorcraft_block_ore:1' weight='1.0' />
+                        <Replaces block='ReactorCraft:reactorcraft_block_ore:2' weight='1.0' />
+                        <Replaces block='ReactorCraft:reactorcraft_block_ore:3' weight='1.0' />
+                        <Replaces block='ReactorCraft:reactorcraft_block_ore:4' weight='1.0' />
+                        <Replaces block='ReactorCraft:reactorcraft_block_ore:7' weight='1.0' />
+                        <Replaces block='ReactorCraft:reactorcraft_block_ore:8' weight='1.0' />
                     </Substitute>
                 </IfCondition>
 
@@ -779,8 +780,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:1")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:1' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -898,8 +899,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:2")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:2' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1017,8 +1018,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:3")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:3' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1136,8 +1137,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:4")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:4' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1262,8 +1263,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:7")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:7' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1388,8 +1389,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:8")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:8' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1508,8 +1509,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1628,8 +1629,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:1")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:1' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1748,8 +1749,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:2")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:2' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1869,8 +1870,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:3")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:3' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1989,8 +1990,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:4")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:4' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -2108,8 +2109,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:5")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:5' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -2228,8 +2229,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:6")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:6' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -2348,8 +2349,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:7")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:7' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -2383,8 +2384,8 @@
                             must be large  enough to catch all ore
                             clusters (>=  32).
                         </Comment>
-                        <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:6")'> <Replaces block='ReactorCraft:reactorcraft_block_ore:6' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:9")'> <Replaces block='ReactorCraft:reactorcraft_block_ore:9' weight='1.0' /> </IfCondition>
+                        <Replaces block='ReactorCraft:reactorcraft_block_ore:6' weight='1.0' />
+                        <Replaces block='ReactorCraft:reactorcraft_block_ore:9' weight='1.0' />
                     </Substitute>
                 </IfCondition>
 
@@ -2509,8 +2510,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:6")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:6' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -2628,8 +2629,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:9")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:9' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -2663,7 +2664,7 @@
                             must be large  enough to catch all ore
                             clusters (>=  32).
                         </Comment>
-                        <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:5")'> <Replaces block='ReactorCraft:reactorcraft_block_ore:5' weight='1.0' /> </IfCondition>
+                        <Replaces block='ReactorCraft:reactorcraft_block_ore:5' weight='1.0' />
                     </Substitute>
                 </IfCondition>
 
@@ -2787,8 +2788,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:5")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:5' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>

--- a/src/main/resources/config/modules/SimpleOres.xml
+++ b/src/main/resources/config/modules/SimpleOres.xml
@@ -5,7 +5,7 @@
 
 
 <!-- This mod provides several "simple ores" to expand Minecraft
-     gameplay. -->
+     gameplay. Configuration by Reteo. -->
 
 
 
@@ -226,10 +226,10 @@
                             must be large  enough to catch all ore
                             clusters (>=  32).
                         </Comment>
-                        <IfCondition condition=':= ?blockExists("simpleores:adamantium_ore")'> <Replaces block='simpleores:adamantium_ore' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("simpleores:copper_ore")'> <Replaces block='simpleores:copper_ore' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("simpleores:mythril_ore")'> <Replaces block='simpleores:mythril_ore' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("simpleores:tin_ore")'> <Replaces block='simpleores:tin_ore' weight='1.0' /> </IfCondition>
+                        <Replaces block='simpleores:adamantium_ore' weight='1.0' />
+                        <Replaces block='simpleores:copper_ore' weight='1.0' />
+                        <Replaces block='simpleores:mythril_ore' weight='1.0' />
+                        <Replaces block='simpleores:tin_ore' weight='1.0' />
                     </Substitute>
                 </IfCondition>
 
@@ -324,8 +324,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("simpleores:copper_ore")'> <OreBlock block='simpleores:copper_ore' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -443,8 +443,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("simpleores:tin_ore")'> <OreBlock block='simpleores:tin_ore' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -562,8 +562,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("simpleores:mythril_ore")'> <OreBlock block='simpleores:mythril_ore' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -681,8 +681,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("simpleores:adamantium_ore")'> <OreBlock block='simpleores:adamantium_ore' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -737,7 +737,7 @@
                             must be large  enough to catch all ore
                             clusters (>=  32).
                         </Comment>
-                        <IfCondition condition=':= ?blockExists("simpleores:onyx_ore")'> <Replaces block='simpleores:onyx_ore' weight='1.0' /> </IfCondition>
+                        <Replaces block='simpleores:onyx_ore' weight='1.0' />
                     </Substitute>
                 </IfCondition>
 
@@ -756,7 +756,7 @@
                                 up from near the bottom  of the map.
                             </Description>
                             <IfCondition condition=':= ?blockExists("simpleores:onyx_ore")'> <OreBlock block='simpleores:onyx_ore' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.597 * _default_ * smpoOnyxFreq ' range=':= 1.597 * _default_ * smpoOnyxFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * smpoOnyxSize ' range=':= 0 * _default_ * smpoOnyxSize ' type='normal' />
@@ -778,8 +778,8 @@
                         <!-- Configuring contained material. -->
                         <Veins name='smpoOnyxVeinsPipe'  inherits='smpoOnyxVeins' seed='0x1523' drawWireframe='true' wireframeColor='0x60232323' drawBoundBox='false' boundBoxColor='0x60232323'>
                             <IfCondition condition=':= ?blockExists("minecraft:stone")'> <OreBlock block='minecraft:stone' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("simpleores:onyx_ore")'> <Replaces block='simpleores:onyx_ore' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
+                            <Replaces block='simpleores:onyx_ore' weight='1.0' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * smpoOnyxSize  * 0.5 ' range=':= 0 * _default_ * smpoOnyxSize  * 0.5 ' type='normal' />
                             <Setting name='SegmentRadius' avg=':= 1.124 * _default_ * smpoOnyxSize  * 0.5 ' range=':= 1.124 * _default_ * smpoOnyxSize  * 0.5 ' type='normal' />
                             <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
@@ -808,7 +808,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("simpleores:onyx_ore")'> <OreBlock block='simpleores:onyx_ore' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.957 * _default_ * smpoOnyxSize ' range=':= 0.957 * _default_ * smpoOnyxSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.957 * _default_ * smpoOnyxSize ' range=':= 0.957 * _default_ * smpoOnyxSize ' type='normal' scaleTo='base' />
@@ -842,8 +842,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("simpleores:onyx_ore")'> <OreBlock block='simpleores:onyx_ore' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -860,7 +860,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("simpleores:onyx_ore")'> <OreBlock block='simpleores:onyx_ore' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 7.000 * smpoOnyxSize ' range=':= _default_ * smpoOnyxSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 5.000 * smpoOnyxFreq ' range=':= _default_ * smpoOnyxFreq ' type='normal' scaleTo='base' />

--- a/src/main/resources/config/modules/Thaumcraft4.xml
+++ b/src/main/resources/config/modules/Thaumcraft4.xml
@@ -6,6 +6,9 @@
      ================================================================= -->
 
 
+<!-- Magic mod that encourages exploration and research.  Has a few
+     ores, and several types of "infused stone." Configuration by
+     Reteo. -->
 
 
 
@@ -328,14 +331,14 @@
                             must be large  enough to catch all ore
                             clusters (>=  32).
                         </Comment>
-                        <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre")'> <Replaces block='Thaumcraft:blockCustomOre' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:1")'> <Replaces block='Thaumcraft:blockCustomOre:1' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:2")'> <Replaces block='Thaumcraft:blockCustomOre:2' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:3")'> <Replaces block='Thaumcraft:blockCustomOre:3' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:4")'> <Replaces block='Thaumcraft:blockCustomOre:4' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:5")'> <Replaces block='Thaumcraft:blockCustomOre:5' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:6")'> <Replaces block='Thaumcraft:blockCustomOre:6' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:7")'> <Replaces block='Thaumcraft:blockCustomOre:7' weight='1.0' /> </IfCondition>
+                        <Replaces block='Thaumcraft:blockCustomOre' weight='1.0' />
+                        <Replaces block='Thaumcraft:blockCustomOre:1' weight='1.0' />
+                        <Replaces block='Thaumcraft:blockCustomOre:2' weight='1.0' />
+                        <Replaces block='Thaumcraft:blockCustomOre:3' weight='1.0' />
+                        <Replaces block='Thaumcraft:blockCustomOre:4' weight='1.0' />
+                        <Replaces block='Thaumcraft:blockCustomOre:5' weight='1.0' />
+                        <Replaces block='Thaumcraft:blockCustomOre:6' weight='1.0' />
+                        <Replaces block='Thaumcraft:blockCustomOre:7' weight='1.0' />
                     </Substitute>
                 </IfCondition>
 
@@ -439,8 +442,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:7")'> <OreBlock block='Thaumcraft:blockCustomOre:7' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -566,8 +569,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre")'> <OreBlock block='Thaumcraft:blockCustomOre' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -722,8 +725,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:1")'> <OreBlock block='Thaumcraft:blockCustomOre:1' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
 
@@ -752,8 +755,8 @@
                                     preferred biomes.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:1")'> <OreBlock block='Thaumcraft:blockCustomOre:1' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                         <!-- "Preferred" configuration complete. -->
@@ -910,8 +913,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:2")'> <OreBlock block='Thaumcraft:blockCustomOre:2' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
 
@@ -940,8 +943,8 @@
                                     preferred biomes.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:2")'> <OreBlock block='Thaumcraft:blockCustomOre:2' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                         <!-- "Preferred" configuration complete. -->
@@ -1100,8 +1103,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:3")'> <OreBlock block='Thaumcraft:blockCustomOre:3' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
 
@@ -1131,8 +1134,8 @@
                                     preferred biomes.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:3")'> <OreBlock block='Thaumcraft:blockCustomOre:3' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                         <!-- "Preferred" configuration complete. -->
@@ -1290,8 +1293,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:4")'> <OreBlock block='Thaumcraft:blockCustomOre:4' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
 
@@ -1320,8 +1323,8 @@
                                     preferred biomes.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:4")'> <OreBlock block='Thaumcraft:blockCustomOre:4' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                         <!-- "Preferred" configuration complete. -->
@@ -1481,8 +1484,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:5")'> <OreBlock block='Thaumcraft:blockCustomOre:5' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
 
@@ -1513,8 +1516,8 @@
                                     preferred biomes.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:5")'> <OreBlock block='Thaumcraft:blockCustomOre:5' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                         <!-- "Preferred" configuration complete. -->
@@ -1673,8 +1676,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:6")'> <OreBlock block='Thaumcraft:blockCustomOre:6' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
 
@@ -1704,8 +1707,8 @@
                                     preferred biomes.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:6")'> <OreBlock block='Thaumcraft:blockCustomOre:6' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                         <!-- "Preferred" configuration complete. -->

--- a/src/main/resources/config/modules/ThermalFoundation.xml
+++ b/src/main/resources/config/modules/ThermalFoundation.xml
@@ -7,7 +7,7 @@
 
 <!-- Thermal Foundation is the basis upon which "Thermal Expansion"
      depends.  Included in this foundation are the six ores that are
-     heavily used by all associated mods. -->
+     heavily used by all associated mods. Configuration by Reteo. -->
 
 
 
@@ -262,12 +262,12 @@
                             must be large  enough to catch all ore
                             clusters (>=  32).
                         </Comment>
-                        <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore")'> <Replaces block='ThermalFoundation:Ore' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:1")'> <Replaces block='ThermalFoundation:Ore:1' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:2")'> <Replaces block='ThermalFoundation:Ore:2' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:3")'> <Replaces block='ThermalFoundation:Ore:3' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:4")'> <Replaces block='ThermalFoundation:Ore:4' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:5")'> <Replaces block='ThermalFoundation:Ore:5' weight='1.0' /> </IfCondition>
+                        <Replaces block='ThermalFoundation:Ore' weight='1.0' />
+                        <Replaces block='ThermalFoundation:Ore:1' weight='1.0' />
+                        <Replaces block='ThermalFoundation:Ore:2' weight='1.0' />
+                        <Replaces block='ThermalFoundation:Ore:3' weight='1.0' />
+                        <Replaces block='ThermalFoundation:Ore:4' weight='1.0' />
+                        <Replaces block='ThermalFoundation:Ore:5' weight='1.0' />
                     </Substitute>
                 </IfCondition>
 
@@ -362,8 +362,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore")'> <OreBlock block='ThermalFoundation:Ore' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -481,8 +481,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:1")'> <OreBlock block='ThermalFoundation:Ore:1' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -600,8 +600,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:2")'> <OreBlock block='ThermalFoundation:Ore:2' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -719,8 +719,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:3")'> <OreBlock block='ThermalFoundation:Ore:3' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -838,8 +838,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:4")'> <OreBlock block='ThermalFoundation:Ore:4' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -957,8 +957,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:5")'> <OreBlock block='ThermalFoundation:Ore:5' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>

--- a/src/main/resources/config/modules/TinkersConstruct.xml
+++ b/src/main/resources/config/modules/TinkersConstruct.xml
@@ -8,7 +8,7 @@
 
 <!-- A mod centering around tool manufacturing, the smelting of ores
      plays a large part.  This mod also includes ores that are
-     embedded in gravel, rather than stone. -->
+     embedded in gravel, rather than stone. Configuration by Reteo. -->
 
 
 
@@ -433,11 +433,11 @@
                             must be large  enough to catch all ore
                             clusters (>=  32).
                         </Comment>
-                        <IfCondition condition=':= ?blockExists("TConstruct:GravelOre")'> <Replaces block='TConstruct:GravelOre' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:1")'> <Replaces block='TConstruct:GravelOre:1' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:2")'> <Replaces block='TConstruct:GravelOre:2' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:3")'> <Replaces block='TConstruct:GravelOre:3' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:4")'> <Replaces block='TConstruct:GravelOre:4' weight='1.0' /> </IfCondition>
+                        <Replaces block='TConstruct:GravelOre' weight='1.0' />
+                        <Replaces block='TConstruct:GravelOre:1' weight='1.0' />
+                        <Replaces block='TConstruct:GravelOre:2' weight='1.0' />
+                        <Replaces block='TConstruct:GravelOre:3' weight='1.0' />
+                        <Replaces block='TConstruct:GravelOre:4' weight='1.0' />
                     </Substitute>
                 </IfCondition>
 
@@ -452,9 +452,9 @@
                             must be large  enough to catch all ore
                             clusters (>=  32).
                         </Comment>
-                        <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:3")'> <Replaces block='TConstruct:SearedBrick:3' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:4")'> <Replaces block='TConstruct:SearedBrick:4' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:5")'> <Replaces block='TConstruct:SearedBrick:5' weight='1.0' /> </IfCondition>
+                        <Replaces block='TConstruct:SearedBrick:3' weight='1.0' />
+                        <Replaces block='TConstruct:SearedBrick:4' weight='1.0' />
+                        <Replaces block='TConstruct:SearedBrick:5' weight='1.0' />
                     </Substitute>
                 </IfCondition>
 
@@ -549,8 +549,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:3")'> <OreBlock block='TConstruct:SearedBrick:3' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -668,8 +668,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:4")'> <OreBlock block='TConstruct:SearedBrick:4' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -787,8 +787,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:5")'> <OreBlock block='TConstruct:SearedBrick:5' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -830,7 +830,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre")'> <OreBlock block='TConstruct:GravelOre' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("gravel")'> <ReplacesOre block='gravel' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='gravel' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.238 * _default_ * ticoIronGravelFreq ' range=':= 2.238 * _default_ * ticoIronGravelFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.144 * _default_ * ticoIronGravelSize ' range=':= 1.144 * _default_ * ticoIronGravelSize ' type='normal' />
@@ -872,7 +872,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre")'> <OreBlock block='TConstruct:GravelOre' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("gravel")'> <ReplacesOre block='gravel' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='gravel' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.399 * _default_ * ticoIronGravelSize ' range=':= 1.399 * _default_ * ticoIronGravelSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.399 * _default_ * ticoIronGravelSize ' range=':= 1.399 * _default_ * ticoIronGravelSize ' type='normal' scaleTo='base' />
@@ -906,8 +906,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("TConstruct:GravelOre")'> <OreBlock block='TConstruct:GravelOre' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -924,7 +924,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre")'> <OreBlock block='TConstruct:GravelOre' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("gravel")'> <ReplacesOre block='gravel' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='gravel' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 8.000 * ticoIronGravelSize ' range=':= _default_ * ticoIronGravelSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 20.000 * ticoIronGravelFreq ' range=':= _default_ * ticoIronGravelFreq ' type='normal' scaleTo='base' />
@@ -949,7 +949,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:1")'> <OreBlock block='TConstruct:GravelOre:1' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("gravel")'> <ReplacesOre block='gravel' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='gravel' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.708 * _default_ * ticoGoldGravelFreq ' range=':= 0.708 * _default_ * ticoGoldGravelFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.944 * _default_ * ticoGoldGravelSize ' range=':= 0.944 * _default_ * ticoGoldGravelSize ' type='normal' />
@@ -991,7 +991,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:1")'> <OreBlock block='TConstruct:GravelOre:1' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("gravel")'> <ReplacesOre block='gravel' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='gravel' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.787 * _default_ * ticoGoldGravelSize ' range=':= 0.787 * _default_ * ticoGoldGravelSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.787 * _default_ * ticoGoldGravelSize ' range=':= 0.787 * _default_ * ticoGoldGravelSize ' type='normal' scaleTo='base' />
@@ -1025,8 +1025,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:1")'> <OreBlock block='TConstruct:GravelOre:1' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1043,7 +1043,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:1")'> <OreBlock block='TConstruct:GravelOre:1' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("gravel")'> <ReplacesOre block='gravel' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='gravel' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 8.000 * ticoGoldGravelSize ' range=':= _default_ * ticoGoldGravelSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 2.000 * ticoGoldGravelFreq ' range=':= _default_ * ticoGoldGravelFreq ' type='normal' scaleTo='base' />
@@ -1068,7 +1068,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:2")'> <OreBlock block='TConstruct:GravelOre:2' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("gravel")'> <ReplacesOre block='gravel' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='gravel' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.583 * _default_ * ticoCopperGravelFreq ' range=':= 1.583 * _default_ * ticoCopperGravelFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.080 * _default_ * ticoCopperGravelSize ' range=':= 1.080 * _default_ * ticoCopperGravelSize ' type='normal' />
@@ -1111,7 +1111,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:2")'> <OreBlock block='TConstruct:GravelOre:2' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("gravel")'> <ReplacesOre block='gravel' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='gravel' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.177 * _default_ * ticoCopperGravelSize ' range=':= 1.177 * _default_ * ticoCopperGravelSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.177 * _default_ * ticoCopperGravelSize ' range=':= 1.177 * _default_ * ticoCopperGravelSize ' type='normal' scaleTo='base' />
@@ -1145,8 +1145,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:2")'> <OreBlock block='TConstruct:GravelOre:2' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1163,7 +1163,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:2")'> <OreBlock block='TConstruct:GravelOre:2' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("gravel")'> <ReplacesOre block='gravel' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='gravel' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 8.000 * ticoCopperGravelSize ' range=':= _default_ * ticoCopperGravelSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 10.000 * ticoCopperGravelFreq ' range=':= _default_ * ticoCopperGravelFreq ' type='normal' scaleTo='base' />
@@ -1188,7 +1188,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:3")'> <OreBlock block='TConstruct:GravelOre:3' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("gravel")'> <ReplacesOre block='gravel' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='gravel' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.416 * _default_ * ticoTinGravelFreq ' range=':= 1.416 * _default_ * ticoTinGravelFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.060 * _default_ * ticoTinGravelSize ' range=':= 1.060 * _default_ * ticoTinGravelSize ' type='normal' />
@@ -1230,7 +1230,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:3")'> <OreBlock block='TConstruct:GravelOre:3' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("gravel")'> <ReplacesOre block='gravel' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='gravel' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.113 * _default_ * ticoTinGravelSize ' range=':= 1.113 * _default_ * ticoTinGravelSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.113 * _default_ * ticoTinGravelSize ' range=':= 1.113 * _default_ * ticoTinGravelSize ' type='normal' scaleTo='base' />
@@ -1264,8 +1264,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:3")'> <OreBlock block='TConstruct:GravelOre:3' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1282,7 +1282,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:3")'> <OreBlock block='TConstruct:GravelOre:3' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("gravel")'> <ReplacesOre block='gravel' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='gravel' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 8.000 * ticoTinGravelSize ' range=':= _default_ * ticoTinGravelSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 8.000 * ticoTinGravelFreq ' range=':= _default_ * ticoTinGravelFreq ' type='normal' scaleTo='base' />
@@ -1307,7 +1307,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:4")'> <OreBlock block='TConstruct:GravelOre:4' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("gravel")'> <ReplacesOre block='gravel' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='gravel' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.751 * _default_ * ticoAluminumGravelFreq ' range=':= 0.751 * _default_ * ticoAluminumGravelFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.953 * _default_ * ticoAluminumGravelSize ' range=':= 0.953 * _default_ * ticoAluminumGravelSize ' type='normal' />
@@ -1350,7 +1350,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:4")'> <OreBlock block='TConstruct:GravelOre:4' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("gravel")'> <ReplacesOre block='gravel' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='gravel' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.810 * _default_ * ticoAluminumGravelSize ' range=':= 0.810 * _default_ * ticoAluminumGravelSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.810 * _default_ * ticoAluminumGravelSize ' range=':= 0.810 * _default_ * ticoAluminumGravelSize ' type='normal' scaleTo='base' />
@@ -1384,8 +1384,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:4")'> <OreBlock block='TConstruct:GravelOre:4' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1402,7 +1402,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:4")'> <OreBlock block='TConstruct:GravelOre:4' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("gravel")'> <ReplacesOre block='gravel' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='gravel' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 6.000 * ticoAluminumGravelSize ' range=':= _default_ * ticoAluminumGravelSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 3.000 * ticoAluminumGravelFreq ' range=':= _default_ * ticoAluminumGravelFreq ' type='normal' scaleTo='base' />
@@ -1440,7 +1440,7 @@
                             must be large  enough to catch all ore
                             clusters (>=  32).
                         </Comment>
-                        <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:5")'> <Replaces block='TConstruct:GravelOre:5' weight='1.0' /> </IfCondition>
+                        <Replaces block='TConstruct:GravelOre:5' weight='1.0' />
                     </Substitute>
                 </IfCondition>
 
@@ -1455,8 +1455,8 @@
                             must be large  enough to catch all ore
                             clusters (>=  32).
                         </Comment>
-                        <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:1")'> <Replaces block='TConstruct:SearedBrick:1' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:2")'> <Replaces block='TConstruct:SearedBrick:2' weight='1.0' /> </IfCondition>
+                        <Replaces block='TConstruct:SearedBrick:1' weight='1.0' />
+                        <Replaces block='TConstruct:SearedBrick:2' weight='1.0' />
                     </Substitute>
                 </IfCondition>
 
@@ -1477,7 +1477,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:1")'> <OreBlock block='TConstruct:SearedBrick:1' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.084 * _default_ * ticoCobaltFreq ' range=':= 1.084 * _default_ * ticoCobaltFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.014 * _default_ * ticoCobaltSize ' range=':= 1.014 * _default_ * ticoCobaltSize ' type='normal' />
@@ -1519,7 +1519,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:1")'> <OreBlock block='TConstruct:SearedBrick:1' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.871 * _default_ * ticoCobaltSize ' range=':= 0.871 * _default_ * ticoCobaltSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.871 * _default_ * ticoCobaltSize ' range=':= 0.871 * _default_ * ticoCobaltSize ' type='normal' scaleTo='base' />
@@ -1553,8 +1553,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:1")'> <OreBlock block='TConstruct:SearedBrick:1' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1571,7 +1571,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:1")'> <OreBlock block='TConstruct:SearedBrick:1' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.000 * ticoCobaltSize ' range=':= _default_ * ticoCobaltSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 8.000 * ticoCobaltFreq ' range=':= _default_ * ticoCobaltFreq ' type='normal' scaleTo='base' />
@@ -1598,7 +1598,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:2")'> <OreBlock block='TConstruct:SearedBrick:2' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.084 * _default_ * ticoArditeFreq ' range=':= 1.084 * _default_ * ticoArditeFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.014 * _default_ * ticoArditeSize ' range=':= 1.014 * _default_ * ticoArditeSize ' type='normal' />
@@ -1640,7 +1640,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:2")'> <OreBlock block='TConstruct:SearedBrick:2' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.871 * _default_ * ticoArditeSize ' range=':= 0.871 * _default_ * ticoArditeSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.871 * _default_ * ticoArditeSize ' range=':= 0.871 * _default_ * ticoArditeSize ' type='normal' scaleTo='base' />
@@ -1674,8 +1674,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:2")'> <OreBlock block='TConstruct:SearedBrick:2' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1692,7 +1692,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:2")'> <OreBlock block='TConstruct:SearedBrick:2' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.000 * ticoArditeSize ' range=':= _default_ * ticoArditeSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 8.000 * ticoArditeFreq ' range=':= _default_ * ticoArditeFreq ' type='normal' scaleTo='base' />
@@ -1718,7 +1718,7 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:5")'> <OreBlock block='TConstruct:GravelOre:5' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("gravel")'> <ReplacesOre block='gravel' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='gravel' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.867 * _default_ * ticoNetherCobaltGravelFreq ' range=':= 0.867 * _default_ * ticoNetherCobaltGravelFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.976 * _default_ * ticoNetherCobaltGravelSize ' range=':= 0.976 * _default_ * ticoNetherCobaltGravelSize ' type='normal' />
@@ -1761,7 +1761,7 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:5")'> <OreBlock block='TConstruct:GravelOre:5' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("gravel")'> <ReplacesOre block='gravel' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='gravel' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.871 * _default_ * ticoNetherCobaltGravelSize ' range=':= 0.871 * _default_ * ticoNetherCobaltGravelSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.871 * _default_ * ticoNetherCobaltGravelSize ' range=':= 0.871 * _default_ * ticoNetherCobaltGravelSize ' type='normal' scaleTo='base' />
@@ -1795,8 +1795,8 @@
                                     already be scaled by that.
                                 </Description>
                                 <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:5")'> <OreBlock block='TConstruct:GravelOre:5' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1814,7 +1814,7 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:5")'> <OreBlock block='TConstruct:GravelOre:5' weight='1.0' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("gravel")'> <ReplacesOre block='gravel' weight='1.0' /> </IfCondition>
+                            <ReplacesOre block='gravel' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.000 * ticoNetherCobaltGravelSize ' range=':= _default_ * ticoNetherCobaltGravelSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 8.000 * ticoNetherCobaltGravelFreq ' range=':= _default_ * ticoNetherCobaltGravelFreq ' type='normal' scaleTo='base' />

--- a/src/main/resources/config/modules/TinkersSteelworks.xml
+++ b/src/main/resources/config/modules/TinkersSteelworks.xml
@@ -4,6 +4,8 @@
      ================================================================= -->
 
 
+<!-- Adds the High Furnace and the High Tank to Tinker's Construct,
+     and allows the creation of steel. Configuration by Reteo. -->
 
 
 
@@ -78,7 +80,7 @@
                             must be large  enough to catch all ore
                             clusters (>=  32).
                         </Comment>
-                        <IfCondition condition=':= ?blockExists("TSteelworks:Limestone")'> <Replaces block='TSteelworks:Limestone' weight='1.0' /> </IfCondition>
+                        <Replaces block='TSteelworks:Limestone' weight='1.0' />
                     </Substitute>
                 </IfCondition>
 

--- a/src/main/resources/config/modules/VanillaMinecraft.xml
+++ b/src/main/resources/config/modules/VanillaMinecraft.xml
@@ -5,7 +5,8 @@
      ================================================================= -->
 
 
-<!-- This is a set of configurations for vanilla minecraft. -->
+<!-- This is a set of configurations for vanilla minecraft.
+     Configuration by Reteo. -->
 
 
 
@@ -347,7 +348,7 @@
                     The global option deferredPopulationRange  must be
                     large enough to catch all ore  clusters (>= 32).
                 </Comment>
-                <IfCondition condition=':= ?blockExists("minecraft:clay")'> <Replaces block='minecraft:clay' weight='1.0' /> </IfCondition>
+                <Replaces block='minecraft:clay' weight='1.0' />
             </Substitute>
         </IfCondition>
 
@@ -361,13 +362,13 @@
                     The global option deferredPopulationRange  must be
                     large enough to catch all ore  clusters (>= 32).
                 </Comment>
-                <IfCondition condition=':= ?blockExists("minecraft:coal_ore")'> <Replaces block='minecraft:coal_ore' weight='1.0' /> </IfCondition>
-                <IfCondition condition=':= ?blockExists("minecraft:diamond_ore")'> <Replaces block='minecraft:diamond_ore' weight='1.0' /> </IfCondition>
-                <IfCondition condition=':= ?blockExists("minecraft:emerald_ore")'> <Replaces block='minecraft:emerald_ore' weight='1.0' /> </IfCondition>
-                <IfCondition condition=':= ?blockExists("minecraft:gold_ore")'> <Replaces block='minecraft:gold_ore' weight='1.0' /> </IfCondition>
-                <IfCondition condition=':= ?blockExists("minecraft:iron_ore")'> <Replaces block='minecraft:iron_ore' weight='1.0' /> </IfCondition>
-                <IfCondition condition=':= ?blockExists("minecraft:lapis_ore")'> <Replaces block='minecraft:lapis_ore' weight='1.0' /> </IfCondition>
-                <IfCondition condition=':= ?blockExists("minecraft:redstone_ore")'> <Replaces block='minecraft:redstone_ore' weight='1.0' /> </IfCondition>
+                <Replaces block='minecraft:coal_ore' weight='1.0' />
+                <Replaces block='minecraft:diamond_ore' weight='1.0' />
+                <Replaces block='minecraft:emerald_ore' weight='1.0' />
+                <Replaces block='minecraft:gold_ore' weight='1.0' />
+                <Replaces block='minecraft:iron_ore' weight='1.0' />
+                <Replaces block='minecraft:lapis_ore' weight='1.0' />
+                <Replaces block='minecraft:redstone_ore' weight='1.0' />
             </Substitute>
         </IfCondition>
 
@@ -387,9 +388,9 @@
                         StandardGen distributions.
                     </Description>
                     <IfCondition condition=':= ?blockExists("minecraft:clay")'> <OreBlock block='minecraft:clay' weight='1.0' /> </IfCondition>
-                    <IfCondition condition=':= ?blockExists("sand")'> <ReplacesOre block='sand' weight='1.0' /> </IfCondition>
-                    <IfCondition condition=':= ?blockExists("gravel")'> <ReplacesOre block='gravel' weight='1.0' /> </IfCondition>
-                    <IfCondition condition=':= ?blockExists("dirt")'> <ReplacesOre block='dirt' weight='1.0' /> </IfCondition>
+                    <ReplacesOre block='sand' weight='1.0' />
+                    <ReplacesOre block='gravel' weight='1.0' />
+                    <ReplacesOre block='dirt' weight='1.0' />
                     <Biome name='.*'  />
                     <Biome name='Ocean'  weight='-1' />
                     <Biome name='Desert'  weight='-1' />
@@ -418,9 +419,9 @@
                         biomes.
                     </Description>
                     <IfCondition condition=':= ?blockExists("minecraft:clay")'> <OreBlock block='minecraft:clay' weight='1.0' /> </IfCondition>
-                    <IfCondition condition=':= ?blockExists("sand")'> <ReplacesOre block='sand' weight='1.0' /> </IfCondition>
-                    <IfCondition condition=':= ?blockExists("gravel")'> <ReplacesOre block='gravel' weight='1.0' /> </IfCondition>
-                    <IfCondition condition=':= ?blockExists("dirt")'> <ReplacesOre block='dirt' weight='1.0' /> </IfCondition>
+                    <ReplacesOre block='sand' weight='1.0' />
+                    <ReplacesOre block='gravel' weight='1.0' />
+                    <ReplacesOre block='dirt' weight='1.0' />
                     <BiomeType name='Swamp'  />
                     <BiomeType name='Beach'  />
                     <BiomeType name='River'  />
@@ -540,8 +541,8 @@
                             scaled  by that.
                         </Description>
                         <IfCondition condition=':= ?blockExists("minecraft:coal_ore")'> <OreBlock block='minecraft:coal_ore' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                        <Replaces block='minecraft:dirt' weight='1.0' />
+                        <Replaces block='minecraft:sandstone' weight='1.0' />
                     </Veins>
                 </Cloud>
             </IfCondition>
@@ -618,8 +619,8 @@
                             scaled  by that.
                         </Description>
                         <IfCondition condition=':= ?blockExists("minecraft:coal_ore")'> <OreBlock block='minecraft:coal_ore' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                        <Replaces block='minecraft:dirt' weight='1.0' />
+                        <Replaces block='minecraft:sandstone' weight='1.0' />
                     </Veins>
                 </Cloud>
             </IfCondition>
@@ -732,8 +733,8 @@
                             scaled  by that.
                         </Description>
                         <IfCondition condition=':= ?blockExists("minecraft:iron_ore")'> <OreBlock block='minecraft:iron_ore' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                        <Replaces block='minecraft:dirt' weight='1.0' />
+                        <Replaces block='minecraft:sandstone' weight='1.0' />
                     </Veins>
                 </Cloud>
             </IfCondition>
@@ -846,8 +847,8 @@
                             scaled  by that.
                         </Description>
                         <IfCondition condition=':= ?blockExists("minecraft:gold_ore")'> <OreBlock block='minecraft:gold_ore' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                        <Replaces block='minecraft:dirt' weight='1.0' />
+                        <Replaces block='minecraft:sandstone' weight='1.0' />
                     </Veins>
                 </Cloud>
             </IfCondition>
@@ -988,8 +989,8 @@
                             scaled  by that.
                         </Description>
                         <IfCondition condition=':= ?blockExists("minecraft:redstone_ore")'> <OreBlock block='minecraft:redstone_ore' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                        <Replaces block='minecraft:dirt' weight='1.0' />
+                        <Replaces block='minecraft:sandstone' weight='1.0' />
                     </Veins>
                 </Cloud>
 
@@ -1018,8 +1019,8 @@
                             biomes.
                         </Description>
                         <IfCondition condition=':= ?blockExists("minecraft:redstone_ore")'> <OreBlock block='minecraft:redstone_ore' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                        <Replaces block='minecraft:dirt' weight='1.0' />
+                        <Replaces block='minecraft:sandstone' weight='1.0' />
                     </Veins>
                 </Cloud>
                 <!-- "Preferred" configuration complete. -->
@@ -1065,7 +1066,7 @@
                 <Veins name='vnlaDiamondVeinsPipe'  inherits='vnlaDiamondVeins' seed='0x197B' drawWireframe='true' wireframeColor='0x608BF4E3' drawBoundBox='false' boundBoxColor='0x608BF4E3'>
                     <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
                     <ReplacesOre block='stone' weight='1.0' />
-                    <IfCondition condition=':= ?blockExists("minecraft:diamond_ore")'> <Replaces block='minecraft:diamond_ore' weight='1.0' /> </IfCondition>
+                    <Replaces block='minecraft:diamond_ore' weight='1.0' />
                     <Setting name='MotherlodeSize' avg=':= 0 * _default_ * vnlaDiamondSize  * 0.5 ' range=':= 0 * _default_ * vnlaDiamondSize  * 0.5 ' type='normal' />
                     <Setting name='SegmentRadius' avg=':= 0.919 * _default_ * vnlaDiamondSize  * 0.5 ' range=':= 0.919 * _default_ * vnlaDiamondSize  * 0.5 ' type='normal' />
                     <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
@@ -1144,8 +1145,8 @@
                             scaled  by that.
                         </Description>
                         <IfCondition condition=':= ?blockExists("minecraft:diamond_ore")'> <OreBlock block='minecraft:diamond_ore' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                        <Replaces block='minecraft:dirt' weight='1.0' />
+                        <Replaces block='minecraft:sandstone' weight='1.0' />
                     </Veins>
                 </Cloud>
             </IfCondition>
@@ -1286,8 +1287,8 @@
                             scaled  by that.
                         </Description>
                         <IfCondition condition=':= ?blockExists("minecraft:lapis_ore")'> <OreBlock block='minecraft:lapis_ore' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                        <Replaces block='minecraft:dirt' weight='1.0' />
+                        <Replaces block='minecraft:sandstone' weight='1.0' />
                     </Veins>
                 </Cloud>
 
@@ -1316,8 +1317,8 @@
                             biomes.
                         </Description>
                         <IfCondition condition=':= ?blockExists("minecraft:lapis_ore")'> <OreBlock block='minecraft:lapis_ore' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                        <Replaces block='minecraft:dirt' weight='1.0' />
+                        <Replaces block='minecraft:sandstone' weight='1.0' />
                     </Veins>
                 </Cloud>
                 <!-- "Preferred" configuration complete. -->
@@ -1363,7 +1364,7 @@
                 <Veins name='vnlaEmeraldVeinsPipe'  inherits='vnlaEmeraldVeins' seed='0x54B3' drawWireframe='true' wireframeColor='0x606CE391' drawBoundBox='false' boundBoxColor='0x606CE391'>
                     <IfCondition condition=':= ?blockExists("minecraft:monster_egg")'> <OreBlock block='minecraft:monster_egg' weight='1.0' /> </IfCondition>
                     <ReplacesOre block='stone' weight='1.0' />
-                    <IfCondition condition=':= ?blockExists("minecraft:emerald_ore")'> <Replaces block='minecraft:emerald_ore' weight='1.0' /> </IfCondition>
+                    <Replaces block='minecraft:emerald_ore' weight='1.0' />
                     <Setting name='MotherlodeSize' avg=':= 0 * _default_ * vnlaEmeraldSize  * 0.5 ' range=':= 0 * _default_ * vnlaEmeraldSize  * 0.5 ' type='normal' />
                     <Setting name='SegmentRadius' avg=':= 1.035 * _default_ * vnlaEmeraldSize  * 0.5 ' range=':= 1.035 * _default_ * vnlaEmeraldSize  * 0.5 ' type='normal' />
                     <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
@@ -1442,8 +1443,8 @@
                             scaled  by that.
                         </Description>
                         <IfCondition condition=':= ?blockExists("minecraft:emerald_ore")'> <OreBlock block='minecraft:emerald_ore' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                        <Replaces block='minecraft:dirt' weight='1.0' />
+                        <Replaces block='minecraft:sandstone' weight='1.0' />
                     </Veins>
                 </Cloud>
             </IfCondition>
@@ -1476,7 +1477,7 @@
                     The global option deferredPopulationRange  must be
                     large enough to catch all ore  clusters (>= 32).
                 </Comment>
-                <IfCondition condition=':= ?blockExists("minecraft:quartz_ore")'> <Replaces block='minecraft:quartz_ore' weight='1.0' /> </IfCondition>
+                <Replaces block='minecraft:quartz_ore' weight='1.0' />
             </Substitute>
         </IfCondition>
 
@@ -1495,7 +1496,7 @@
                         horizontal veins each.
                     </Description>
                     <IfCondition condition=':= ?blockExists("minecraft:quartz_ore")'> <OreBlock block='minecraft:quartz_ore' weight='1.0' /> </IfCondition>
-                    <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                    <Replaces block='minecraft:netherrack' weight='1.0' />
                     <Biome name='.*'  />
                     <Setting name='MotherlodeFrequency' avg=':= 6.247 * _default_ * vnlaNetherQuartzFreq ' range=':= 6.247 * _default_ * vnlaNetherQuartzFreq ' type='normal' scaleTo='base' />
                     <Setting name='MotherlodeSize' avg=':= 0 * _default_ * vnlaNetherQuartzSize ' range=':= 0 * _default_ * vnlaNetherQuartzSize ' type='normal' />
@@ -1527,7 +1528,7 @@
                         distributions.
                     </Description>
                     <IfCondition condition=':= ?blockExists("minecraft:quartz_ore")'> <OreBlock block='minecraft:quartz_ore' weight='1.0' /> </IfCondition>
-                    <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                    <Replaces block='minecraft:netherrack' weight='1.0' />
                     <Biome name='.*'  />
                     <Setting name='Size' avg=':= 16.000 * vnlaNetherQuartzSize ' range=':= _default_ * vnlaNetherQuartzSize ' type='normal' />
                     <Setting name='Frequency' avg=':= 13.000 * vnlaNetherQuartzFreq ' range=':= _default_ * vnlaNetherQuartzFreq ' type='normal' scaleTo='base' />
@@ -1556,7 +1557,7 @@
                         time actually  mining the ore.
                     </Description>
                     <IfCondition condition=':= ?blockExists("minecraft:quartz_ore")'> <OreBlock block='minecraft:quartz_ore' weight='1.0' /> </IfCondition>
-                    <IfCondition condition=':= ?blockExists("minecraft:netherrack")'> <Replaces block='minecraft:netherrack' weight='1.0' /> </IfCondition>
+                    <Replaces block='minecraft:netherrack' weight='1.0' />
                     <Biome name='.*'  />
                     <Setting name='CloudRadius' avg=':= 1.494 * _default_ * vnlaNetherQuartzSize ' range=':= 1.494 * _default_ * vnlaNetherQuartzSize ' type='normal' />
                     <Setting name='CloudThickness' avg=':= 1.494 * _default_ * vnlaNetherQuartzSize ' range=':= 1.494 * _default_ * vnlaNetherQuartzSize ' type='normal' scaleTo='base' />
@@ -1587,8 +1588,8 @@
                             scaled  by that.
                         </Description>
                         <IfCondition condition=':= ?blockExists("minecraft:quartz_ore")'> <OreBlock block='minecraft:quartz_ore' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("minecraft:dirt")'> <Replaces block='minecraft:dirt' weight='1.0' /> </IfCondition>
-                        <IfCondition condition=':= ?blockExists("minecraft:sandstone")'> <Replaces block='minecraft:sandstone' weight='1.0' /> </IfCondition>
+                        <Replaces block='minecraft:dirt' weight='1.0' />
+                        <Replaces block='minecraft:sandstone' weight='1.0' />
                     </Veins>
                 </Cloud>
             </IfCondition>


### PR DESCRIPTION
As requested, Sprocket has been updated to remove the block check from <Replaces> and <ReplacesOre> commands.