### PR TITLE
Rearrenged configs in the default.

### DIFF
--- a/src/main/resources/config/CustomOreGen_Config_Default.xml
+++ b/src/main/resources/config/CustomOreGen_Config_Default.xml
@@ -393,26 +393,38 @@
          NOTE: to override a default config, remove the corresponding
          directive (and optionally add something to 'modules/custom')
     -->
+    
+    <!-- First are the stone-based configurations; this way, they can be
+         overridden using the stone oredict entry. -->
+    <Import file='modules/default/Chisel2.xml'/>
+    <Import file='modules/default/GeoStrata.xml'/>   
+    <Import file='modules/default/TinkersSteelworks.xml'/>
 
-    <!-- Vanilla minecraft should always be the first thing to load. -->
+    <!-- Extra Caves creates air pockets in stone.  We'll make this
+         next in order to reduce the available stone for following
+         oregens to use. -->
+    <Import file='modules/default/ExtraCaves.xml'/>
+
+    <!-- Vanilla minecraft ores should always be the first ores to 
+         load. -->
     <Import file='modules/default/VanillaMinecraft.xml'/>
+    
+    <!-- Dense Ores in particular NEEDS to be run after the vanilla
+         configuration, as it clears and regenerates vanilla ores while
+         mixing the dense ores with them. -->
+    <Import file='modules/default/DenseOres.xml'/> 
 
     <!-- Then, the rest are free to come in. -->
     <Import file='modules/default/AppliedEnergistics.xml'/>
     <Import file='modules/default/ArsMagica2.xml'/>
     <Import file='modules/default/BiomesOPlenty.xml'/>
-    <Import file='modules/default/Chisel2.xml'/>
     <Import file='modules/default/Dartcraft.xml'/>
-    <!-- DO in particular NEEDS to be run after the vanilla config! -->
-    <Import file='modules/default/DenseOres.xml'/> 
     <Import file='modules/default/ElectriCraft.xml'/>
-    <Import file='modules/default/ExtraCaves.xml'/>
     <Import file='modules/default/Factorization.xml'/>
     <Import file='modules/default/FlaxbeardsSteamcraft.xml'/>
     <Import file='modules/default/Forestry.xml'/>
     <Import file='modules/default/FossilsandArchaeology.xml'/>
     <Import file='modules/default/Galacticraft.xml'/>
-    <Import file='modules/default/GeoStrata.xml'/>
     <Import file='modules/default/ImmersiveEngineering.xml'/>
     <Import file='modules/default/IndustrialCraft2.xml'/>
     <Import file='modules/default/Mekanism.xml'/>


### PR DESCRIPTION
The order is now as follows:

* Stone is first; now that all oregens now replace the 'stone' oredict, let's push the stone to the front of the queue.
* Next in line is extra caves; might as well reduce the number of replacements before they're made; this might improve performance a little bit.
* Next, vanilla takes priority.
* Next, dense ores is in place to replace vanilla ores with a 10:1 vanilla/dense mix.
* Next, the bulk of the oregen configurations are added, in alphabetical order; these do not interact with one another, so order doesn't matter.
* Finally, Gregtech replaces a lot of the above oregens with its own designs, so it should be last.