### PR TITLE
Fixed vanilla oregen values

### DIFF
--- a/src/main/resources/config/modules/AppliedEnergistics.xml
+++ b/src/main/resources/config/modules/AppliedEnergistics.xml
@@ -155,8 +155,8 @@
                             <IfCondition condition=':= ?blockExists("appliedenergistics2:tile.OreQuartzCharged")'> <OreBlock block='appliedenergistics2:tile.OreQuartzCharged' weight='0.10' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4 * apenCertusQuartzSize ' range=':= _default_ * apenCertusQuartzSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 15 * apenCertusQuartzFreq ' range=':= _default_ * apenCertusQuartzFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.000 * apenCertusQuartzSize ' range=':= 2.000 * apenCertusQuartzSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 7.500 * apenCertusQuartzFreq ' range=':= 7.500 * apenCertusQuartzFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 43 ' range=':= 26 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>

--- a/src/main/resources/config/modules/ArsMagica2.xml
+++ b/src/main/resources/config/modules/ArsMagica2.xml
@@ -282,8 +282,8 @@
                             <IfCondition condition=':= ?blockExists("arsmagica2:vinteumOre")'> <OreBlock block='arsmagica2:vinteumOre' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4 * arsmVinteumSize ' range=':= _default_ * arsmVinteumSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 6 * arsmVinteumFreq ' range=':= _default_ * arsmVinteumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.000 * arsmVinteumSize ' range=':= 2.000 * arsmVinteumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 3.000 * arsmVinteumFreq ' range=':= 3.000 * arsmVinteumFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 27.5 ' range=':= 17.5 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -408,8 +408,8 @@
                             <IfCondition condition=':= ?blockExists("arsmagica2:vinteumOre:1")'> <OreBlock block='arsmagica2:vinteumOre:1' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 6 * arsmChimeriteSize ' range=':= _default_ * arsmChimeriteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 8 * arsmChimeriteFreq ' range=':= _default_ * arsmChimeriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 3.000 * arsmChimeriteSize ' range=':= 3.000 * arsmChimeriteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4.000 * arsmChimeriteFreq ' range=':= 4.000 * arsmChimeriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 45 ' range=':= 35 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -534,8 +534,8 @@
                             <IfCondition condition=':= ?blockExists("arsmagica2:vinteumOre:2")'> <OreBlock block='arsmagica2:vinteumOre:2' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 6 * arsmBlueTopazSize ' range=':= _default_ * arsmBlueTopazSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 8 * arsmBlueTopazFreq ' range=':= _default_ * arsmBlueTopazFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 3.000 * arsmBlueTopazSize ' range=':= 3.000 * arsmBlueTopazSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4.000 * arsmBlueTopazFreq ' range=':= 4.000 * arsmBlueTopazFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 45 ' range=':= 35 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>

--- a/src/main/resources/config/modules/BiomesOPlenty.xml
+++ b/src/main/resources/config/modules/BiomesOPlenty.xml
@@ -460,8 +460,8 @@
                             <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:2")'> <OreBlock block='BiomesOPlenty:gemOre:2' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Desert'  />
-                            <Setting name='Size' avg=':= 1 * boplRubySize ' range=':= _default_ * boplRubySize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1 * boplRubyFreq ' range=':= _default_ * boplRubyFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 0.500 * boplRubySize ' range=':= 0.500 * boplRubySize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 0.500 * boplRubyFreq ' range=':= 0.500 * boplRubyFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -589,8 +589,8 @@
                             <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:4")'> <OreBlock block='BiomesOPlenty:gemOre:4' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Plains'  />
-                            <Setting name='Size' avg=':= 1 * boplPeridotSize ' range=':= _default_ * boplPeridotSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1 * boplPeridotFreq ' range=':= _default_ * boplPeridotFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 0.500 * boplPeridotSize ' range=':= 0.500 * boplPeridotSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 0.500 * boplPeridotFreq ' range=':= 0.500 * boplPeridotFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -718,8 +718,8 @@
                             <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:6")'> <OreBlock block='BiomesOPlenty:gemOre:6' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Jungle'  />
-                            <Setting name='Size' avg=':= 1 * boplTopazSize ' range=':= _default_ * boplTopazSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1 * boplTopazFreq ' range=':= _default_ * boplTopazFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 0.500 * boplTopazSize ' range=':= 0.500 * boplTopazSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 0.500 * boplTopazFreq ' range=':= 0.500 * boplTopazFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -853,8 +853,8 @@
                             <BiomeType name='Frozen'  />
                             <Biome name='Alps'  weight='-1' />
                             <Biome name='Alps Forest'  weight='-1' />
-                            <Setting name='Size' avg=':= 1 * boplTanzaniteSize ' range=':= _default_ * boplTanzaniteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1 * boplTanzaniteFreq ' range=':= _default_ * boplTanzaniteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 0.500 * boplTanzaniteSize ' range=':= 0.500 * boplTanzaniteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 0.500 * boplTanzaniteFreq ' range=':= 0.500 * boplTanzaniteFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -982,8 +982,8 @@
                             <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:10")'> <OreBlock block='BiomesOPlenty:gemOre:10' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Swamp'  />
-                            <Setting name='Size' avg=':= 1 * boplMalachiteSize ' range=':= _default_ * boplMalachiteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1 * boplMalachiteFreq ' range=':= _default_ * boplMalachiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 0.500 * boplMalachiteSize ' range=':= 0.500 * boplMalachiteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 0.500 * boplMalachiteFreq ' range=':= 0.500 * boplMalachiteFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -1129,8 +1129,8 @@
                             <Biome name='Mangrove'  />
                             <Biome name='Sacred Springs'  />
                             <Biome name='Tropics'  />
-                            <Setting name='Size' avg=':= 1 * boplSapphireSize ' range=':= _default_ * boplSapphireSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1 * boplSapphireFreq ' range=':= _default_ * boplSapphireFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 0.500 * boplSapphireSize ' range=':= 0.500 * boplSapphireSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 0.500 * boplSapphireFreq ' range=':= 0.500 * boplSapphireFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -1267,8 +1267,8 @@
                             <Biome name='Grove'  />
                             <Biome name='Shield'  />
                             <Biome name='Thicket'  />
-                            <Setting name='Size' avg=':= 1 * boplAmberSize ' range=':= _default_ * boplAmberSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1 * boplAmberFreq ' range=':= _default_ * boplAmberFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 0.500 * boplAmberSize ' range=':= 0.500 * boplAmberSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 0.500 * boplAmberFreq ' range=':= 0.500 * boplAmberFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -1429,8 +1429,8 @@
                             <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre")'> <OreBlock block='BiomesOPlenty:gemOre' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 1 * boplEnderAmathystSize ' range=':= _default_ * boplEnderAmathystSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1 * boplEnderAmathystFreq ' range=':= _default_ * boplEnderAmathystFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 0.500 * boplEnderAmathystSize ' range=':= 0.500 * boplEnderAmathystSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 0.500 * boplEnderAmathystFreq ' range=':= 0.500 * boplEnderAmathystFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>

--- a/src/main/resources/config/modules/DenseOres.xml
+++ b/src/main/resources/config/modules/DenseOres.xml
@@ -369,19 +369,19 @@
                             <IfCondition condition=':= ?blockExists("denseores:block0")'> <OreBlock block='denseores:block0' weight='0.1' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.583 * _default_ * dnsoIronFreq ' range=':= 1.583 * _default_ * dnsoIronFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.080 * _default_ * dnsoIronSize ' range=':= 1.080 * _default_ * dnsoIronSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 36 ' range=':= 31 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeFrequency' avg=':= 2.238 * _default_ * dnsoIronFreq ' range=':= 2.238 * _default_ * dnsoIronFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.144 * _default_ * dnsoIronSize ' range=':= 1.144 * _default_ * dnsoIronSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 32 ' range=':= 32 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.258 * _default_ ' range=':= 1.258 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.496 * _default_ ' range=':= 1.496 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * dnsoIronSize ' range=':= _default_ * dnsoIronSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.122 * _default_ * dnsoIronSize ' range=':= 1.122 * _default_ * dnsoIronSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.223 * _default_ * dnsoIronSize ' range=':= 1.223 * _default_ * dnsoIronSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -402,9 +402,9 @@
                             <IfCondition condition=':= ?blockExists("denseores:block0")'> <OreBlock block='denseores:block0' weight='0.1' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 8.000 * dnsoIronSize ' range=':= _default_ * dnsoIronSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 10.000 * dnsoIronFreq ' range=':= _default_ * dnsoIronFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 36 ' range=':= 31 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.000 * dnsoIronSize ' range=':= 4.000 * dnsoIronSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 10.000 * dnsoIronFreq ' range=':= 10.000 * dnsoIronFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 32 ' range=':= 32 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -434,10 +434,10 @@
                             <IfCondition condition=':= ?blockExists("denseores:block0")'> <OreBlock block='denseores:block0' weight='0.1' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.177 * _default_ * dnsoIronSize ' range=':= 1.177 * _default_ * dnsoIronSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.177 * _default_ * dnsoIronSize ' range=':= 1.177 * _default_ * dnsoIronSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.385 * _default_ * dnsoIronFreq ' range=':= 1.385 * _default_ * dnsoIronFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 36 ' range=':= 31 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 1.399 * _default_ * dnsoIronSize ' range=':= 1.399 * _default_ * dnsoIronSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.399 * _default_ * dnsoIronSize ' range=':= 1.399 * _default_ * dnsoIronSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.958 * _default_ * dnsoIronFreq ' range=':= 1.958 * _default_ * dnsoIronFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 32 ' range=':= 32 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -492,19 +492,19 @@
                             <IfCondition condition=':= ?blockExists("denseores:block0:1")'> <OreBlock block='denseores:block0:1' weight='0.1' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.500 * _default_ * dnsoGoldFreq ' range=':= 0.500 * _default_ * dnsoGoldFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.891 * _default_ * dnsoGoldSize ' range=':= 0.891 * _default_ * dnsoGoldSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 19 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.708 * _default_ * dnsoGoldFreq ' range=':= 0.708 * _default_ * dnsoGoldFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.944 * _default_ * dnsoGoldSize ' range=':= 0.944 * _default_ * dnsoGoldSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 16 ' range=':= 16 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.707 * _default_ ' range=':= 0.707 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.841 * _default_ ' range=':= 0.841 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * dnsoGoldSize ' range=':= _default_ * dnsoGoldSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.841 * _default_ * dnsoGoldSize ' range=':= 0.841 * _default_ * dnsoGoldSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.917 * _default_ * dnsoGoldSize ' range=':= 0.917 * _default_ * dnsoGoldSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -525,9 +525,9 @@
                             <IfCondition condition=':= ?blockExists("denseores:block0:1")'> <OreBlock block='denseores:block0:1' weight='0.1' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 8.000 * dnsoGoldSize ' range=':= _default_ * dnsoGoldSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.000 * dnsoGoldFreq ' range=':= _default_ * dnsoGoldFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 19 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.000 * dnsoGoldSize ' range=':= 4.000 * dnsoGoldSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.000 * dnsoGoldFreq ' range=':= 1.000 * dnsoGoldFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 16 ' range=':= 16 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -557,10 +557,10 @@
                             <IfCondition condition=':= ?blockExists("denseores:block0:1")'> <OreBlock block='denseores:block0:1' weight='0.1' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.662 * _default_ * dnsoGoldSize ' range=':= 0.662 * _default_ * dnsoGoldSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.662 * _default_ * dnsoGoldSize ' range=':= 0.662 * _default_ * dnsoGoldSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.438 * _default_ * dnsoGoldFreq ' range=':= 0.438 * _default_ * dnsoGoldFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 19 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.787 * _default_ * dnsoGoldSize ' range=':= 0.787 * _default_ * dnsoGoldSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.787 * _default_ * dnsoGoldSize ' range=':= 0.787 * _default_ * dnsoGoldSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.619 * _default_ * dnsoGoldFreq ' range=':= 0.619 * _default_ * dnsoGoldFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 16 ' range=':= 16 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -617,7 +617,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.787 * _default_ * dnsoLapisFreq ' range=':= 0.787 * _default_ * dnsoLapisFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * dnsoLapisSize ' range=':= 0 * _default_ * dnsoLapisSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 19 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 16 ' range=':= 0 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= -_default_ ' range=':= -_default_ ' type='normal' />
@@ -644,7 +644,7 @@
                             <BiomeType name='Ocean'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.787 * _default_ * dnsoLapisFreq ' range=':= 0.787 * _default_ * dnsoLapisFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * dnsoLapisSize ' range=':= 0 * _default_ * dnsoLapisSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 19 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 16 ' range=':= 0 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= -_default_ ' range=':= -_default_ ' type='normal' />
@@ -677,9 +677,9 @@
                             <IfCondition condition=':= ?blockExists("denseores:block0:2")'> <OreBlock block='denseores:block0:2' weight='0.1' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 6.000 * dnsoLapisSize ' range=':= _default_ * dnsoLapisSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.000 * dnsoLapisFreq ' range=':= _default_ * dnsoLapisFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 19 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 3.000 * dnsoLapisSize ' range=':= 3.000 * dnsoLapisSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 0.500 * dnsoLapisFreq ' range=':= 0.500 * dnsoLapisFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 16 ' range=':= 0 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -712,7 +712,7 @@
                             <Setting name='CloudRadius' avg=':= 0.616 * _default_ * dnsoLapisSize ' range=':= 0.616 * _default_ * dnsoLapisSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.616 * _default_ * dnsoLapisSize ' range=':= 0.616 * _default_ * dnsoLapisSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.379 * _default_ * dnsoLapisFreq ' range=':= 0.379 * _default_ * dnsoLapisFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 19 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 16 ' range=':= 0 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -760,7 +760,7 @@
                             <Setting name='CloudRadius' avg=':= 0.616 * _default_ * dnsoLapisSize ' range=':= 0.616 * _default_ * dnsoLapisSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.616 * _default_ * dnsoLapisSize ' range=':= 0.616 * _default_ * dnsoLapisSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.379 * _default_ * dnsoLapisFreq ' range=':= 0.379 * _default_ * dnsoLapisFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 19 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 16 ' range=':= 0 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -935,19 +935,19 @@
                             <IfCondition condition=':= ?blockExists("denseores:block0:4")'> <OreBlock block='denseores:block0:4' weight='0.1' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Mountain'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.121 * _default_ * dnsoEmeraldFreq ' range=':= 0.121 * _default_ * dnsoEmeraldFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.145 * _default_ * dnsoEmeraldFreq ' range=':= 1.145 * _default_ * dnsoEmeraldFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * dnsoEmeraldSize ' range=':= 0 * _default_ * dnsoEmeraldSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 16 ' range=':= 12 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.347 * _default_ ' range=':= 0.347 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.070 * _default_ ' range=':= 1.070 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * dnsoEmeraldSize ' range=':= _default_ * dnsoEmeraldSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.589 * _default_ * dnsoEmeraldSize ' range=':= 0.589 * _default_ * dnsoEmeraldSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.035 * _default_ * dnsoEmeraldSize ' range=':= 1.035 * _default_ * dnsoEmeraldSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -959,7 +959,7 @@
                             <Replaces block='minecraft:emerald_ore' weight='1.0' />
                             <Replaces block='denseores:block0:4' weight='1.0' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * dnsoEmeraldSize  * 0.5 ' range=':= 0 * _default_ * dnsoEmeraldSize  * 0.5 ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.589 * _default_ * dnsoEmeraldSize  * 0.5 ' range=':= 0.589 * _default_ * dnsoEmeraldSize  * 0.5 ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.035 * _default_ * dnsoEmeraldSize  * 0.5 ' range=':= 1.035 * _default_ * dnsoEmeraldSize  * 0.5 ' type='normal' />
                             <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
                         </Veins>
                     </IfCondition>
@@ -979,9 +979,9 @@
                             <IfCondition condition=':= ?blockExists("denseores:block0:4")'> <OreBlock block='denseores:block0:4' weight='0.1' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Mountain'  />
-                            <Setting name='Size' avg=':= 1.000 * dnsoEmeraldSize ' range=':= _default_ * dnsoEmeraldSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 0.200 * dnsoEmeraldFreq ' range=':= _default_ * dnsoEmeraldFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 1.000 * dnsoEmeraldSize ' range=':= 1.000 * dnsoEmeraldSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4.500 * dnsoEmeraldFreq ' range=':= 4.500 * dnsoEmeraldFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 16 ' range=':= 12 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1011,10 +1011,10 @@
                             <IfCondition condition=':= ?blockExists("denseores:block0:4")'> <OreBlock block='denseores:block0:4' weight='0.1' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Mountain'  />
-                            <Setting name='CloudRadius' avg=':= 0.263 * _default_ * dnsoEmeraldSize ' range=':= 0.263 * _default_ * dnsoEmeraldSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.263 * _default_ * dnsoEmeraldSize ' range=':= 0.263 * _default_ * dnsoEmeraldSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.069 * _default_ * dnsoEmeraldFreq ' range=':= 0.069 * _default_ * dnsoEmeraldFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.810 * _default_ * dnsoEmeraldSize ' range=':= 0.810 * _default_ * dnsoEmeraldSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.810 * _default_ * dnsoEmeraldSize ' range=':= 0.810 * _default_ * dnsoEmeraldSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.657 * _default_ * dnsoEmeraldFreq ' range=':= 0.657 * _default_ * dnsoEmeraldFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 16 ' range=':= 12 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1069,9 +1069,9 @@
                             <IfCondition condition=':= ?blockExists("denseores:block0:5")'> <OreBlock block='denseores:block0:5' weight='0.1' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.575 * _default_ * dnsoRedstoneFreq ' range=':= 1.575 * _default_ * dnsoRedstoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeFrequency' avg=':= 2.406 * _default_ * dnsoRedstoneFreq ' range=':= 2.406 * _default_ * dnsoRedstoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * dnsoRedstoneSize ' range=':= 0 * _default_ * dnsoRedstoneSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 10 ' range=':= 5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 8 ' range=':= 8 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= -_default_ ' range=':= -_default_ ' type='normal' />
@@ -1081,7 +1081,7 @@
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * dnsoRedstoneSize ' range=':= _default_ * dnsoRedstoneSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.255 * _default_ * dnsoRedstoneSize ' range=':= 1.255 * _default_ * dnsoRedstoneSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.551 * _default_ * dnsoRedstoneSize ' range=':= 1.551 * _default_ * dnsoRedstoneSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1096,9 +1096,9 @@
                             <IfCondition condition=':= ?blockExists("denseores:block0:5")'> <OreBlock block='denseores:block0:5' weight='0.1' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Desert'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.575 * _default_ * dnsoRedstoneFreq ' range=':= 1.575 * _default_ * dnsoRedstoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeFrequency' avg=':= 2.406 * _default_ * dnsoRedstoneFreq ' range=':= 2.406 * _default_ * dnsoRedstoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * dnsoRedstoneSize ' range=':= 0 * _default_ * dnsoRedstoneSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 10 ' range=':= 5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 8 ' range=':= 8 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= -_default_ ' range=':= -_default_ ' type='normal' />
@@ -1108,7 +1108,7 @@
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * dnsoRedstoneSize ' range=':= _default_ * dnsoRedstoneSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.255 * _default_ * dnsoRedstoneSize ' range=':= 1.255 * _default_ * dnsoRedstoneSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.551 * _default_ * dnsoRedstoneSize ' range=':= 1.551 * _default_ * dnsoRedstoneSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1131,9 +1131,9 @@
                             <IfCondition condition=':= ?blockExists("denseores:block0:5")'> <OreBlock block='denseores:block0:5' weight='0.1' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 6.000 * dnsoRedstoneSize ' range=':= _default_ * dnsoRedstoneSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 4.000 * dnsoRedstoneFreq ' range=':= _default_ * dnsoRedstoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 10 ' range=':= 5 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 3.500 * dnsoRedstoneSize ' range=':= 3.500 * dnsoRedstoneSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4.000 * dnsoRedstoneFreq ' range=':= 4.000 * dnsoRedstoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 8 ' range=':= 8 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1163,10 +1163,10 @@
                             <IfCondition condition=':= ?blockExists("denseores:block0:5")'> <OreBlock block='denseores:block0:5' weight='0.1' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.871 * _default_ * dnsoRedstoneSize ' range=':= 0.871 * _default_ * dnsoRedstoneSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.871 * _default_ * dnsoRedstoneSize ' range=':= 0.871 * _default_ * dnsoRedstoneSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.758 * _default_ * dnsoRedstoneFreq ' range=':= 0.758 * _default_ * dnsoRedstoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 10 ' range=':= 5 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 1.076 * _default_ * dnsoRedstoneSize ' range=':= 1.076 * _default_ * dnsoRedstoneSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.076 * _default_ * dnsoRedstoneSize ' range=':= 1.076 * _default_ * dnsoRedstoneSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.159 * _default_ * dnsoRedstoneFreq ' range=':= 1.159 * _default_ * dnsoRedstoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 8 ' range=':= 8 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1211,10 +1211,10 @@
                             <IfCondition condition=':= ?blockExists("denseores:block0:5")'> <OreBlock block='denseores:block0:5' weight='0.1' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Desert'  />
-                            <Setting name='CloudRadius' avg=':= 0.871 * _default_ * dnsoRedstoneSize ' range=':= 0.871 * _default_ * dnsoRedstoneSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.871 * _default_ * dnsoRedstoneSize ' range=':= 0.871 * _default_ * dnsoRedstoneSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.758 * _default_ * dnsoRedstoneFreq ' range=':= 0.758 * _default_ * dnsoRedstoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 10 ' range=':= 5 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 1.076 * _default_ * dnsoRedstoneSize ' range=':= 1.076 * _default_ * dnsoRedstoneSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.076 * _default_ * dnsoRedstoneSize ' range=':= 1.076 * _default_ * dnsoRedstoneSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.159 * _default_ * dnsoRedstoneFreq ' range=':= 1.159 * _default_ * dnsoRedstoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 8 ' range=':= 8 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1262,19 +1262,19 @@
                             <IfCondition condition=':= ?blockExists("denseores:block0:6")'> <OreBlock block='denseores:block0:6' weight='0.1' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 5.198 * _default_ * dnsoCoalFreq ' range=':= 5.198 * _default_ * dnsoCoalFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeFrequency' avg=':= 7.748 * _default_ * dnsoCoalFreq ' range=':= 7.748 * _default_ * dnsoCoalFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * dnsoCoalSize ' range=':= 0 * _default_ * dnsoCoalSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 68 ' range=':= 63 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 64 ' range=':= 64 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 2.280 * _default_ ' range=':= 2.280 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 2.784 * _default_ ' range=':= 2.784 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * dnsoCoalSize ' range=':= _default_ * dnsoCoalSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.510 * _default_ * dnsoCoalSize ' range=':= 1.510 * _default_ * dnsoCoalSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.668 * _default_ * dnsoCoalSize ' range=':= 1.668 * _default_ * dnsoCoalSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1305,10 +1305,10 @@
                             <IfCondition condition=':= ?blockExists("denseores:block0:6")'> <OreBlock block='denseores:block0:6' weight='0.1' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.363 * _default_ * dnsoCoalSize ' range=':= 1.363 * _default_ * dnsoCoalSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.363 * _default_ * dnsoCoalSize ' range=':= 1.363 * _default_ * dnsoCoalSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.858 * _default_ * dnsoCoalFreq ' range=':= 1.858 * _default_ * dnsoCoalFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 68 ' range=':= 63 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 1.664 * _default_ * dnsoCoalSize ' range=':= 1.664 * _default_ * dnsoCoalSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.664 * _default_ * dnsoCoalSize ' range=':= 1.664 * _default_ * dnsoCoalSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 2.770 * _default_ * dnsoCoalFreq ' range=':= 2.770 * _default_ * dnsoCoalFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64 ' range=':= 64 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1359,9 +1359,9 @@
                             <IfCondition condition=':= ?blockExists("denseores:block0:6")'> <OreBlock block='denseores:block0:6' weight='0.1' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 16.000 * dnsoCoalSize ' range=':= _default_ * dnsoCoalSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 9.000 * dnsoCoalFreq ' range=':= _default_ * dnsoCoalFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 68 ' range=':= 63 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 8.000 * dnsoCoalSize ' range=':= 8.000 * dnsoCoalSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 10.000 * dnsoCoalFreq ' range=':= 10.000 * dnsoCoalFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64 ' range=':= 64 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1391,10 +1391,10 @@
                             <IfCondition condition=':= ?blockExists("denseores:block0:6")'> <OreBlock block='denseores:block0:6' weight='0.1' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.363 * _default_ * dnsoCoalSize ' range=':= 1.363 * _default_ * dnsoCoalSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.363 * _default_ * dnsoCoalSize ' range=':= 1.363 * _default_ * dnsoCoalSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.858 * _default_ * dnsoCoalFreq ' range=':= 1.858 * _default_ * dnsoCoalFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 68 ' range=':= 63 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 1.664 * _default_ * dnsoCoalSize ' range=':= 1.664 * _default_ * dnsoCoalSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.664 * _default_ * dnsoCoalSize ' range=':= 1.664 * _default_ * dnsoCoalSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 2.770 * _default_ * dnsoCoalFreq ' range=':= 2.770 * _default_ * dnsoCoalFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64 ' range=':= 64 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1484,7 +1484,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 6.247 * _default_ * dnsoNetherQuartzFreq ' range=':= 6.247 * _default_ * dnsoNetherQuartzFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * dnsoNetherQuartzSize ' range=':= 0 * _default_ * dnsoNetherQuartzSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 68 ' range=':= 52 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 59 ' range=':= 49 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1516,9 +1516,9 @@
                             <IfCondition condition=':= ?blockExists("denseores:block0:7")'> <OreBlock block='denseores:block0:7' weight='0.1' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 13.000 * dnsoNetherQuartzSize ' range=':= _default_ * dnsoNetherQuartzSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 16.000 * dnsoNetherQuartzFreq ' range=':= _default_ * dnsoNetherQuartzFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 68 ' range=':= 52 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 8.000 * dnsoNetherQuartzSize ' range=':= 8.000 * dnsoNetherQuartzSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 6.500 * dnsoNetherQuartzFreq ' range=':= 6.500 * dnsoNetherQuartzFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 59 ' range=':= 49 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1551,7 +1551,7 @@
                             <Setting name='CloudRadius' avg=':= 1.494 * _default_ * dnsoNetherQuartzSize ' range=':= 1.494 * _default_ * dnsoNetherQuartzSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.494 * _default_ * dnsoNetherQuartzSize ' range=':= 1.494 * _default_ * dnsoNetherQuartzSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 2.233 * _default_ * dnsoNetherQuartzFreq ' range=':= 2.233 * _default_ * dnsoNetherQuartzFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 68 ' range=':= 52 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 59 ' range=':= 49 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />

--- a/src/main/resources/config/modules/ElectriCraft.xml
+++ b/src/main/resources/config/modules/ElectriCraft.xml
@@ -319,8 +319,8 @@
                             <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore")'> <OreBlock block='ElectriCraft:electricraft_block_ore' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 6.000 * elcrCopperSize ' range=':= _default_ * elcrCopperSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 8.000 * elcrCopperFreq ' range=':= _default_ * elcrCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 3.000 * elcrCopperSize ' range=':= 3.000 * elcrCopperSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4.000 * elcrCopperFreq ' range=':= 4.000 * elcrCopperFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 48 ' range=':= 16 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -438,8 +438,8 @@
                             <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:1")'> <OreBlock block='ElectriCraft:electricraft_block_ore:1' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 8.000 * elcrTinSize ' range=':= _default_ * elcrTinSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 8.000 * elcrTinFreq ' range=':= _default_ * elcrTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.000 * elcrTinSize ' range=':= 4.000 * elcrTinSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4.000 * elcrTinFreq ' range=':= 4.000 * elcrTinFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 60 ' range=':= 12 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -557,8 +557,8 @@
                             <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:2")'> <OreBlock block='ElectriCraft:electricraft_block_ore:2' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 6.000 * elcrSilverSize ' range=':= _default_ * elcrSilverSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 4.000 * elcrSilverFreq ' range=':= _default_ * elcrSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 3.000 * elcrSilverSize ' range=':= 3.000 * elcrSilverSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2.000 * elcrSilverFreq ' range=':= 2.000 * elcrSilverFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -676,8 +676,8 @@
                             <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:3")'> <OreBlock block='ElectriCraft:electricraft_block_ore:3' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 8.000 * elcrNickelSize ' range=':= _default_ * elcrNickelSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 6.000 * elcrNickelFreq ' range=':= _default_ * elcrNickelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.000 * elcrNickelSize ' range=':= 4.000 * elcrNickelSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 3.000 * elcrNickelFreq ' range=':= 3.000 * elcrNickelFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 32 ' range=':= 16 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -795,8 +795,8 @@
                             <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:4")'> <OreBlock block='ElectriCraft:electricraft_block_ore:4' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 8.000 * elcrAluminumSize ' range=':= _default_ * elcrAluminumSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 10.000 * elcrAluminumFreq ' range=':= _default_ * elcrAluminumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.000 * elcrAluminumSize ' range=':= 4.000 * elcrAluminumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 5.000 * elcrAluminumFreq ' range=':= 5.000 * elcrAluminumFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 94 ' range=':= 34 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -914,8 +914,8 @@
                             <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:5")'> <OreBlock block='ElectriCraft:electricraft_block_ore:5' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.000 * elcrPlatinumSize ' range=':= _default_ * elcrPlatinumSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2.000 * elcrPlatinumFreq ' range=':= _default_ * elcrPlatinumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.000 * elcrPlatinumSize ' range=':= 2.000 * elcrPlatinumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.000 * elcrPlatinumFreq ' range=':= 1.000 * elcrPlatinumFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 11 ' range=':= 5 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>

--- a/src/main/resources/config/modules/Factorization.xml
+++ b/src/main/resources/config/modules/Factorization.xml
@@ -240,8 +240,8 @@
                             <IfCondition condition=':= ?blockExists("factorization:ResourceBlock")'> <OreBlock block='factorization:ResourceBlock' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 7.000 * fctrSilverSize ' range=':= _default_ * fctrSilverSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 3.000 * fctrSilverFreq ' range=':= _default_ * fctrSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 3.500 * fctrSilverSize ' range=':= 3.500 * fctrSilverSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.500 * fctrSilverFreq ' range=':= 1.500 * fctrSilverFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 25 ' range=':= 10 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -372,8 +372,8 @@
                             <ReplacesOre block='dirt' weight='1.0' />
                             <ReplacesOre block='gravel' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 1.000 * fctrDarkIronSize ' range=':= _default_ * fctrDarkIronSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.000 * fctrDarkIronFreq ' range=':= _default_ * fctrDarkIronFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 0.500 * fctrDarkIronSize ' range=':= 0.500 * fctrDarkIronSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 0.500 * fctrDarkIronFreq ' range=':= 0.500 * fctrDarkIronFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 3 ' range=':= 2 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>

--- a/src/main/resources/config/modules/FlaxbeardsSteamcraft.xml
+++ b/src/main/resources/config/modules/FlaxbeardsSteamcraft.xml
@@ -240,8 +240,8 @@
                             <IfCondition condition=':= ?blockExists("Steamcraft:steamcraftOre")'> <OreBlock block='Steamcraft:steamcraftOre' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 5.000 * flxbCopperSize ' range=':= _default_ * flxbCopperSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 10.000 * flxbCopperFreq ' range=':= _default_ * flxbCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.500 * flxbCopperSize ' range=':= 2.500 * flxbCopperSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 5.000 * flxbCopperFreq ' range=':= 5.000 * flxbCopperFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 42.5 ' range=':= 37.5 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -359,8 +359,8 @@
                             <IfCondition condition=':= ?blockExists("Steamcraft:steamcraftOre:1")'> <OreBlock block='Steamcraft:steamcraftOre:1' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.000 * flxbZincSize ' range=':= _default_ * flxbZincSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 7.000 * flxbZincFreq ' range=':= _default_ * flxbZincFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.000 * flxbZincSize ' range=':= 2.000 * flxbZincSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 3.500 * flxbZincFreq ' range=':= 3.500 * flxbZincFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 40 ' range=':= 35 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>

--- a/src/main/resources/config/modules/Forestry.xml
+++ b/src/main/resources/config/modules/Forestry.xml
@@ -282,8 +282,8 @@
                             <IfCondition condition=':= ?blockExists("Forestry:resources")'> <OreBlock block='Forestry:resources' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 36.000 * frstApatiteSize ' range=':= _default_ * frstApatiteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.000 * frstApatiteFreq ' range=':= _default_ * frstApatiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 18.000 * frstApatiteSize ' range=':= 18.000 * frstApatiteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 0.500 * frstApatiteFreq ' range=':= 0.500 * frstApatiteFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 120 ' range=':= 64 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -401,8 +401,8 @@
                             <IfCondition condition=':= ?blockExists("Forestry:resources:1")'> <OreBlock block='Forestry:resources:1' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 6.000 * frstCopperSize ' range=':= _default_ * frstCopperSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 20.000 * frstCopperFreq ' range=':= _default_ * frstCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 3.000 * frstCopperSize ' range=':= 3.000 * frstCopperSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 10.000 * frstCopperFreq ' range=':= 10.000 * frstCopperFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 106 ' range=':= 74 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -520,8 +520,8 @@
                             <IfCondition condition=':= ?blockExists("Forestry:resources:2")'> <OreBlock block='Forestry:resources:2' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 6.000 * frstTinSize ' range=':= _default_ * frstTinSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 18.000 * frstTinFreq ' range=':= _default_ * frstTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 3.000 * frstTinSize ' range=':= 3.000 * frstTinSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 9.000 * frstTinFreq ' range=':= 9.000 * frstTinFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 98 ' range=':= 82 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>

--- a/src/main/resources/config/modules/FossilsandArchaeology.xml
+++ b/src/main/resources/config/modules/FossilsandArchaeology.xml
@@ -310,8 +310,8 @@
                             <IfCondition condition=':= ?blockExists("fossil:fossil")'> <OreBlock block='fossil:fossil' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 8.000 * fsarFossilsSize ' range=':= _default_ * fsarFossilsSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 38.000 * fsarFossilsFreq ' range=':= _default_ * fsarFossilsFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.000 * fsarFossilsSize ' range=':= 4.000 * fsarFossilsSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 19.000 * fsarFossilsFreq ' range=':= 19.000 * fsarFossilsFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 53 ' range=':= 47 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -439,8 +439,8 @@
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <BiomeType name='Frozen'  />
-                            <Setting name='Size' avg=':= 4.000 * fsarPermafrostSize ' range=':= _default_ * fsarPermafrostSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 8.000 * fsarPermafrostFreq ' range=':= _default_ * fsarPermafrostFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.000 * fsarPermafrostSize ' range=':= 2.000 * fsarPermafrostSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4.000 * fsarPermafrostFreq ' range=':= 4.000 * fsarPermafrostFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 18 ' range=':= 12.5 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>

--- a/src/main/resources/config/modules/Galacticraft.xml
+++ b/src/main/resources/config/modules/Galacticraft.xml
@@ -311,8 +311,8 @@
                             <IfCondition condition=':= ?blockExists("GalacticraftCore:tile.gcBlockCore:5")'> <OreBlock block='GalacticraftCore:tile.gcBlockCore:5' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 7.000 * glctCopperSize ' range=':= _default_ * glctCopperSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 24.000 * glctCopperFreq ' range=':= _default_ * glctCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 3.500 * glctCopperSize ' range=':= 3.500 * glctCopperSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 12.000 * glctCopperFreq ' range=':= 12.000 * glctCopperFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 40 ' range=':= 35 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -430,8 +430,8 @@
                             <IfCondition condition=':= ?blockExists("GalacticraftCore:tile.gcBlockCore:6")'> <OreBlock block='GalacticraftCore:tile.gcBlockCore:6' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 7.000 * glctTinSize ' range=':= _default_ * glctTinSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 22.000 * glctTinFreq ' range=':= _default_ * glctTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 3.500 * glctTinSize ' range=':= 3.500 * glctTinSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 11.000 * glctTinFreq ' range=':= 11.000 * glctTinFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 33 ' range=':= 27 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -549,8 +549,8 @@
                             <IfCondition condition=':= ?blockExists("GalacticraftCore:tile.gcBlockCore:7")'> <OreBlock block='GalacticraftCore:tile.gcBlockCore:7' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 7.000 * glctAluminumSize ' range=':= _default_ * glctAluminumSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 18.000 * glctAluminumFreq ' range=':= _default_ * glctAluminumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 3.500 * glctAluminumSize ' range=':= 3.500 * glctAluminumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 9.000 * glctAluminumFreq ' range=':= 9.000 * glctAluminumFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 25 ' range=':= 20 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -668,8 +668,8 @@
                             <IfCondition condition=':= ?blockExists("GalacticraftCore:tile.gcBlockCore:8")'> <OreBlock block='GalacticraftCore:tile.gcBlockCore:8' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 7.000 * glctSiliconSize ' range=':= _default_ * glctSiliconSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 3.000 * glctSiliconFreq ' range=':= _default_ * glctSiliconFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 3.500 * glctSiliconSize ' range=':= 3.500 * glctSiliconSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.500 * glctSiliconFreq ' range=':= 1.500 * glctSiliconFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 15 ' range=':= 10 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>

--- a/src/main/resources/config/modules/GeoStrata.xml
+++ b/src/main/resources/config/modules/GeoStrata.xml
@@ -767,8 +767,8 @@
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_shale_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_shale_smooth' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 32 * gstaShaleSize ' range=':= _default_ * gstaShaleSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 24.000 * gstaShaleFreq ' range=':= _default_ * gstaShaleFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 16.000 * gstaShaleSize ' range=':= 16.000 * gstaShaleSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 12.000 * gstaShaleFreq ' range=':= 12.000 * gstaShaleFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 56 ' range=':= 8 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -886,8 +886,8 @@
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_sandstone_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_sandstone_smooth' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 32 * gstaSandstoneSize ' range=':= _default_ * gstaSandstoneSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 24.000 * gstaSandstoneFreq ' range=':= _default_ * gstaSandstoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 16.000 * gstaSandstoneSize ' range=':= 16.000 * gstaSandstoneSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 12.000 * gstaSandstoneFreq ' range=':= 12.000 * gstaSandstoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 88 ' range=':= 40 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -1005,8 +1005,8 @@
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_limestone_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_limestone_smooth' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 32 * gstaLimestoneSize ' range=':= _default_ * gstaLimestoneSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 24.000 * gstaLimestoneFreq ' range=':= _default_ * gstaLimestoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 16.000 * gstaLimestoneSize ' range=':= 16.000 * gstaLimestoneSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 12.000 * gstaLimestoneFreq ' range=':= 12.000 * gstaLimestoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 88 ' range=':= 40 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -1124,8 +1124,8 @@
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_pumice_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_pumice_smooth' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 32 * gstaPumiceSize ' range=':= _default_ * gstaPumiceSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 14.400 * gstaPumiceFreq ' range=':= _default_ * gstaPumiceFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 16.000 * gstaPumiceSize ' range=':= 16.000 * gstaPumiceSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 7.200 * gstaPumiceFreq ' range=':= 7.200 * gstaPumiceFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 11 ' range=':= 5 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -1243,8 +1243,8 @@
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_opal_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_opal_smooth' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 32 * gstaOpalSize ' range=':= _default_ * gstaOpalSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 3.000 * gstaOpalFreq ' range=':= _default_ * gstaOpalFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 16.000 * gstaOpalSize ' range=':= 16.000 * gstaOpalSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.500 * gstaOpalFreq ' range=':= 1.500 * gstaOpalFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -1362,8 +1362,8 @@
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_slate_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_slate_smooth' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 32 * gstaSlateSize ' range=':= _default_ * gstaSlateSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 24.000 * gstaSlateFreq ' range=':= _default_ * gstaSlateFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 16.000 * gstaSlateSize ' range=':= 16.000 * gstaSlateSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 12.000 * gstaSlateFreq ' range=':= 12.000 * gstaSlateFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 40 ' range=':= 8 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -1481,8 +1481,8 @@
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_gneiss_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_gneiss_smooth' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 32 * gstaGneissSize ' range=':= _default_ * gstaGneissSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 19.200 * gstaGneissFreq ' range=':= _default_ * gstaGneissFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 16.000 * gstaGneissSize ' range=':= 16.000 * gstaGneissSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 9.600 * gstaGneissFreq ' range=':= 9.600 * gstaGneissFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 24 ' range=':= 8 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -1600,8 +1600,8 @@
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_peridotite_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_peridotite_smooth' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 32 * gstaPeridotiteSize ' range=':= _default_ * gstaPeridotiteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 14.400 * gstaPeridotiteFreq ' range=':= _default_ * gstaPeridotiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 16.000 * gstaPeridotiteSize ' range=':= 16.000 * gstaPeridotiteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 7.200 * gstaPeridotiteFreq ' range=':= 7.200 * gstaPeridotiteFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 15 ' range=':= 9 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -1719,8 +1719,8 @@
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_granulite_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_granulite_smooth' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 32 * gstaGranuliteSize ' range=':= _default_ * gstaGranuliteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 16.800 * gstaGranuliteFreq ' range=':= _default_ * gstaGranuliteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 16.000 * gstaGranuliteSize ' range=':= 16.000 * gstaGranuliteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 8.400 * gstaGranuliteFreq ' range=':= 8.400 * gstaGranuliteFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 24 ' range=':= 8 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -1838,8 +1838,8 @@
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_migmatite_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_migmatite_smooth' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 32 * gstaMigmatiteSize ' range=':= _default_ * gstaMigmatiteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 14.400 * gstaMigmatiteFreq ' range=':= _default_ * gstaMigmatiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 16.000 * gstaMigmatiteSize ' range=':= 16.000 * gstaMigmatiteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 7.200 * gstaMigmatiteFreq ' range=':= 7.200 * gstaMigmatiteFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 11 ' range=':= 5 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -1957,8 +1957,8 @@
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_schist_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_schist_smooth' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 32 * gstaSchistSize ' range=':= _default_ * gstaSchistSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 19.200 * gstaSchistFreq ' range=':= _default_ * gstaSchistFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 16.000 * gstaSchistSize ' range=':= 16.000 * gstaSchistSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 9.600 * gstaSchistFreq ' range=':= 9.600 * gstaSchistFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 32 ' range=':= 16 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -2076,8 +2076,8 @@
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_basalt_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_basalt_smooth' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 32 * gstaBasaltSize ' range=':= _default_ * gstaBasaltSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 24.000 * gstaBasaltFreq ' range=':= _default_ * gstaBasaltFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 16.000 * gstaBasaltSize ' range=':= 16.000 * gstaBasaltSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 12.000 * gstaBasaltFreq ' range=':= 12.000 * gstaBasaltFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 88 ' range=':= 40 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -2195,8 +2195,8 @@
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_onyx_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_onyx_smooth' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 32 * gstaOnyxSize ' range=':= _default_ * gstaOnyxSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 24.000 * gstaOnyxFreq ' range=':= _default_ * gstaOnyxFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 16.000 * gstaOnyxSize ' range=':= 16.000 * gstaOnyxSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 12.000 * gstaOnyxFreq ' range=':= 12.000 * gstaOnyxFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 15 ' range=':= 9 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -2314,8 +2314,8 @@
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_quartz_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_quartz_smooth' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 32 * gstaQuartzSize ' range=':= _default_ * gstaQuartzSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 12.000 * gstaQuartzFreq ' range=':= _default_ * gstaQuartzFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 16.000 * gstaQuartzSize ' range=':= 16.000 * gstaQuartzSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 6.000 * gstaQuartzFreq ' range=':= 6.000 * gstaQuartzFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 35 ' range=':= 29 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -2433,8 +2433,8 @@
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_marble_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_marble_smooth' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 32 * gstaMarbleSize ' range=':= _default_ * gstaMarbleSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 24.000 * gstaMarbleFreq ' range=':= _default_ * gstaMarbleFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 16.000 * gstaMarbleSize ' range=':= 16.000 * gstaMarbleSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 12.000 * gstaMarbleFreq ' range=':= 12.000 * gstaMarbleFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 40 ' range=':= 24 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -2552,8 +2552,8 @@
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_granite_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_granite_smooth' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 32 * gstaGraniteSize ' range=':= _default_ * gstaGraniteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 24.000 * gstaGraniteFreq ' range=':= _default_ * gstaGraniteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 16.000 * gstaGraniteSize ' range=':= 16.000 * gstaGraniteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 12.000 * gstaGraniteFreq ' range=':= 12.000 * gstaGraniteFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 32 ' range=':= 16 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -2671,8 +2671,8 @@
                             <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_hornfel_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_hornfel_smooth' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 32 * gstaHornfelSize ' range=':= _default_ * gstaHornfelSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 19.200 * gstaHornfelFreq ' range=':= _default_ * gstaHornfelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 16.000 * gstaHornfelSize ' range=':= 16.000 * gstaHornfelSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 9.600 * gstaHornfelFreq ' range=':= 9.600 * gstaHornfelFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 35 ' range=':= 29 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>

--- a/src/main/resources/config/modules/ImmersiveEngineering.xml
+++ b/src/main/resources/config/modules/ImmersiveEngineering.xml
@@ -251,19 +251,19 @@
                             <IfCondition condition=':= ?blockExists("ImmersiveEngineering:ore:0")'> <OreBlock block='ImmersiveEngineering:ore:0' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.416 * _default_ * iengCopperFreq ' range=':= 1.416 * _default_ * iengCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.060 * _default_ * iengCopperSize ' range=':= 1.060 * _default_ * iengCopperSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.001 * _default_ * iengCopperFreq ' range=':= 1.001 * _default_ * iengCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.000 * _default_ * iengCopperSize ' range=':= 1.000 * _default_ * iengCopperSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 56 ' range=':= 16 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.190 * _default_ ' range=':= 1.190 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.000 * _default_ ' range=':= 1.000 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * iengCopperSize ' range=':= _default_ * iengCopperSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.091 * _default_ * iengCopperSize ' range=':= 1.091 * _default_ * iengCopperSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.000 * _default_ * iengCopperSize ' range=':= 1.000 * _default_ * iengCopperSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -293,9 +293,9 @@
                             <IfCondition condition=':= ?blockExists("ImmersiveEngineering:ore:0")'> <OreBlock block='ImmersiveEngineering:ore:0' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.113 * _default_ * iengCopperSize ' range=':= 1.113 * _default_ * iengCopperSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.113 * _default_ * iengCopperSize ' range=':= 1.113 * _default_ * iengCopperSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.239 * _default_ * iengCopperFreq ' range=':= 1.239 * _default_ * iengCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.936 * _default_ * iengCopperSize ' range=':= 0.936 * _default_ * iengCopperSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.936 * _default_ * iengCopperSize ' range=':= 0.936 * _default_ * iengCopperSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.876 * _default_ * iengCopperFreq ' range=':= 0.876 * _default_ * iengCopperFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 56 ' range=':= 16 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -345,8 +345,8 @@
                             <IfCondition condition=':= ?blockExists("ImmersiveEngineering:ore:0")'> <OreBlock block='ImmersiveEngineering:ore:0' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 8.000 * iengCopperSize ' range=':= _default_ * iengCopperSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 8.000 * iengCopperFreq ' range=':= _default_ * iengCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.000 * iengCopperSize ' range=':= 4.000 * iengCopperSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4.000 * iengCopperFreq ' range=':= 4.000 * iengCopperFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 56 ' range=':= 16 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -370,19 +370,19 @@
                             <IfCondition condition=':= ?blockExists("ImmersiveEngineering:ore:1")'> <OreBlock block='ImmersiveEngineering:ore:1' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.001 * _default_ * iengBauxiteFreq ' range=':= 1.001 * _default_ * iengBauxiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.000 * _default_ * iengBauxiteSize ' range=':= 1.000 * _default_ * iengBauxiteSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.708 * _default_ * iengBauxiteFreq ' range=':= 0.708 * _default_ * iengBauxiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.944 * _default_ * iengBauxiteSize ' range=':= 0.944 * _default_ * iengBauxiteSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 62.5 ' range=':= 22.5 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.000 * _default_ ' range=':= 1.000 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.841 * _default_ ' range=':= 0.841 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * iengBauxiteSize ' range=':= _default_ * iengBauxiteSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.000 * _default_ * iengBauxiteSize ' range=':= 1.000 * _default_ * iengBauxiteSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.917 * _default_ * iengBauxiteSize ' range=':= 0.917 * _default_ * iengBauxiteSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -412,9 +412,9 @@
                             <IfCondition condition=':= ?blockExists("ImmersiveEngineering:ore:1")'> <OreBlock block='ImmersiveEngineering:ore:1' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.936 * _default_ * iengBauxiteSize ' range=':= 0.936 * _default_ * iengBauxiteSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.936 * _default_ * iengBauxiteSize ' range=':= 0.936 * _default_ * iengBauxiteSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.876 * _default_ * iengBauxiteFreq ' range=':= 0.876 * _default_ * iengBauxiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.787 * _default_ * iengBauxiteSize ' range=':= 0.787 * _default_ * iengBauxiteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.787 * _default_ * iengBauxiteSize ' range=':= 0.787 * _default_ * iengBauxiteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.619 * _default_ * iengBauxiteFreq ' range=':= 0.619 * _default_ * iengBauxiteFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 62.5 ' range=':= 22.5 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -464,8 +464,8 @@
                             <IfCondition condition=':= ?blockExists("ImmersiveEngineering:ore:1")'> <OreBlock block='ImmersiveEngineering:ore:1' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.000 * iengBauxiteSize ' range=':= _default_ * iengBauxiteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 8.000 * iengBauxiteFreq ' range=':= _default_ * iengBauxiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.000 * iengBauxiteSize ' range=':= 2.000 * iengBauxiteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4.000 * iengBauxiteFreq ' range=':= 4.000 * iengBauxiteFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 62.5 ' range=':= 22.5 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -489,19 +489,19 @@
                             <IfCondition condition=':= ?blockExists("ImmersiveEngineering:ore:2")'> <OreBlock block='ImmersiveEngineering:ore:2' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.867 * _default_ * iengLeadFreq ' range=':= 0.867 * _default_ * iengLeadFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.976 * _default_ * iengLeadSize ' range=':= 0.976 * _default_ * iengLeadSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.613 * _default_ * iengLeadFreq ' range=':= 0.613 * _default_ * iengLeadFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * iengLeadSize ' range=':= 0.922 * _default_ * iengLeadSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 22 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.931 * _default_ ' range=':= 0.931 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.783 * _default_ ' range=':= 0.783 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * iengLeadSize ' range=':= _default_ * iengLeadSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.965 * _default_ * iengLeadSize ' range=':= 0.965 * _default_ * iengLeadSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.885 * _default_ * iengLeadSize ' range=':= 0.885 * _default_ * iengLeadSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -531,9 +531,9 @@
                             <IfCondition condition=':= ?blockExists("ImmersiveEngineering:ore:2")'> <OreBlock block='ImmersiveEngineering:ore:2' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.871 * _default_ * iengLeadSize ' range=':= 0.871 * _default_ * iengLeadSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.871 * _default_ * iengLeadSize ' range=':= 0.871 * _default_ * iengLeadSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.758 * _default_ * iengLeadFreq ' range=':= 0.758 * _default_ * iengLeadFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.732 * _default_ * iengLeadSize ' range=':= 0.732 * _default_ * iengLeadSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.732 * _default_ * iengLeadSize ' range=':= 0.732 * _default_ * iengLeadSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.536 * _default_ * iengLeadFreq ' range=':= 0.536 * _default_ * iengLeadFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 22 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -583,8 +583,8 @@
                             <IfCondition condition=':= ?blockExists("ImmersiveEngineering:ore:2")'> <OreBlock block='ImmersiveEngineering:ore:2' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 6.000 * iengLeadSize ' range=':= _default_ * iengLeadSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 4.000 * iengLeadFreq ' range=':= _default_ * iengLeadFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 3.000 * iengLeadSize ' range=':= 3.000 * iengLeadSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2.000 * iengLeadFreq ' range=':= 2.000 * iengLeadFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 22 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -608,19 +608,19 @@
                             <IfCondition condition=':= ?blockExists("ImmersiveEngineering:ore:3")'> <OreBlock block='ImmersiveEngineering:ore:3' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.001 * _default_ * iengSilverFreq ' range=':= 1.001 * _default_ * iengSilverFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.000 * _default_ * iengSilverSize ' range=':= 1.000 * _default_ * iengSilverSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.708 * _default_ * iengSilverFreq ' range=':= 0.708 * _default_ * iengSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.944 * _default_ * iengSilverSize ' range=':= 0.944 * _default_ * iengSilverSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 24 ' range=':= 16 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.000 * _default_ ' range=':= 1.000 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.841 * _default_ ' range=':= 0.841 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * iengSilverSize ' range=':= _default_ * iengSilverSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.000 * _default_ * iengSilverSize ' range=':= 1.000 * _default_ * iengSilverSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.917 * _default_ * iengSilverSize ' range=':= 0.917 * _default_ * iengSilverSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -650,9 +650,9 @@
                             <IfCondition condition=':= ?blockExists("ImmersiveEngineering:ore:3")'> <OreBlock block='ImmersiveEngineering:ore:3' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.936 * _default_ * iengSilverSize ' range=':= 0.936 * _default_ * iengSilverSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.936 * _default_ * iengSilverSize ' range=':= 0.936 * _default_ * iengSilverSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.876 * _default_ * iengSilverFreq ' range=':= 0.876 * _default_ * iengSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.787 * _default_ * iengSilverSize ' range=':= 0.787 * _default_ * iengSilverSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.787 * _default_ * iengSilverSize ' range=':= 0.787 * _default_ * iengSilverSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.619 * _default_ * iengSilverFreq ' range=':= 0.619 * _default_ * iengSilverFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 24 ' range=':= 16 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -702,8 +702,8 @@
                             <IfCondition condition=':= ?blockExists("ImmersiveEngineering:ore:3")'> <OreBlock block='ImmersiveEngineering:ore:3' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 8.000 * iengSilverSize ' range=':= _default_ * iengSilverSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 4.000 * iengSilverFreq ' range=':= _default_ * iengSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.000 * iengSilverSize ' range=':= 4.000 * iengSilverSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2.000 * iengSilverFreq ' range=':= 2.000 * iengSilverFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 24 ' range=':= 16 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -727,19 +727,19 @@
                             <IfCondition condition=':= ?blockExists("ImmersiveEngineering:ore:4")'> <OreBlock block='ImmersiveEngineering:ore:4' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.613 * _default_ * iengNickelFreq ' range=':= 0.613 * _default_ * iengNickelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * iengNickelSize ' range=':= 0.922 * _default_ * iengNickelSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.433 * _default_ * iengNickelFreq ' range=':= 0.433 * _default_ * iengNickelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.870 * _default_ * iengNickelSize ' range=':= 0.870 * _default_ * iengNickelSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 16 ' range=':= 8 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.783 * _default_ ' range=':= 0.783 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.658 * _default_ ' range=':= 0.658 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * iengNickelSize ' range=':= _default_ * iengNickelSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.885 * _default_ * iengNickelSize ' range=':= 0.885 * _default_ * iengNickelSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.811 * _default_ * iengNickelSize ' range=':= 0.811 * _default_ * iengNickelSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -769,9 +769,9 @@
                             <IfCondition condition=':= ?blockExists("ImmersiveEngineering:ore:4")'> <OreBlock block='ImmersiveEngineering:ore:4' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.732 * _default_ * iengNickelSize ' range=':= 0.732 * _default_ * iengNickelSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.732 * _default_ * iengNickelSize ' range=':= 0.732 * _default_ * iengNickelSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.536 * _default_ * iengNickelFreq ' range=':= 0.536 * _default_ * iengNickelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.616 * _default_ * iengNickelSize ' range=':= 0.616 * _default_ * iengNickelSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.616 * _default_ * iengNickelSize ' range=':= 0.616 * _default_ * iengNickelSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.379 * _default_ * iengNickelFreq ' range=':= 0.379 * _default_ * iengNickelFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 16 ' range=':= 8 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -821,8 +821,8 @@
                             <IfCondition condition=':= ?blockExists("ImmersiveEngineering:ore:4")'> <OreBlock block='ImmersiveEngineering:ore:4' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 6.000 * iengNickelSize ' range=':= _default_ * iengNickelSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2.000 * iengNickelFreq ' range=':= _default_ * iengNickelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 3.000 * iengNickelSize ' range=':= 3.000 * iengNickelSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.000 * iengNickelFreq ' range=':= 1.000 * iengNickelFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 16 ' range=':= 8 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>

--- a/src/main/resources/config/modules/Mekanism.xml
+++ b/src/main/resources/config/modules/Mekanism.xml
@@ -180,19 +180,19 @@
                             <IfCondition condition=':= ?blockExists("Mekanism:OreBlock")'> <OreBlock block='Mekanism:OreBlock' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.734 * _default_ * mknsOsmiumFreq ' range=':= 1.734 * _default_ * mknsOsmiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.096 * _default_ * mknsOsmiumSize ' range=':= 1.096 * _default_ * mknsOsmiumSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.226 * _default_ * mknsOsmiumFreq ' range=':= 1.226 * _default_ * mknsOsmiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.035 * _default_ * mknsOsmiumSize ' range=':= 1.035 * _default_ * mknsOsmiumSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 33 ' range=':= 27 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.317 * _default_ ' range=':= 1.317 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.107 * _default_ ' range=':= 1.107 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mknsOsmiumSize ' range=':= _default_ * mknsOsmiumSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.147 * _default_ * mknsOsmiumSize ' range=':= 1.147 * _default_ * mknsOsmiumSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.052 * _default_ * mknsOsmiumSize ' range=':= 1.052 * _default_ * mknsOsmiumSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -222,9 +222,9 @@
                             <IfCondition condition=':= ?blockExists("Mekanism:OreBlock")'> <OreBlock block='Mekanism:OreBlock' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.232 * _default_ * mknsOsmiumSize ' range=':= 1.232 * _default_ * mknsOsmiumSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.232 * _default_ * mknsOsmiumSize ' range=':= 1.232 * _default_ * mknsOsmiumSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.517 * _default_ * mknsOsmiumFreq ' range=':= 1.517 * _default_ * mknsOsmiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 1.036 * _default_ * mknsOsmiumSize ' range=':= 1.036 * _default_ * mknsOsmiumSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.036 * _default_ * mknsOsmiumSize ' range=':= 1.036 * _default_ * mknsOsmiumSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.073 * _default_ * mknsOsmiumFreq ' range=':= 1.073 * _default_ * mknsOsmiumFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 33 ' range=':= 27 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -274,8 +274,8 @@
                             <IfCondition condition=':= ?blockExists("Mekanism:OreBlock")'> <OreBlock block='Mekanism:OreBlock' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 8.000 * mknsOsmiumSize ' range=':= _default_ * mknsOsmiumSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 12.000 * mknsOsmiumFreq ' range=':= _default_ * mknsOsmiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.000 * mknsOsmiumSize ' range=':= 4.000 * mknsOsmiumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 6.000 * mknsOsmiumFreq ' range=':= 6.000 * mknsOsmiumFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 33 ' range=':= 27 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -299,19 +299,19 @@
                             <IfCondition condition=':= ?blockExists("Mekanism:OreBlock:1")'> <OreBlock block='Mekanism:OreBlock:1' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 2.002 * _default_ * mknsCopperFreq ' range=':= 2.002 * _default_ * mknsCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.123 * _default_ * mknsCopperSize ' range=':= 1.123 * _default_ * mknsCopperSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.416 * _default_ * mknsCopperFreq ' range=':= 1.416 * _default_ * mknsCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.060 * _default_ * mknsCopperSize ' range=':= 1.060 * _default_ * mknsCopperSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 33 ' range=':= 27 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.415 * _default_ ' range=':= 1.415 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.190 * _default_ ' range=':= 1.190 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mknsCopperSize ' range=':= _default_ * mknsCopperSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.189 * _default_ * mknsCopperSize ' range=':= 1.189 * _default_ * mknsCopperSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.091 * _default_ * mknsCopperSize ' range=':= 1.091 * _default_ * mknsCopperSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -341,9 +341,9 @@
                             <IfCondition condition=':= ?blockExists("Mekanism:OreBlock:1")'> <OreBlock block='Mekanism:OreBlock:1' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.323 * _default_ * mknsCopperSize ' range=':= 1.323 * _default_ * mknsCopperSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.323 * _default_ * mknsCopperSize ' range=':= 1.323 * _default_ * mknsCopperSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.752 * _default_ * mknsCopperFreq ' range=':= 1.752 * _default_ * mknsCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 1.113 * _default_ * mknsCopperSize ' range=':= 1.113 * _default_ * mknsCopperSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.113 * _default_ * mknsCopperSize ' range=':= 1.113 * _default_ * mknsCopperSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.239 * _default_ * mknsCopperFreq ' range=':= 1.239 * _default_ * mknsCopperFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 33 ' range=':= 27 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -393,8 +393,8 @@
                             <IfCondition condition=':= ?blockExists("Mekanism:OreBlock:1")'> <OreBlock block='Mekanism:OreBlock:1' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 8.000 * mknsCopperSize ' range=':= _default_ * mknsCopperSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 16.000 * mknsCopperFreq ' range=':= _default_ * mknsCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.000 * mknsCopperSize ' range=':= 4.000 * mknsCopperSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 8.000 * mknsCopperFreq ' range=':= 8.000 * mknsCopperFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 33 ' range=':= 27 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -418,19 +418,19 @@
                             <IfCondition condition=':= ?blockExists("Mekanism:OreBlock:2")'> <OreBlock block='Mekanism:OreBlock:2' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.873 * _default_ * mknsTinFreq ' range=':= 1.873 * _default_ * mknsTinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.110 * _default_ * mknsTinSize ' range=':= 1.110 * _default_ * mknsTinSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.324 * _default_ * mknsTinFreq ' range=':= 1.324 * _default_ * mknsTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.048 * _default_ * mknsTinSize ' range=':= 1.048 * _default_ * mknsTinSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 33 ' range=':= 27 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.368 * _default_ ' range=':= 1.368 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.151 * _default_ ' range=':= 1.151 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mknsTinSize ' range=':= _default_ * mknsTinSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.170 * _default_ * mknsTinSize ' range=':= 1.170 * _default_ * mknsTinSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.073 * _default_ * mknsTinSize ' range=':= 1.073 * _default_ * mknsTinSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -460,9 +460,9 @@
                             <IfCondition condition=':= ?blockExists("Mekanism:OreBlock:2")'> <OreBlock block='Mekanism:OreBlock:2' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.280 * _default_ * mknsTinSize ' range=':= 1.280 * _default_ * mknsTinSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.280 * _default_ * mknsTinSize ' range=':= 1.280 * _default_ * mknsTinSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.638 * _default_ * mknsTinFreq ' range=':= 1.638 * _default_ * mknsTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 1.076 * _default_ * mknsTinSize ' range=':= 1.076 * _default_ * mknsTinSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.076 * _default_ * mknsTinSize ' range=':= 1.076 * _default_ * mknsTinSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.159 * _default_ * mknsTinFreq ' range=':= 1.159 * _default_ * mknsTinFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 33 ' range=':= 27 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -512,8 +512,8 @@
                             <IfCondition condition=':= ?blockExists("Mekanism:OreBlock:2")'> <OreBlock block='Mekanism:OreBlock:2' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 8.000 * mknsTinSize ' range=':= _default_ * mknsTinSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 14.000 * mknsTinFreq ' range=':= _default_ * mknsTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.000 * mknsTinSize ' range=':= 4.000 * mknsTinSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 7.000 * mknsTinFreq ' range=':= 7.000 * mknsTinFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 33 ' range=':= 27 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>

--- a/src/main/resources/config/modules/Metallurgy4.xml
+++ b/src/main/resources/config/modules/Metallurgy4.xml
@@ -1303,19 +1303,19 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore")'> <OreBlock block='Metallurgy:utility.ore' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.733 * _default_ * mtlgSulfurFreq ' range=':= 1.733 * _default_ * mtlgSulfurFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.225 * _default_ * mtlgSulfurFreq ' range=':= 1.225 * _default_ * mtlgSulfurFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * mtlgSulfurSize ' range=':= 0 * _default_ * mtlgSulfurSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.316 * _default_ ' range=':= 1.316 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.107 * _default_ ' range=':= 1.107 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mtlgSulfurSize ' range=':= _default_ * mtlgSulfurSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.147 * _default_ * mtlgSulfurSize ' range=':= 1.147 * _default_ * mtlgSulfurSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.052 * _default_ * mtlgSulfurSize ' range=':= 1.052 * _default_ * mtlgSulfurSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1345,9 +1345,9 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore")'> <OreBlock block='Metallurgy:utility.ore' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.787 * _default_ * mtlgSulfurSize ' range=':= 0.787 * _default_ * mtlgSulfurSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.787 * _default_ * mtlgSulfurSize ' range=':= 0.787 * _default_ * mtlgSulfurSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.619 * _default_ * mtlgSulfurFreq ' range=':= 0.619 * _default_ * mtlgSulfurFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.662 * _default_ * mtlgSulfurSize ' range=':= 0.662 * _default_ * mtlgSulfurSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.662 * _default_ * mtlgSulfurSize ' range=':= 0.662 * _default_ * mtlgSulfurSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.438 * _default_ * mtlgSulfurFreq ' range=':= 0.438 * _default_ * mtlgSulfurFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1397,8 +1397,8 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore")'> <OreBlock block='Metallurgy:utility.ore' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.000 * mtlgSulfurSize ' range=':= _default_ * mtlgSulfurSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 4.000 * mtlgSulfurFreq ' range=':= _default_ * mtlgSulfurFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.000 * mtlgSulfurSize ' range=':= 2.000 * mtlgSulfurSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2.000 * mtlgSulfurFreq ' range=':= 2.000 * mtlgSulfurFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -1429,19 +1429,19 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:1")'> <OreBlock block='Metallurgy:utility.ore:1' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.733 * _default_ * mtlgPhosphoriteFreq ' range=':= 1.733 * _default_ * mtlgPhosphoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.225 * _default_ * mtlgPhosphoriteFreq ' range=':= 1.225 * _default_ * mtlgPhosphoriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * mtlgPhosphoriteSize ' range=':= 0 * _default_ * mtlgPhosphoriteSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.316 * _default_ ' range=':= 1.316 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.107 * _default_ ' range=':= 1.107 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mtlgPhosphoriteSize ' range=':= _default_ * mtlgPhosphoriteSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.147 * _default_ * mtlgPhosphoriteSize ' range=':= 1.147 * _default_ * mtlgPhosphoriteSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.052 * _default_ * mtlgPhosphoriteSize ' range=':= 1.052 * _default_ * mtlgPhosphoriteSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1471,9 +1471,9 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:1")'> <OreBlock block='Metallurgy:utility.ore:1' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.787 * _default_ * mtlgPhosphoriteSize ' range=':= 0.787 * _default_ * mtlgPhosphoriteSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.787 * _default_ * mtlgPhosphoriteSize ' range=':= 0.787 * _default_ * mtlgPhosphoriteSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.619 * _default_ * mtlgPhosphoriteFreq ' range=':= 0.619 * _default_ * mtlgPhosphoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.662 * _default_ * mtlgPhosphoriteSize ' range=':= 0.662 * _default_ * mtlgPhosphoriteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.662 * _default_ * mtlgPhosphoriteSize ' range=':= 0.662 * _default_ * mtlgPhosphoriteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.438 * _default_ * mtlgPhosphoriteFreq ' range=':= 0.438 * _default_ * mtlgPhosphoriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1523,8 +1523,8 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:1")'> <OreBlock block='Metallurgy:utility.ore:1' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.000 * mtlgPhosphoriteSize ' range=':= _default_ * mtlgPhosphoriteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 4.000 * mtlgPhosphoriteFreq ' range=':= _default_ * mtlgPhosphoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.000 * mtlgPhosphoriteSize ' range=':= 2.000 * mtlgPhosphoriteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2.000 * mtlgPhosphoriteFreq ' range=':= 2.000 * mtlgPhosphoriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -1555,19 +1555,19 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:2")'> <OreBlock block='Metallurgy:utility.ore:2' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.733 * _default_ * mtlgSaltpeterFreq ' range=':= 1.733 * _default_ * mtlgSaltpeterFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.225 * _default_ * mtlgSaltpeterFreq ' range=':= 1.225 * _default_ * mtlgSaltpeterFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * mtlgSaltpeterSize ' range=':= 0 * _default_ * mtlgSaltpeterSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.316 * _default_ ' range=':= 1.316 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.107 * _default_ ' range=':= 1.107 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mtlgSaltpeterSize ' range=':= _default_ * mtlgSaltpeterSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.147 * _default_ * mtlgSaltpeterSize ' range=':= 1.147 * _default_ * mtlgSaltpeterSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.052 * _default_ * mtlgSaltpeterSize ' range=':= 1.052 * _default_ * mtlgSaltpeterSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1597,9 +1597,9 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:2")'> <OreBlock block='Metallurgy:utility.ore:2' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.787 * _default_ * mtlgSaltpeterSize ' range=':= 0.787 * _default_ * mtlgSaltpeterSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.787 * _default_ * mtlgSaltpeterSize ' range=':= 0.787 * _default_ * mtlgSaltpeterSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.619 * _default_ * mtlgSaltpeterFreq ' range=':= 0.619 * _default_ * mtlgSaltpeterFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.662 * _default_ * mtlgSaltpeterSize ' range=':= 0.662 * _default_ * mtlgSaltpeterSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.662 * _default_ * mtlgSaltpeterSize ' range=':= 0.662 * _default_ * mtlgSaltpeterSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.438 * _default_ * mtlgSaltpeterFreq ' range=':= 0.438 * _default_ * mtlgSaltpeterFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1649,8 +1649,8 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:2")'> <OreBlock block='Metallurgy:utility.ore:2' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.000 * mtlgSaltpeterSize ' range=':= _default_ * mtlgSaltpeterSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 4.000 * mtlgSaltpeterFreq ' range=':= _default_ * mtlgSaltpeterFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.000 * mtlgSaltpeterSize ' range=':= 2.000 * mtlgSaltpeterSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2.000 * mtlgSaltpeterFreq ' range=':= 2.000 * mtlgSaltpeterFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -1681,19 +1681,19 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:3")'> <OreBlock block='Metallurgy:utility.ore:3' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.733 * _default_ * mtlgMagnesiumFreq ' range=':= 1.733 * _default_ * mtlgMagnesiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.225 * _default_ * mtlgMagnesiumFreq ' range=':= 1.225 * _default_ * mtlgMagnesiumFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * mtlgMagnesiumSize ' range=':= 0 * _default_ * mtlgMagnesiumSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.316 * _default_ ' range=':= 1.316 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.107 * _default_ ' range=':= 1.107 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mtlgMagnesiumSize ' range=':= _default_ * mtlgMagnesiumSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.147 * _default_ * mtlgMagnesiumSize ' range=':= 1.147 * _default_ * mtlgMagnesiumSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.052 * _default_ * mtlgMagnesiumSize ' range=':= 1.052 * _default_ * mtlgMagnesiumSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1723,9 +1723,9 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:3")'> <OreBlock block='Metallurgy:utility.ore:3' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.787 * _default_ * mtlgMagnesiumSize ' range=':= 0.787 * _default_ * mtlgMagnesiumSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.787 * _default_ * mtlgMagnesiumSize ' range=':= 0.787 * _default_ * mtlgMagnesiumSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.619 * _default_ * mtlgMagnesiumFreq ' range=':= 0.619 * _default_ * mtlgMagnesiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.662 * _default_ * mtlgMagnesiumSize ' range=':= 0.662 * _default_ * mtlgMagnesiumSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.662 * _default_ * mtlgMagnesiumSize ' range=':= 0.662 * _default_ * mtlgMagnesiumSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.438 * _default_ * mtlgMagnesiumFreq ' range=':= 0.438 * _default_ * mtlgMagnesiumFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1775,8 +1775,8 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:3")'> <OreBlock block='Metallurgy:utility.ore:3' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.000 * mtlgMagnesiumSize ' range=':= _default_ * mtlgMagnesiumSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 4.000 * mtlgMagnesiumFreq ' range=':= _default_ * mtlgMagnesiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.000 * mtlgMagnesiumSize ' range=':= 2.000 * mtlgMagnesiumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2.000 * mtlgMagnesiumFreq ' range=':= 2.000 * mtlgMagnesiumFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -1807,19 +1807,19 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:4")'> <OreBlock block='Metallurgy:utility.ore:4' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.733 * _default_ * mtlgBitumenFreq ' range=':= 1.733 * _default_ * mtlgBitumenFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.225 * _default_ * mtlgBitumenFreq ' range=':= 1.225 * _default_ * mtlgBitumenFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * mtlgBitumenSize ' range=':= 0 * _default_ * mtlgBitumenSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.316 * _default_ ' range=':= 1.316 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.107 * _default_ ' range=':= 1.107 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mtlgBitumenSize ' range=':= _default_ * mtlgBitumenSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.147 * _default_ * mtlgBitumenSize ' range=':= 1.147 * _default_ * mtlgBitumenSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.052 * _default_ * mtlgBitumenSize ' range=':= 1.052 * _default_ * mtlgBitumenSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1849,9 +1849,9 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:4")'> <OreBlock block='Metallurgy:utility.ore:4' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.787 * _default_ * mtlgBitumenSize ' range=':= 0.787 * _default_ * mtlgBitumenSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.787 * _default_ * mtlgBitumenSize ' range=':= 0.787 * _default_ * mtlgBitumenSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.619 * _default_ * mtlgBitumenFreq ' range=':= 0.619 * _default_ * mtlgBitumenFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.662 * _default_ * mtlgBitumenSize ' range=':= 0.662 * _default_ * mtlgBitumenSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.662 * _default_ * mtlgBitumenSize ' range=':= 0.662 * _default_ * mtlgBitumenSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.438 * _default_ * mtlgBitumenFreq ' range=':= 0.438 * _default_ * mtlgBitumenFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1901,8 +1901,8 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:4")'> <OreBlock block='Metallurgy:utility.ore:4' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.000 * mtlgBitumenSize ' range=':= _default_ * mtlgBitumenSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 4.000 * mtlgBitumenFreq ' range=':= _default_ * mtlgBitumenFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.000 * mtlgBitumenSize ' range=':= 2.000 * mtlgBitumenSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2.000 * mtlgBitumenFreq ' range=':= 2.000 * mtlgBitumenFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -1933,19 +1933,19 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:5")'> <OreBlock block='Metallurgy:utility.ore:5' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.733 * _default_ * mtlgPotashFreq ' range=':= 1.733 * _default_ * mtlgPotashFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.225 * _default_ * mtlgPotashFreq ' range=':= 1.225 * _default_ * mtlgPotashFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * mtlgPotashSize ' range=':= 0 * _default_ * mtlgPotashSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.316 * _default_ ' range=':= 1.316 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.107 * _default_ ' range=':= 1.107 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mtlgPotashSize ' range=':= _default_ * mtlgPotashSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.147 * _default_ * mtlgPotashSize ' range=':= 1.147 * _default_ * mtlgPotashSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.052 * _default_ * mtlgPotashSize ' range=':= 1.052 * _default_ * mtlgPotashSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1975,9 +1975,9 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:5")'> <OreBlock block='Metallurgy:utility.ore:5' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.787 * _default_ * mtlgPotashSize ' range=':= 0.787 * _default_ * mtlgPotashSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.787 * _default_ * mtlgPotashSize ' range=':= 0.787 * _default_ * mtlgPotashSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.619 * _default_ * mtlgPotashFreq ' range=':= 0.619 * _default_ * mtlgPotashFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.662 * _default_ * mtlgPotashSize ' range=':= 0.662 * _default_ * mtlgPotashSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.662 * _default_ * mtlgPotashSize ' range=':= 0.662 * _default_ * mtlgPotashSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.438 * _default_ * mtlgPotashFreq ' range=':= 0.438 * _default_ * mtlgPotashFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2027,8 +2027,8 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:5")'> <OreBlock block='Metallurgy:utility.ore:5' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.000 * mtlgPotashSize ' range=':= _default_ * mtlgPotashSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 4.000 * mtlgPotashFreq ' range=':= _default_ * mtlgPotashFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.000 * mtlgPotashSize ' range=':= 2.000 * mtlgPotashSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2.000 * mtlgPotashFreq ' range=':= 2.000 * mtlgPotashFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -2052,19 +2052,19 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:base.ore")'> <OreBlock block='Metallurgy:base.ore' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.501 * _default_ * mtlgCopperFreq ' range=':= 1.501 * _default_ * mtlgCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.070 * _default_ * mtlgCopperSize ' range=':= 1.070 * _default_ * mtlgCopperSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.062 * _default_ * mtlgCopperFreq ' range=':= 1.062 * _default_ * mtlgCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.010 * _default_ * mtlgCopperSize ' range=':= 1.010 * _default_ * mtlgCopperSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.225 * _default_ ' range=':= 1.225 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.030 * _default_ ' range=':= 1.030 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mtlgCopperSize ' range=':= _default_ * mtlgCopperSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.107 * _default_ * mtlgCopperSize ' range=':= 1.107 * _default_ * mtlgCopperSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.015 * _default_ * mtlgCopperSize ' range=':= 1.015 * _default_ * mtlgCopperSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -2094,9 +2094,9 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:base.ore")'> <OreBlock block='Metallurgy:base.ore' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.146 * _default_ * mtlgCopperSize ' range=':= 1.146 * _default_ * mtlgCopperSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.146 * _default_ * mtlgCopperSize ' range=':= 1.146 * _default_ * mtlgCopperSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.314 * _default_ * mtlgCopperFreq ' range=':= 1.314 * _default_ * mtlgCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.964 * _default_ * mtlgCopperSize ' range=':= 0.964 * _default_ * mtlgCopperSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.964 * _default_ * mtlgCopperSize ' range=':= 0.964 * _default_ * mtlgCopperSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.929 * _default_ * mtlgCopperFreq ' range=':= 0.929 * _default_ * mtlgCopperFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2146,8 +2146,8 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:base.ore")'> <OreBlock block='Metallurgy:base.ore' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 6.000 * mtlgCopperSize ' range=':= _default_ * mtlgCopperSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 12.000 * mtlgCopperFreq ' range=':= _default_ * mtlgCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 3.000 * mtlgCopperSize ' range=':= 3.000 * mtlgCopperSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 6.000 * mtlgCopperFreq ' range=':= 6.000 * mtlgCopperFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -2171,19 +2171,19 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:base.ore:1")'> <OreBlock block='Metallurgy:base.ore:1' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.480 * _default_ * mtlgTinFreq ' range=':= 1.480 * _default_ * mtlgTinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.068 * _default_ * mtlgTinSize ' range=':= 1.068 * _default_ * mtlgTinSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.047 * _default_ * mtlgTinFreq ' range=':= 1.047 * _default_ * mtlgTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.008 * _default_ * mtlgTinSize ' range=':= 1.008 * _default_ * mtlgTinSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.217 * _default_ ' range=':= 1.217 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.023 * _default_ ' range=':= 1.023 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mtlgTinSize ' range=':= _default_ * mtlgTinSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.103 * _default_ * mtlgTinSize ' range=':= 1.103 * _default_ * mtlgTinSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.012 * _default_ * mtlgTinSize ' range=':= 1.012 * _default_ * mtlgTinSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -2213,9 +2213,9 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:base.ore:1")'> <OreBlock block='Metallurgy:base.ore:1' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.138 * _default_ * mtlgTinSize ' range=':= 1.138 * _default_ * mtlgTinSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.138 * _default_ * mtlgTinSize ' range=':= 1.138 * _default_ * mtlgTinSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.295 * _default_ * mtlgTinFreq ' range=':= 1.295 * _default_ * mtlgTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.957 * _default_ * mtlgTinSize ' range=':= 0.957 * _default_ * mtlgTinSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.957 * _default_ * mtlgTinSize ' range=':= 0.957 * _default_ * mtlgTinSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.916 * _default_ * mtlgTinFreq ' range=':= 0.916 * _default_ * mtlgTinFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2265,8 +2265,8 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:base.ore:1")'> <OreBlock block='Metallurgy:base.ore:1' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 10.000 * mtlgTinSize ' range=':= _default_ * mtlgTinSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 7.000 * mtlgTinFreq ' range=':= _default_ * mtlgTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 5.000 * mtlgTinSize ' range=':= 5.000 * mtlgTinSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 3.500 * mtlgTinFreq ' range=':= 3.500 * mtlgTinFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -2290,19 +2290,19 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:base.ore:2")'> <OreBlock block='Metallurgy:base.ore:2' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.791 * _default_ * mtlgManganeseFreq ' range=':= 0.791 * _default_ * mtlgManganeseFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.962 * _default_ * mtlgManganeseSize ' range=':= 0.962 * _default_ * mtlgManganeseSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.560 * _default_ * mtlgManganeseFreq ' range=':= 0.560 * _default_ * mtlgManganeseFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.908 * _default_ * mtlgManganeseSize ' range=':= 0.908 * _default_ * mtlgManganeseSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.890 * _default_ ' range=':= 0.890 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.748 * _default_ ' range=':= 0.748 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mtlgManganeseSize ' range=':= _default_ * mtlgManganeseSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.943 * _default_ * mtlgManganeseSize ' range=':= 0.943 * _default_ * mtlgManganeseSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.865 * _default_ * mtlgManganeseSize ' range=':= 0.865 * _default_ * mtlgManganeseSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -2332,9 +2332,9 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:base.ore:2")'> <OreBlock block='Metallurgy:base.ore:2' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.832 * _default_ * mtlgManganeseSize ' range=':= 0.832 * _default_ * mtlgManganeseSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.832 * _default_ * mtlgManganeseSize ' range=':= 0.832 * _default_ * mtlgManganeseSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.692 * _default_ * mtlgManganeseFreq ' range=':= 0.692 * _default_ * mtlgManganeseFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.700 * _default_ * mtlgManganeseSize ' range=':= 0.700 * _default_ * mtlgManganeseSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.700 * _default_ * mtlgManganeseSize ' range=':= 0.700 * _default_ * mtlgManganeseSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.490 * _default_ * mtlgManganeseFreq ' range=':= 0.490 * _default_ * mtlgManganeseFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2384,8 +2384,8 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:base.ore:2")'> <OreBlock block='Metallurgy:base.ore:2' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.000 * mtlgManganeseSize ' range=':= _default_ * mtlgManganeseSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 5.000 * mtlgManganeseFreq ' range=':= _default_ * mtlgManganeseFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.000 * mtlgManganeseSize ' range=':= 2.000 * mtlgManganeseSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2.500 * mtlgManganeseFreq ' range=':= 2.500 * mtlgManganeseFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -2409,19 +2409,19 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:precious.ore")'> <OreBlock block='Metallurgy:precious.ore' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * mtlgZincFreq ' range=':= 0.969 * _default_ * mtlgZincFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.995 * _default_ * mtlgZincSize ' range=':= 0.995 * _default_ * mtlgZincSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.685 * _default_ * mtlgZincFreq ' range=':= 0.685 * _default_ * mtlgZincFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.939 * _default_ * mtlgZincSize ' range=':= 0.939 * _default_ * mtlgZincSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.984 * _default_ ' range=':= 0.984 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.828 * _default_ ' range=':= 0.828 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mtlgZincSize ' range=':= _default_ * mtlgZincSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.992 * _default_ * mtlgZincSize ' range=':= 0.992 * _default_ * mtlgZincSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.910 * _default_ * mtlgZincSize ' range=':= 0.910 * _default_ * mtlgZincSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -2451,9 +2451,9 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:precious.ore")'> <OreBlock block='Metallurgy:precious.ore' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.921 * _default_ * mtlgZincSize ' range=':= 0.921 * _default_ * mtlgZincSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.921 * _default_ * mtlgZincSize ' range=':= 0.921 * _default_ * mtlgZincSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.848 * _default_ * mtlgZincFreq ' range=':= 0.848 * _default_ * mtlgZincFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.774 * _default_ * mtlgZincSize ' range=':= 0.774 * _default_ * mtlgZincSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.774 * _default_ * mtlgZincSize ' range=':= 0.774 * _default_ * mtlgZincSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.600 * _default_ * mtlgZincFreq ' range=':= 0.600 * _default_ * mtlgZincFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2503,8 +2503,8 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:precious.ore")'> <OreBlock block='Metallurgy:precious.ore' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 5.000 * mtlgZincSize ' range=':= _default_ * mtlgZincSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 6.000 * mtlgZincFreq ' range=':= _default_ * mtlgZincFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.500 * mtlgZincSize ' range=':= 2.500 * mtlgZincSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 3.000 * mtlgZincFreq ' range=':= 3.000 * mtlgZincFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -2528,19 +2528,19 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:precious.ore:1")'> <OreBlock block='Metallurgy:precious.ore:1' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * mtlgSilverFreq ' range=':= 0.969 * _default_ * mtlgSilverFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.995 * _default_ * mtlgSilverSize ' range=':= 0.995 * _default_ * mtlgSilverSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.685 * _default_ * mtlgSilverFreq ' range=':= 0.685 * _default_ * mtlgSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.939 * _default_ * mtlgSilverSize ' range=':= 0.939 * _default_ * mtlgSilverSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.984 * _default_ ' range=':= 0.984 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.828 * _default_ ' range=':= 0.828 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mtlgSilverSize ' range=':= _default_ * mtlgSilverSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.992 * _default_ * mtlgSilverSize ' range=':= 0.992 * _default_ * mtlgSilverSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.910 * _default_ * mtlgSilverSize ' range=':= 0.910 * _default_ * mtlgSilverSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -2570,9 +2570,9 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:precious.ore:1")'> <OreBlock block='Metallurgy:precious.ore:1' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.921 * _default_ * mtlgSilverSize ' range=':= 0.921 * _default_ * mtlgSilverSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.921 * _default_ * mtlgSilverSize ' range=':= 0.921 * _default_ * mtlgSilverSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.848 * _default_ * mtlgSilverFreq ' range=':= 0.848 * _default_ * mtlgSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.774 * _default_ * mtlgSilverSize ' range=':= 0.774 * _default_ * mtlgSilverSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.774 * _default_ * mtlgSilverSize ' range=':= 0.774 * _default_ * mtlgSilverSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.600 * _default_ * mtlgSilverFreq ' range=':= 0.600 * _default_ * mtlgSilverFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2622,8 +2622,8 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:precious.ore:1")'> <OreBlock block='Metallurgy:precious.ore:1' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 5.000 * mtlgSilverSize ' range=':= _default_ * mtlgSilverSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 6.000 * mtlgSilverFreq ' range=':= _default_ * mtlgSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.500 * mtlgSilverSize ' range=':= 2.500 * mtlgSilverSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 3.000 * mtlgSilverFreq ' range=':= 3.000 * mtlgSilverFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -2647,19 +2647,19 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:precious.ore:2")'> <OreBlock block='Metallurgy:precious.ore:2' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.531 * _default_ * mtlgPlatinumFreq ' range=':= 0.531 * _default_ * mtlgPlatinumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.900 * _default_ * mtlgPlatinumSize ' range=':= 0.900 * _default_ * mtlgPlatinumSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.375 * _default_ * mtlgPlatinumFreq ' range=':= 0.375 * _default_ * mtlgPlatinumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.849 * _default_ * mtlgPlatinumSize ' range=':= 0.849 * _default_ * mtlgPlatinumSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.729 * _default_ ' range=':= 0.729 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.613 * _default_ ' range=':= 0.613 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mtlgPlatinumSize ' range=':= _default_ * mtlgPlatinumSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.854 * _default_ * mtlgPlatinumSize ' range=':= 0.854 * _default_ * mtlgPlatinumSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.783 * _default_ * mtlgPlatinumSize ' range=':= 0.783 * _default_ * mtlgPlatinumSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -2689,9 +2689,9 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:precious.ore:2")'> <OreBlock block='Metallurgy:precious.ore:2' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.682 * _default_ * mtlgPlatinumSize ' range=':= 0.682 * _default_ * mtlgPlatinumSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.682 * _default_ * mtlgPlatinumSize ' range=':= 0.682 * _default_ * mtlgPlatinumSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.464 * _default_ * mtlgPlatinumFreq ' range=':= 0.464 * _default_ * mtlgPlatinumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.573 * _default_ * mtlgPlatinumSize ' range=':= 0.573 * _default_ * mtlgPlatinumSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.573 * _default_ * mtlgPlatinumSize ' range=':= 0.573 * _default_ * mtlgPlatinumSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.328 * _default_ * mtlgPlatinumFreq ' range=':= 0.328 * _default_ * mtlgPlatinumFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2741,8 +2741,8 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:precious.ore:2")'> <OreBlock block='Metallurgy:precious.ore:2' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3.000 * mtlgPlatinumSize ' range=':= _default_ * mtlgPlatinumSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 3.000 * mtlgPlatinumFreq ' range=':= _default_ * mtlgPlatinumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 1.500 * mtlgPlatinumSize ' range=':= 1.500 * mtlgPlatinumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.500 * mtlgPlatinumFreq ' range=':= 1.500 * mtlgPlatinumFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -2766,19 +2766,19 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore")'> <OreBlock block='Metallurgy:fantasy.ore' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * mtlgPromethiumFreq ' range=':= 0.969 * _default_ * mtlgPromethiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.995 * _default_ * mtlgPromethiumSize ' range=':= 0.995 * _default_ * mtlgPromethiumSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.685 * _default_ * mtlgPromethiumFreq ' range=':= 0.685 * _default_ * mtlgPromethiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.939 * _default_ * mtlgPromethiumSize ' range=':= 0.939 * _default_ * mtlgPromethiumSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.984 * _default_ ' range=':= 0.984 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.828 * _default_ ' range=':= 0.828 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mtlgPromethiumSize ' range=':= _default_ * mtlgPromethiumSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.992 * _default_ * mtlgPromethiumSize ' range=':= 0.992 * _default_ * mtlgPromethiumSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.910 * _default_ * mtlgPromethiumSize ' range=':= 0.910 * _default_ * mtlgPromethiumSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -2808,9 +2808,9 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore")'> <OreBlock block='Metallurgy:fantasy.ore' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.921 * _default_ * mtlgPromethiumSize ' range=':= 0.921 * _default_ * mtlgPromethiumSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.921 * _default_ * mtlgPromethiumSize ' range=':= 0.921 * _default_ * mtlgPromethiumSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.848 * _default_ * mtlgPromethiumFreq ' range=':= 0.848 * _default_ * mtlgPromethiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.774 * _default_ * mtlgPromethiumSize ' range=':= 0.774 * _default_ * mtlgPromethiumSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.774 * _default_ * mtlgPromethiumSize ' range=':= 0.774 * _default_ * mtlgPromethiumSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.600 * _default_ * mtlgPromethiumFreq ' range=':= 0.600 * _default_ * mtlgPromethiumFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2860,8 +2860,8 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore")'> <OreBlock block='Metallurgy:fantasy.ore' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 6.000 * mtlgPromethiumSize ' range=':= _default_ * mtlgPromethiumSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 5.000 * mtlgPromethiumFreq ' range=':= _default_ * mtlgPromethiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 3.000 * mtlgPromethiumSize ' range=':= 3.000 * mtlgPromethiumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2.500 * mtlgPromethiumFreq ' range=':= 2.500 * mtlgPromethiumFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -2885,19 +2885,19 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:1")'> <OreBlock block='Metallurgy:fantasy.ore:1' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.791 * _default_ * mtlgDeepIronFreq ' range=':= 0.791 * _default_ * mtlgDeepIronFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.962 * _default_ * mtlgDeepIronSize ' range=':= 0.962 * _default_ * mtlgDeepIronSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.560 * _default_ * mtlgDeepIronFreq ' range=':= 0.560 * _default_ * mtlgDeepIronFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.908 * _default_ * mtlgDeepIronSize ' range=':= 0.908 * _default_ * mtlgDeepIronSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.890 * _default_ ' range=':= 0.890 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.748 * _default_ ' range=':= 0.748 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mtlgDeepIronSize ' range=':= _default_ * mtlgDeepIronSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.943 * _default_ * mtlgDeepIronSize ' range=':= 0.943 * _default_ * mtlgDeepIronSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.865 * _default_ * mtlgDeepIronSize ' range=':= 0.865 * _default_ * mtlgDeepIronSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -2927,9 +2927,9 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:1")'> <OreBlock block='Metallurgy:fantasy.ore:1' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.832 * _default_ * mtlgDeepIronSize ' range=':= 0.832 * _default_ * mtlgDeepIronSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.832 * _default_ * mtlgDeepIronSize ' range=':= 0.832 * _default_ * mtlgDeepIronSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.692 * _default_ * mtlgDeepIronFreq ' range=':= 0.692 * _default_ * mtlgDeepIronFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.700 * _default_ * mtlgDeepIronSize ' range=':= 0.700 * _default_ * mtlgDeepIronSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.700 * _default_ * mtlgDeepIronSize ' range=':= 0.700 * _default_ * mtlgDeepIronSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.490 * _default_ * mtlgDeepIronFreq ' range=':= 0.490 * _default_ * mtlgDeepIronFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2979,8 +2979,8 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:1")'> <OreBlock block='Metallurgy:fantasy.ore:1' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.000 * mtlgDeepIronSize ' range=':= _default_ * mtlgDeepIronSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 5.000 * mtlgDeepIronFreq ' range=':= _default_ * mtlgDeepIronFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.000 * mtlgDeepIronSize ' range=':= 2.000 * mtlgDeepIronSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2.500 * mtlgDeepIronFreq ' range=':= 2.500 * mtlgDeepIronFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -3004,19 +3004,19 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:2")'> <OreBlock block='Metallurgy:fantasy.ore:2' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.791 * _default_ * mtlgInfuscoliumFreq ' range=':= 0.791 * _default_ * mtlgInfuscoliumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.962 * _default_ * mtlgInfuscoliumSize ' range=':= 0.962 * _default_ * mtlgInfuscoliumSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.560 * _default_ * mtlgInfuscoliumFreq ' range=':= 0.560 * _default_ * mtlgInfuscoliumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.908 * _default_ * mtlgInfuscoliumSize ' range=':= 0.908 * _default_ * mtlgInfuscoliumSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.890 * _default_ ' range=':= 0.890 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.748 * _default_ ' range=':= 0.748 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mtlgInfuscoliumSize ' range=':= _default_ * mtlgInfuscoliumSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.943 * _default_ * mtlgInfuscoliumSize ' range=':= 0.943 * _default_ * mtlgInfuscoliumSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.865 * _default_ * mtlgInfuscoliumSize ' range=':= 0.865 * _default_ * mtlgInfuscoliumSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -3046,9 +3046,9 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:2")'> <OreBlock block='Metallurgy:fantasy.ore:2' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.832 * _default_ * mtlgInfuscoliumSize ' range=':= 0.832 * _default_ * mtlgInfuscoliumSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.832 * _default_ * mtlgInfuscoliumSize ' range=':= 0.832 * _default_ * mtlgInfuscoliumSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.692 * _default_ * mtlgInfuscoliumFreq ' range=':= 0.692 * _default_ * mtlgInfuscoliumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.700 * _default_ * mtlgInfuscoliumSize ' range=':= 0.700 * _default_ * mtlgInfuscoliumSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.700 * _default_ * mtlgInfuscoliumSize ' range=':= 0.700 * _default_ * mtlgInfuscoliumSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.490 * _default_ * mtlgInfuscoliumFreq ' range=':= 0.490 * _default_ * mtlgInfuscoliumFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3098,8 +3098,8 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:2")'> <OreBlock block='Metallurgy:fantasy.ore:2' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.000 * mtlgInfuscoliumSize ' range=':= _default_ * mtlgInfuscoliumSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 5.000 * mtlgInfuscoliumFreq ' range=':= _default_ * mtlgInfuscoliumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.000 * mtlgInfuscoliumSize ' range=':= 2.000 * mtlgInfuscoliumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2.500 * mtlgInfuscoliumFreq ' range=':= 2.500 * mtlgInfuscoliumFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -3123,19 +3123,19 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:4")'> <OreBlock block='Metallurgy:fantasy.ore:4' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.613 * _default_ * mtlgOureclaseFreq ' range=':= 0.613 * _default_ * mtlgOureclaseFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * mtlgOureclaseSize ' range=':= 0.922 * _default_ * mtlgOureclaseSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.433 * _default_ * mtlgOureclaseFreq ' range=':= 0.433 * _default_ * mtlgOureclaseFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.870 * _default_ * mtlgOureclaseSize ' range=':= 0.870 * _default_ * mtlgOureclaseSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.783 * _default_ ' range=':= 0.783 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.658 * _default_ ' range=':= 0.658 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mtlgOureclaseSize ' range=':= _default_ * mtlgOureclaseSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.885 * _default_ * mtlgOureclaseSize ' range=':= 0.885 * _default_ * mtlgOureclaseSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.811 * _default_ * mtlgOureclaseSize ' range=':= 0.811 * _default_ * mtlgOureclaseSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -3165,9 +3165,9 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:4")'> <OreBlock block='Metallurgy:fantasy.ore:4' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.732 * _default_ * mtlgOureclaseSize ' range=':= 0.732 * _default_ * mtlgOureclaseSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.732 * _default_ * mtlgOureclaseSize ' range=':= 0.732 * _default_ * mtlgOureclaseSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.536 * _default_ * mtlgOureclaseFreq ' range=':= 0.536 * _default_ * mtlgOureclaseFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.616 * _default_ * mtlgOureclaseSize ' range=':= 0.616 * _default_ * mtlgOureclaseSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.616 * _default_ * mtlgOureclaseSize ' range=':= 0.616 * _default_ * mtlgOureclaseSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.379 * _default_ * mtlgOureclaseFreq ' range=':= 0.379 * _default_ * mtlgOureclaseFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3217,8 +3217,8 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:4")'> <OreBlock block='Metallurgy:fantasy.ore:4' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3.000 * mtlgOureclaseSize ' range=':= _default_ * mtlgOureclaseSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 4.000 * mtlgOureclaseFreq ' range=':= _default_ * mtlgOureclaseFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 1.500 * mtlgOureclaseSize ' range=':= 1.500 * mtlgOureclaseSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2.000 * mtlgOureclaseFreq ' range=':= 2.000 * mtlgOureclaseFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -3242,19 +3242,19 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:5")'> <OreBlock block='Metallurgy:fantasy.ore:5' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.613 * _default_ * mtlgAstralSilverFreq ' range=':= 0.613 * _default_ * mtlgAstralSilverFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * mtlgAstralSilverSize ' range=':= 0.922 * _default_ * mtlgAstralSilverSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.433 * _default_ * mtlgAstralSilverFreq ' range=':= 0.433 * _default_ * mtlgAstralSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.870 * _default_ * mtlgAstralSilverSize ' range=':= 0.870 * _default_ * mtlgAstralSilverSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.783 * _default_ ' range=':= 0.783 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.658 * _default_ ' range=':= 0.658 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mtlgAstralSilverSize ' range=':= _default_ * mtlgAstralSilverSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.885 * _default_ * mtlgAstralSilverSize ' range=':= 0.885 * _default_ * mtlgAstralSilverSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.811 * _default_ * mtlgAstralSilverSize ' range=':= 0.811 * _default_ * mtlgAstralSilverSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -3285,9 +3285,9 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:5")'> <OreBlock block='Metallurgy:fantasy.ore:5' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.732 * _default_ * mtlgAstralSilverSize ' range=':= 0.732 * _default_ * mtlgAstralSilverSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.732 * _default_ * mtlgAstralSilverSize ' range=':= 0.732 * _default_ * mtlgAstralSilverSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.536 * _default_ * mtlgAstralSilverFreq ' range=':= 0.536 * _default_ * mtlgAstralSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.616 * _default_ * mtlgAstralSilverSize ' range=':= 0.616 * _default_ * mtlgAstralSilverSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.616 * _default_ * mtlgAstralSilverSize ' range=':= 0.616 * _default_ * mtlgAstralSilverSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.379 * _default_ * mtlgAstralSilverFreq ' range=':= 0.379 * _default_ * mtlgAstralSilverFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3337,8 +3337,8 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:5")'> <OreBlock block='Metallurgy:fantasy.ore:5' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3.000 * mtlgAstralSilverSize ' range=':= _default_ * mtlgAstralSilverSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 4.000 * mtlgAstralSilverFreq ' range=':= _default_ * mtlgAstralSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 1.500 * mtlgAstralSilverSize ' range=':= 1.500 * mtlgAstralSilverSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2.000 * mtlgAstralSilverFreq ' range=':= 2.000 * mtlgAstralSilverFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -3362,19 +3362,19 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:6")'> <OreBlock block='Metallurgy:fantasy.ore:6' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.531 * _default_ * mtlgCarmotFreq ' range=':= 0.531 * _default_ * mtlgCarmotFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.900 * _default_ * mtlgCarmotSize ' range=':= 0.900 * _default_ * mtlgCarmotSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.375 * _default_ * mtlgCarmotFreq ' range=':= 0.375 * _default_ * mtlgCarmotFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.849 * _default_ * mtlgCarmotSize ' range=':= 0.849 * _default_ * mtlgCarmotSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.729 * _default_ ' range=':= 0.729 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.613 * _default_ ' range=':= 0.613 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mtlgCarmotSize ' range=':= _default_ * mtlgCarmotSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.854 * _default_ * mtlgCarmotSize ' range=':= 0.854 * _default_ * mtlgCarmotSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.783 * _default_ * mtlgCarmotSize ' range=':= 0.783 * _default_ * mtlgCarmotSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -3404,9 +3404,9 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:6")'> <OreBlock block='Metallurgy:fantasy.ore:6' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.682 * _default_ * mtlgCarmotSize ' range=':= 0.682 * _default_ * mtlgCarmotSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.682 * _default_ * mtlgCarmotSize ' range=':= 0.682 * _default_ * mtlgCarmotSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.464 * _default_ * mtlgCarmotFreq ' range=':= 0.464 * _default_ * mtlgCarmotFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.573 * _default_ * mtlgCarmotSize ' range=':= 0.573 * _default_ * mtlgCarmotSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.573 * _default_ * mtlgCarmotSize ' range=':= 0.573 * _default_ * mtlgCarmotSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.328 * _default_ * mtlgCarmotFreq ' range=':= 0.328 * _default_ * mtlgCarmotFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3456,8 +3456,8 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:6")'> <OreBlock block='Metallurgy:fantasy.ore:6' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3.000 * mtlgCarmotSize ' range=':= _default_ * mtlgCarmotSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 3.000 * mtlgCarmotFreq ' range=':= _default_ * mtlgCarmotFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 1.500 * mtlgCarmotSize ' range=':= 1.500 * mtlgCarmotSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.500 * mtlgCarmotFreq ' range=':= 1.500 * mtlgCarmotFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -3481,19 +3481,19 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:7")'> <OreBlock block='Metallurgy:fantasy.ore:7' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.531 * _default_ * mtlgMithrilFreq ' range=':= 0.531 * _default_ * mtlgMithrilFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.900 * _default_ * mtlgMithrilSize ' range=':= 0.900 * _default_ * mtlgMithrilSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.375 * _default_ * mtlgMithrilFreq ' range=':= 0.375 * _default_ * mtlgMithrilFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.849 * _default_ * mtlgMithrilSize ' range=':= 0.849 * _default_ * mtlgMithrilSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.729 * _default_ ' range=':= 0.729 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.613 * _default_ ' range=':= 0.613 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mtlgMithrilSize ' range=':= _default_ * mtlgMithrilSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.854 * _default_ * mtlgMithrilSize ' range=':= 0.854 * _default_ * mtlgMithrilSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.783 * _default_ * mtlgMithrilSize ' range=':= 0.783 * _default_ * mtlgMithrilSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -3523,9 +3523,9 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:7")'> <OreBlock block='Metallurgy:fantasy.ore:7' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.682 * _default_ * mtlgMithrilSize ' range=':= 0.682 * _default_ * mtlgMithrilSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.682 * _default_ * mtlgMithrilSize ' range=':= 0.682 * _default_ * mtlgMithrilSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.464 * _default_ * mtlgMithrilFreq ' range=':= 0.464 * _default_ * mtlgMithrilFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.573 * _default_ * mtlgMithrilSize ' range=':= 0.573 * _default_ * mtlgMithrilSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.573 * _default_ * mtlgMithrilSize ' range=':= 0.573 * _default_ * mtlgMithrilSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.328 * _default_ * mtlgMithrilFreq ' range=':= 0.328 * _default_ * mtlgMithrilFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3575,8 +3575,8 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:7")'> <OreBlock block='Metallurgy:fantasy.ore:7' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3.000 * mtlgMithrilSize ' range=':= _default_ * mtlgMithrilSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 3.000 * mtlgMithrilFreq ' range=':= _default_ * mtlgMithrilFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 1.500 * mtlgMithrilSize ' range=':= 1.500 * mtlgMithrilSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.500 * mtlgMithrilFreq ' range=':= 1.500 * mtlgMithrilFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -3600,19 +3600,19 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:8")'> <OreBlock block='Metallurgy:fantasy.ore:8' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.433 * _default_ * mtlgRubraciumFreq ' range=':= 0.433 * _default_ * mtlgRubraciumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.870 * _default_ * mtlgRubraciumSize ' range=':= 0.870 * _default_ * mtlgRubraciumSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.306 * _default_ * mtlgRubraciumFreq ' range=':= 0.306 * _default_ * mtlgRubraciumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.821 * _default_ * mtlgRubraciumSize ' range=':= 0.821 * _default_ * mtlgRubraciumSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.658 * _default_ ' range=':= 0.658 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.554 * _default_ ' range=':= 0.554 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mtlgRubraciumSize ' range=':= _default_ * mtlgRubraciumSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.811 * _default_ * mtlgRubraciumSize ' range=':= 0.811 * _default_ * mtlgRubraciumSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.744 * _default_ * mtlgRubraciumSize ' range=':= 0.744 * _default_ * mtlgRubraciumSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -3642,9 +3642,9 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:8")'> <OreBlock block='Metallurgy:fantasy.ore:8' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.616 * _default_ * mtlgRubraciumSize ' range=':= 0.616 * _default_ * mtlgRubraciumSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.616 * _default_ * mtlgRubraciumSize ' range=':= 0.616 * _default_ * mtlgRubraciumSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.379 * _default_ * mtlgRubraciumFreq ' range=':= 0.379 * _default_ * mtlgRubraciumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.518 * _default_ * mtlgRubraciumSize ' range=':= 0.518 * _default_ * mtlgRubraciumSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.518 * _default_ * mtlgRubraciumSize ' range=':= 0.518 * _default_ * mtlgRubraciumSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.268 * _default_ * mtlgRubraciumFreq ' range=':= 0.268 * _default_ * mtlgRubraciumFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3694,8 +3694,8 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:8")'> <OreBlock block='Metallurgy:fantasy.ore:8' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3.000 * mtlgRubraciumSize ' range=':= _default_ * mtlgRubraciumSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2.000 * mtlgRubraciumFreq ' range=':= _default_ * mtlgRubraciumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 1.500 * mtlgRubraciumSize ' range=':= 1.500 * mtlgRubraciumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.000 * mtlgRubraciumFreq ' range=':= 1.000 * mtlgRubraciumFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -3719,19 +3719,19 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:11")'> <OreBlock block='Metallurgy:fantasy.ore:11' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.500 * _default_ * mtlgOrichalcumFreq ' range=':= 0.500 * _default_ * mtlgOrichalcumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.891 * _default_ * mtlgOrichalcumSize ' range=':= 0.891 * _default_ * mtlgOrichalcumSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.354 * _default_ * mtlgOrichalcumFreq ' range=':= 0.354 * _default_ * mtlgOrichalcumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.841 * _default_ * mtlgOrichalcumSize ' range=':= 0.841 * _default_ * mtlgOrichalcumSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.707 * _default_ ' range=':= 0.707 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.595 * _default_ ' range=':= 0.595 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mtlgOrichalcumSize ' range=':= _default_ * mtlgOrichalcumSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.841 * _default_ * mtlgOrichalcumSize ' range=':= 0.841 * _default_ * mtlgOrichalcumSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.771 * _default_ * mtlgOrichalcumSize ' range=':= 0.771 * _default_ * mtlgOrichalcumSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -3761,9 +3761,9 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:11")'> <OreBlock block='Metallurgy:fantasy.ore:11' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.662 * _default_ * mtlgOrichalcumSize ' range=':= 0.662 * _default_ * mtlgOrichalcumSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.662 * _default_ * mtlgOrichalcumSize ' range=':= 0.662 * _default_ * mtlgOrichalcumSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.438 * _default_ * mtlgOrichalcumFreq ' range=':= 0.438 * _default_ * mtlgOrichalcumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.556 * _default_ * mtlgOrichalcumSize ' range=':= 0.556 * _default_ * mtlgOrichalcumSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.556 * _default_ * mtlgOrichalcumSize ' range=':= 0.556 * _default_ * mtlgOrichalcumSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.310 * _default_ * mtlgOrichalcumFreq ' range=':= 0.310 * _default_ * mtlgOrichalcumFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3813,8 +3813,8 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:11")'> <OreBlock block='Metallurgy:fantasy.ore:11' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.000 * mtlgOrichalcumSize ' range=':= _default_ * mtlgOrichalcumSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2.000 * mtlgOrichalcumFreq ' range=':= _default_ * mtlgOrichalcumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.000 * mtlgOrichalcumSize ' range=':= 2.000 * mtlgOrichalcumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.000 * mtlgOrichalcumFreq ' range=':= 1.000 * mtlgOrichalcumFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -3838,19 +3838,19 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:13")'> <OreBlock block='Metallurgy:fantasy.ore:13' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.433 * _default_ * mtlgAdamantineFreq ' range=':= 0.433 * _default_ * mtlgAdamantineFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.870 * _default_ * mtlgAdamantineSize ' range=':= 0.870 * _default_ * mtlgAdamantineSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.306 * _default_ * mtlgAdamantineFreq ' range=':= 0.306 * _default_ * mtlgAdamantineFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.821 * _default_ * mtlgAdamantineSize ' range=':= 0.821 * _default_ * mtlgAdamantineSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.658 * _default_ ' range=':= 0.658 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.554 * _default_ ' range=':= 0.554 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mtlgAdamantineSize ' range=':= _default_ * mtlgAdamantineSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.811 * _default_ * mtlgAdamantineSize ' range=':= 0.811 * _default_ * mtlgAdamantineSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.744 * _default_ * mtlgAdamantineSize ' range=':= 0.744 * _default_ * mtlgAdamantineSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -3880,9 +3880,9 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:13")'> <OreBlock block='Metallurgy:fantasy.ore:13' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.616 * _default_ * mtlgAdamantineSize ' range=':= 0.616 * _default_ * mtlgAdamantineSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.616 * _default_ * mtlgAdamantineSize ' range=':= 0.616 * _default_ * mtlgAdamantineSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.379 * _default_ * mtlgAdamantineFreq ' range=':= 0.379 * _default_ * mtlgAdamantineFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.518 * _default_ * mtlgAdamantineSize ' range=':= 0.518 * _default_ * mtlgAdamantineSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.518 * _default_ * mtlgAdamantineSize ' range=':= 0.518 * _default_ * mtlgAdamantineSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.268 * _default_ * mtlgAdamantineFreq ' range=':= 0.268 * _default_ * mtlgAdamantineFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3932,8 +3932,8 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:13")'> <OreBlock block='Metallurgy:fantasy.ore:13' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3.000 * mtlgAdamantineSize ' range=':= _default_ * mtlgAdamantineSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2.000 * mtlgAdamantineFreq ' range=':= _default_ * mtlgAdamantineFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 1.500 * mtlgAdamantineSize ' range=':= 1.500 * mtlgAdamantineSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.000 * mtlgAdamantineFreq ' range=':= 1.000 * mtlgAdamantineFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -3957,19 +3957,19 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:14")'> <OreBlock block='Metallurgy:fantasy.ore:14' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.433 * _default_ * mtlgAtlarusFreq ' range=':= 0.433 * _default_ * mtlgAtlarusFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.870 * _default_ * mtlgAtlarusSize ' range=':= 0.870 * _default_ * mtlgAtlarusSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.306 * _default_ * mtlgAtlarusFreq ' range=':= 0.306 * _default_ * mtlgAtlarusFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.821 * _default_ * mtlgAtlarusSize ' range=':= 0.821 * _default_ * mtlgAtlarusSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.658 * _default_ ' range=':= 0.658 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.554 * _default_ ' range=':= 0.554 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mtlgAtlarusSize ' range=':= _default_ * mtlgAtlarusSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.811 * _default_ * mtlgAtlarusSize ' range=':= 0.811 * _default_ * mtlgAtlarusSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.744 * _default_ * mtlgAtlarusSize ' range=':= 0.744 * _default_ * mtlgAtlarusSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -3999,9 +3999,9 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:14")'> <OreBlock block='Metallurgy:fantasy.ore:14' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.616 * _default_ * mtlgAtlarusSize ' range=':= 0.616 * _default_ * mtlgAtlarusSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.616 * _default_ * mtlgAtlarusSize ' range=':= 0.616 * _default_ * mtlgAtlarusSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.379 * _default_ * mtlgAtlarusFreq ' range=':= 0.379 * _default_ * mtlgAtlarusFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.518 * _default_ * mtlgAtlarusSize ' range=':= 0.518 * _default_ * mtlgAtlarusSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.518 * _default_ * mtlgAtlarusSize ' range=':= 0.518 * _default_ * mtlgAtlarusSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.268 * _default_ * mtlgAtlarusFreq ' range=':= 0.268 * _default_ * mtlgAtlarusFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4051,8 +4051,8 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:14")'> <OreBlock block='Metallurgy:fantasy.ore:14' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3.000 * mtlgAtlarusSize ' range=':= _default_ * mtlgAtlarusSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2.000 * mtlgAtlarusFreq ' range=':= _default_ * mtlgAtlarusFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 1.500 * mtlgAtlarusSize ' range=':= 1.500 * mtlgAtlarusSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.000 * mtlgAtlarusFreq ' range=':= 1.000 * mtlgAtlarusFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -4117,19 +4117,19 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.300 * _default_ * mtlgIgnatiusFreq ' range=':= 1.300 * _default_ * mtlgIgnatiusFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.045 * _default_ * mtlgIgnatiusSize ' range=':= 1.045 * _default_ * mtlgIgnatiusSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.919 * _default_ * mtlgIgnatiusFreq ' range=':= 0.919 * _default_ * mtlgIgnatiusFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.986 * _default_ * mtlgIgnatiusSize ' range=':= 0.986 * _default_ * mtlgIgnatiusSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.140 * _default_ ' range=':= 1.140 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.959 * _default_ ' range=':= 0.959 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mtlgIgnatiusSize ' range=':= _default_ * mtlgIgnatiusSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.068 * _default_ * mtlgIgnatiusSize ' range=':= 1.068 * _default_ * mtlgIgnatiusSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.979 * _default_ * mtlgIgnatiusSize ' range=':= 0.979 * _default_ * mtlgIgnatiusSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -4159,9 +4159,9 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.067 * _default_ * mtlgIgnatiusSize ' range=':= 1.067 * _default_ * mtlgIgnatiusSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.067 * _default_ * mtlgIgnatiusSize ' range=':= 1.067 * _default_ * mtlgIgnatiusSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.138 * _default_ * mtlgIgnatiusFreq ' range=':= 1.138 * _default_ * mtlgIgnatiusFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.897 * _default_ * mtlgIgnatiusSize ' range=':= 0.897 * _default_ * mtlgIgnatiusSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.897 * _default_ * mtlgIgnatiusSize ' range=':= 0.897 * _default_ * mtlgIgnatiusSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.804 * _default_ * mtlgIgnatiusFreq ' range=':= 0.804 * _default_ * mtlgIgnatiusFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4211,8 +4211,8 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 6.000 * mtlgIgnatiusSize ' range=':= _default_ * mtlgIgnatiusSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 9.000 * mtlgIgnatiusFreq ' range=':= _default_ * mtlgIgnatiusFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 3.000 * mtlgIgnatiusSize ' range=':= 3.000 * mtlgIgnatiusSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4.500 * mtlgIgnatiusFreq ' range=':= 4.500 * mtlgIgnatiusFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -4236,19 +4236,19 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:1")'> <OreBlock block='Metallurgy:nether.ore:1' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.147 * _default_ * mtlgShadowIronFreq ' range=':= 1.147 * _default_ * mtlgShadowIronFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.023 * _default_ * mtlgShadowIronSize ' range=':= 1.023 * _default_ * mtlgShadowIronSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.811 * _default_ * mtlgShadowIronFreq ' range=':= 0.811 * _default_ * mtlgShadowIronFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.966 * _default_ * mtlgShadowIronSize ' range=':= 0.966 * _default_ * mtlgShadowIronSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.071 * _default_ ' range=':= 1.071 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.900 * _default_ ' range=':= 0.900 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mtlgShadowIronSize ' range=':= _default_ * mtlgShadowIronSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.035 * _default_ * mtlgShadowIronSize ' range=':= 1.035 * _default_ * mtlgShadowIronSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.949 * _default_ * mtlgShadowIronSize ' range=':= 0.949 * _default_ * mtlgShadowIronSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -4278,9 +4278,9 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:1")'> <OreBlock block='Metallurgy:nether.ore:1' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.002 * _default_ * mtlgShadowIronSize ' range=':= 1.002 * _default_ * mtlgShadowIronSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.002 * _default_ * mtlgShadowIronSize ' range=':= 1.002 * _default_ * mtlgShadowIronSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.003 * _default_ * mtlgShadowIronFreq ' range=':= 1.003 * _default_ * mtlgShadowIronFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.842 * _default_ * mtlgShadowIronSize ' range=':= 0.842 * _default_ * mtlgShadowIronSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.842 * _default_ * mtlgShadowIronSize ' range=':= 0.842 * _default_ * mtlgShadowIronSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.709 * _default_ * mtlgShadowIronFreq ' range=':= 0.709 * _default_ * mtlgShadowIronFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4330,8 +4330,8 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:1")'> <OreBlock block='Metallurgy:nether.ore:1' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 6.000 * mtlgShadowIronSize ' range=':= _default_ * mtlgShadowIronSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 7.000 * mtlgShadowIronFreq ' range=':= _default_ * mtlgShadowIronFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 3.000 * mtlgShadowIronSize ' range=':= 3.000 * mtlgShadowIronSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 3.500 * mtlgShadowIronFreq ' range=':= 3.500 * mtlgShadowIronFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -4355,19 +4355,19 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:2")'> <OreBlock block='Metallurgy:nether.ore:2' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.062 * _default_ * mtlgLemuriteFreq ' range=':= 1.062 * _default_ * mtlgLemuriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.010 * _default_ * mtlgLemuriteSize ' range=':= 1.010 * _default_ * mtlgLemuriteSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.751 * _default_ * mtlgLemuriteFreq ' range=':= 0.751 * _default_ * mtlgLemuriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.953 * _default_ * mtlgLemuriteSize ' range=':= 0.953 * _default_ * mtlgLemuriteSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.030 * _default_ ' range=':= 1.030 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.866 * _default_ ' range=':= 0.866 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mtlgLemuriteSize ' range=':= _default_ * mtlgLemuriteSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.015 * _default_ * mtlgLemuriteSize ' range=':= 1.015 * _default_ * mtlgLemuriteSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.931 * _default_ * mtlgLemuriteSize ' range=':= 0.931 * _default_ * mtlgLemuriteSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -4397,9 +4397,9 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:2")'> <OreBlock block='Metallurgy:nether.ore:2' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.964 * _default_ * mtlgLemuriteSize ' range=':= 0.964 * _default_ * mtlgLemuriteSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.964 * _default_ * mtlgLemuriteSize ' range=':= 0.964 * _default_ * mtlgLemuriteSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.929 * _default_ * mtlgLemuriteFreq ' range=':= 0.929 * _default_ * mtlgLemuriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.810 * _default_ * mtlgLemuriteSize ' range=':= 0.810 * _default_ * mtlgLemuriteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.810 * _default_ * mtlgLemuriteSize ' range=':= 0.810 * _default_ * mtlgLemuriteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.657 * _default_ * mtlgLemuriteFreq ' range=':= 0.657 * _default_ * mtlgLemuriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4449,8 +4449,8 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:2")'> <OreBlock block='Metallurgy:nether.ore:2' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 6.000 * mtlgLemuriteSize ' range=':= _default_ * mtlgLemuriteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 6.000 * mtlgLemuriteFreq ' range=':= _default_ * mtlgLemuriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 3.000 * mtlgLemuriteSize ' range=':= 3.000 * mtlgLemuriteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 3.000 * mtlgLemuriteFreq ' range=':= 3.000 * mtlgLemuriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -4474,19 +4474,19 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:3")'> <OreBlock block='Metallurgy:nether.ore:3' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * mtlgMidasiumFreq ' range=':= 0.969 * _default_ * mtlgMidasiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.995 * _default_ * mtlgMidasiumSize ' range=':= 0.995 * _default_ * mtlgMidasiumSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.685 * _default_ * mtlgMidasiumFreq ' range=':= 0.685 * _default_ * mtlgMidasiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.939 * _default_ * mtlgMidasiumSize ' range=':= 0.939 * _default_ * mtlgMidasiumSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.984 * _default_ ' range=':= 0.984 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.828 * _default_ ' range=':= 0.828 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mtlgMidasiumSize ' range=':= _default_ * mtlgMidasiumSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.992 * _default_ * mtlgMidasiumSize ' range=':= 0.992 * _default_ * mtlgMidasiumSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.910 * _default_ * mtlgMidasiumSize ' range=':= 0.910 * _default_ * mtlgMidasiumSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -4516,9 +4516,9 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:3")'> <OreBlock block='Metallurgy:nether.ore:3' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.921 * _default_ * mtlgMidasiumSize ' range=':= 0.921 * _default_ * mtlgMidasiumSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.921 * _default_ * mtlgMidasiumSize ' range=':= 0.921 * _default_ * mtlgMidasiumSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.848 * _default_ * mtlgMidasiumFreq ' range=':= 0.848 * _default_ * mtlgMidasiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.774 * _default_ * mtlgMidasiumSize ' range=':= 0.774 * _default_ * mtlgMidasiumSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.774 * _default_ * mtlgMidasiumSize ' range=':= 0.774 * _default_ * mtlgMidasiumSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.600 * _default_ * mtlgMidasiumFreq ' range=':= 0.600 * _default_ * mtlgMidasiumFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4568,8 +4568,8 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:3")'> <OreBlock block='Metallurgy:nether.ore:3' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 6.000 * mtlgMidasiumSize ' range=':= _default_ * mtlgMidasiumSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 5.000 * mtlgMidasiumFreq ' range=':= _default_ * mtlgMidasiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 3.000 * mtlgMidasiumSize ' range=':= 3.000 * mtlgMidasiumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2.500 * mtlgMidasiumFreq ' range=':= 2.500 * mtlgMidasiumFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -4593,19 +4593,19 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:4")'> <OreBlock block='Metallurgy:nether.ore:4' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.936 * _default_ * mtlgVyroxeresFreq ' range=':= 0.936 * _default_ * mtlgVyroxeresFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.989 * _default_ * mtlgVyroxeresSize ' range=':= 0.989 * _default_ * mtlgVyroxeresSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.662 * _default_ * mtlgVyroxeresFreq ' range=':= 0.662 * _default_ * mtlgVyroxeresFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.934 * _default_ * mtlgVyroxeresSize ' range=':= 0.934 * _default_ * mtlgVyroxeresSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.968 * _default_ ' range=':= 0.968 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.814 * _default_ ' range=':= 0.814 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mtlgVyroxeresSize ' range=':= _default_ * mtlgVyroxeresSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.984 * _default_ * mtlgVyroxeresSize ' range=':= 0.984 * _default_ * mtlgVyroxeresSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.902 * _default_ * mtlgVyroxeresSize ' range=':= 0.902 * _default_ * mtlgVyroxeresSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -4635,9 +4635,9 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:4")'> <OreBlock block='Metallurgy:nether.ore:4' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.905 * _default_ * mtlgVyroxeresSize ' range=':= 0.905 * _default_ * mtlgVyroxeresSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.905 * _default_ * mtlgVyroxeresSize ' range=':= 0.905 * _default_ * mtlgVyroxeresSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.819 * _default_ * mtlgVyroxeresFreq ' range=':= 0.819 * _default_ * mtlgVyroxeresFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.761 * _default_ * mtlgVyroxeresSize ' range=':= 0.761 * _default_ * mtlgVyroxeresSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.761 * _default_ * mtlgVyroxeresSize ' range=':= 0.761 * _default_ * mtlgVyroxeresSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.579 * _default_ * mtlgVyroxeresFreq ' range=':= 0.579 * _default_ * mtlgVyroxeresFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4687,8 +4687,8 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:4")'> <OreBlock block='Metallurgy:nether.ore:4' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 7.000 * mtlgVyroxeresSize ' range=':= _default_ * mtlgVyroxeresSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 4.000 * mtlgVyroxeresFreq ' range=':= _default_ * mtlgVyroxeresFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 3.500 * mtlgVyroxeresSize ' range=':= 3.500 * mtlgVyroxeresSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2.000 * mtlgVyroxeresFreq ' range=':= 2.000 * mtlgVyroxeresFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -4712,19 +4712,19 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:5")'> <OreBlock block='Metallurgy:nether.ore:5' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.708 * _default_ * mtlgCeruclaseFreq ' range=':= 0.708 * _default_ * mtlgCeruclaseFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.944 * _default_ * mtlgCeruclaseSize ' range=':= 0.944 * _default_ * mtlgCeruclaseSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.500 * _default_ * mtlgCeruclaseFreq ' range=':= 0.500 * _default_ * mtlgCeruclaseFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.891 * _default_ * mtlgCeruclaseSize ' range=':= 0.891 * _default_ * mtlgCeruclaseSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.841 * _default_ ' range=':= 0.841 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.707 * _default_ ' range=':= 0.707 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mtlgCeruclaseSize ' range=':= _default_ * mtlgCeruclaseSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.917 * _default_ * mtlgCeruclaseSize ' range=':= 0.917 * _default_ * mtlgCeruclaseSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.841 * _default_ * mtlgCeruclaseSize ' range=':= 0.841 * _default_ * mtlgCeruclaseSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -4754,9 +4754,9 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:5")'> <OreBlock block='Metallurgy:nether.ore:5' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.787 * _default_ * mtlgCeruclaseSize ' range=':= 0.787 * _default_ * mtlgCeruclaseSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.787 * _default_ * mtlgCeruclaseSize ' range=':= 0.787 * _default_ * mtlgCeruclaseSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.619 * _default_ * mtlgCeruclaseFreq ' range=':= 0.619 * _default_ * mtlgCeruclaseFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.662 * _default_ * mtlgCeruclaseSize ' range=':= 0.662 * _default_ * mtlgCeruclaseSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.662 * _default_ * mtlgCeruclaseSize ' range=':= 0.662 * _default_ * mtlgCeruclaseSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.438 * _default_ * mtlgCeruclaseFreq ' range=':= 0.438 * _default_ * mtlgCeruclaseFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4806,8 +4806,8 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:5")'> <OreBlock block='Metallurgy:nether.ore:5' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.000 * mtlgCeruclaseSize ' range=':= _default_ * mtlgCeruclaseSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 4.000 * mtlgCeruclaseFreq ' range=':= _default_ * mtlgCeruclaseFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.000 * mtlgCeruclaseSize ' range=':= 2.000 * mtlgCeruclaseSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2.000 * mtlgCeruclaseFreq ' range=':= 2.000 * mtlgCeruclaseFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -4831,19 +4831,19 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:6")'> <OreBlock block='Metallurgy:nether.ore:6' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.613 * _default_ * mtlgAlduoriteFreq ' range=':= 0.613 * _default_ * mtlgAlduoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * mtlgAlduoriteSize ' range=':= 0.922 * _default_ * mtlgAlduoriteSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.433 * _default_ * mtlgAlduoriteFreq ' range=':= 0.433 * _default_ * mtlgAlduoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.870 * _default_ * mtlgAlduoriteSize ' range=':= 0.870 * _default_ * mtlgAlduoriteSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.783 * _default_ ' range=':= 0.783 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.658 * _default_ ' range=':= 0.658 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mtlgAlduoriteSize ' range=':= _default_ * mtlgAlduoriteSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.885 * _default_ * mtlgAlduoriteSize ' range=':= 0.885 * _default_ * mtlgAlduoriteSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.811 * _default_ * mtlgAlduoriteSize ' range=':= 0.811 * _default_ * mtlgAlduoriteSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -4873,9 +4873,9 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:6")'> <OreBlock block='Metallurgy:nether.ore:6' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.732 * _default_ * mtlgAlduoriteSize ' range=':= 0.732 * _default_ * mtlgAlduoriteSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.732 * _default_ * mtlgAlduoriteSize ' range=':= 0.732 * _default_ * mtlgAlduoriteSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.536 * _default_ * mtlgAlduoriteFreq ' range=':= 0.536 * _default_ * mtlgAlduoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.616 * _default_ * mtlgAlduoriteSize ' range=':= 0.616 * _default_ * mtlgAlduoriteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.616 * _default_ * mtlgAlduoriteSize ' range=':= 0.616 * _default_ * mtlgAlduoriteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.379 * _default_ * mtlgAlduoriteFreq ' range=':= 0.379 * _default_ * mtlgAlduoriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4925,8 +4925,8 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:6")'> <OreBlock block='Metallurgy:nether.ore:6' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.000 * mtlgAlduoriteSize ' range=':= _default_ * mtlgAlduoriteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 3.000 * mtlgAlduoriteFreq ' range=':= _default_ * mtlgAlduoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.000 * mtlgAlduoriteSize ' range=':= 2.000 * mtlgAlduoriteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.500 * mtlgAlduoriteFreq ' range=':= 1.500 * mtlgAlduoriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -4950,19 +4950,19 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:7")'> <OreBlock block='Metallurgy:nether.ore:7' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.613 * _default_ * mtlgKalendriteFreq ' range=':= 0.613 * _default_ * mtlgKalendriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * mtlgKalendriteSize ' range=':= 0.922 * _default_ * mtlgKalendriteSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.433 * _default_ * mtlgKalendriteFreq ' range=':= 0.433 * _default_ * mtlgKalendriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.870 * _default_ * mtlgKalendriteSize ' range=':= 0.870 * _default_ * mtlgKalendriteSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.783 * _default_ ' range=':= 0.783 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.658 * _default_ ' range=':= 0.658 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mtlgKalendriteSize ' range=':= _default_ * mtlgKalendriteSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.885 * _default_ * mtlgKalendriteSize ' range=':= 0.885 * _default_ * mtlgKalendriteSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.811 * _default_ * mtlgKalendriteSize ' range=':= 0.811 * _default_ * mtlgKalendriteSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -4992,9 +4992,9 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:7")'> <OreBlock block='Metallurgy:nether.ore:7' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.732 * _default_ * mtlgKalendriteSize ' range=':= 0.732 * _default_ * mtlgKalendriteSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.732 * _default_ * mtlgKalendriteSize ' range=':= 0.732 * _default_ * mtlgKalendriteSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.536 * _default_ * mtlgKalendriteFreq ' range=':= 0.536 * _default_ * mtlgKalendriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.616 * _default_ * mtlgKalendriteSize ' range=':= 0.616 * _default_ * mtlgKalendriteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.616 * _default_ * mtlgKalendriteSize ' range=':= 0.616 * _default_ * mtlgKalendriteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.379 * _default_ * mtlgKalendriteFreq ' range=':= 0.379 * _default_ * mtlgKalendriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -5044,8 +5044,8 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:7")'> <OreBlock block='Metallurgy:nether.ore:7' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.000 * mtlgKalendriteSize ' range=':= _default_ * mtlgKalendriteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 3.000 * mtlgKalendriteFreq ' range=':= _default_ * mtlgKalendriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.000 * mtlgKalendriteSize ' range=':= 2.000 * mtlgKalendriteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.500 * mtlgKalendriteFreq ' range=':= 1.500 * mtlgKalendriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -5069,19 +5069,19 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:8")'> <OreBlock block='Metallurgy:nether.ore:8' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.433 * _default_ * mtlgVulcaniteFreq ' range=':= 0.433 * _default_ * mtlgVulcaniteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.870 * _default_ * mtlgVulcaniteSize ' range=':= 0.870 * _default_ * mtlgVulcaniteSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.306 * _default_ * mtlgVulcaniteFreq ' range=':= 0.306 * _default_ * mtlgVulcaniteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.821 * _default_ * mtlgVulcaniteSize ' range=':= 0.821 * _default_ * mtlgVulcaniteSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.658 * _default_ ' range=':= 0.658 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.554 * _default_ ' range=':= 0.554 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mtlgVulcaniteSize ' range=':= _default_ * mtlgVulcaniteSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.811 * _default_ * mtlgVulcaniteSize ' range=':= 0.811 * _default_ * mtlgVulcaniteSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.744 * _default_ * mtlgVulcaniteSize ' range=':= 0.744 * _default_ * mtlgVulcaniteSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -5111,9 +5111,9 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:8")'> <OreBlock block='Metallurgy:nether.ore:8' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.616 * _default_ * mtlgVulcaniteSize ' range=':= 0.616 * _default_ * mtlgVulcaniteSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.616 * _default_ * mtlgVulcaniteSize ' range=':= 0.616 * _default_ * mtlgVulcaniteSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.379 * _default_ * mtlgVulcaniteFreq ' range=':= 0.379 * _default_ * mtlgVulcaniteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.518 * _default_ * mtlgVulcaniteSize ' range=':= 0.518 * _default_ * mtlgVulcaniteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.518 * _default_ * mtlgVulcaniteSize ' range=':= 0.518 * _default_ * mtlgVulcaniteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.268 * _default_ * mtlgVulcaniteFreq ' range=':= 0.268 * _default_ * mtlgVulcaniteFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -5163,8 +5163,8 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:8")'> <OreBlock block='Metallurgy:nether.ore:8' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3.000 * mtlgVulcaniteSize ' range=':= _default_ * mtlgVulcaniteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2.000 * mtlgVulcaniteFreq ' range=':= _default_ * mtlgVulcaniteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 1.500 * mtlgVulcaniteSize ' range=':= 1.500 * mtlgVulcaniteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.000 * mtlgVulcaniteFreq ' range=':= 1.000 * mtlgVulcaniteFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -5188,19 +5188,19 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:9")'> <OreBlock block='Metallurgy:nether.ore:9' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.433 * _default_ * mtlgSanguiniteFreq ' range=':= 0.433 * _default_ * mtlgSanguiniteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.870 * _default_ * mtlgSanguiniteSize ' range=':= 0.870 * _default_ * mtlgSanguiniteSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.306 * _default_ * mtlgSanguiniteFreq ' range=':= 0.306 * _default_ * mtlgSanguiniteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.821 * _default_ * mtlgSanguiniteSize ' range=':= 0.821 * _default_ * mtlgSanguiniteSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.658 * _default_ ' range=':= 0.658 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.554 * _default_ ' range=':= 0.554 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mtlgSanguiniteSize ' range=':= _default_ * mtlgSanguiniteSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.811 * _default_ * mtlgSanguiniteSize ' range=':= 0.811 * _default_ * mtlgSanguiniteSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.744 * _default_ * mtlgSanguiniteSize ' range=':= 0.744 * _default_ * mtlgSanguiniteSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -5230,9 +5230,9 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:9")'> <OreBlock block='Metallurgy:nether.ore:9' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.616 * _default_ * mtlgSanguiniteSize ' range=':= 0.616 * _default_ * mtlgSanguiniteSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.616 * _default_ * mtlgSanguiniteSize ' range=':= 0.616 * _default_ * mtlgSanguiniteSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.379 * _default_ * mtlgSanguiniteFreq ' range=':= 0.379 * _default_ * mtlgSanguiniteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.518 * _default_ * mtlgSanguiniteSize ' range=':= 0.518 * _default_ * mtlgSanguiniteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.518 * _default_ * mtlgSanguiniteSize ' range=':= 0.518 * _default_ * mtlgSanguiniteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.268 * _default_ * mtlgSanguiniteFreq ' range=':= 0.268 * _default_ * mtlgSanguiniteFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -5282,8 +5282,8 @@
                             <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:9")'> <OreBlock block='Metallurgy:nether.ore:9' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3.000 * mtlgSanguiniteSize ' range=':= _default_ * mtlgSanguiniteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2.000 * mtlgSanguiniteFreq ' range=':= _default_ * mtlgSanguiniteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 1.500 * mtlgSanguiniteSize ' range=':= 1.500 * mtlgSanguiniteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.000 * mtlgSanguiniteFreq ' range=':= 1.000 * mtlgSanguiniteFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -5318,7 +5318,6 @@
                             must be large  enough to catch all ore
                             clusters (>=  32).
                         </Comment>
-                        <Replaces block='Metallurgy:ender.ore' weight='1.0' />
                         <Replaces block='Metallurgy:ender.ore:1' weight='1.0' />
                     </Substitute>
                 </IfCondition>
@@ -5332,27 +5331,27 @@
                 <!-- Starting LayeredVeins Preset for Eximite. -->
                 <ConfigSection>
                     <IfCondition condition=':= mtlgEximiteDist = "LayeredVeins"'>
-                        <Veins name='mtlgEximiteVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x607B5994' drawBoundBox='false' boundBoxColor='0x607B5994'>
+                        <Veins name='mtlgEximiteVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x605E5168' drawBoundBox='false' boundBoxColor='0x605E5168'>
                             <Description>
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:ender.ore")'> <OreBlock block='Metallurgy:ender.ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:ender.ore:1")'> <OreBlock block='Metallurgy:ender.ore:1' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.867 * _default_ * mtlgEximiteFreq ' range=':= 0.867 * _default_ * mtlgEximiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.976 * _default_ * mtlgEximiteSize ' range=':= 0.976 * _default_ * mtlgEximiteSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.375 * _default_ * mtlgEximiteFreq ' range=':= 0.375 * _default_ * mtlgEximiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.849 * _default_ * mtlgEximiteSize ' range=':= 0.849 * _default_ * mtlgEximiteSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.931 * _default_ ' range=':= 0.931 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.613 * _default_ ' range=':= 0.613 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mtlgEximiteSize ' range=':= _default_ * mtlgEximiteSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.965 * _default_ * mtlgEximiteSize ' range=':= 0.965 * _default_ * mtlgEximiteSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.783 * _default_ * mtlgEximiteSize ' range=':= 0.783 * _default_ * mtlgEximiteSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -5364,7 +5363,7 @@
                 <!-- Starting Cloud Preset for Eximite. -->
                 <ConfigSection>
                     <IfCondition condition=':= mtlgEximiteDist = "Cloud"'>
-                        <Cloud name='mtlgEximiteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x607B5994' drawBoundBox='false' boundBoxColor='0x607B5994'>
+                        <Cloud name='mtlgEximiteCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x605E5168' drawBoundBox='false' boundBoxColor='0x605E5168'>
                             <Description>
                                 Large irregular clouds filled  lightly
                                 with ore.  These are  huge, spanning
@@ -5379,12 +5378,12 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:ender.ore")'> <OreBlock block='Metallurgy:ender.ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:ender.ore:1")'> <OreBlock block='Metallurgy:ender.ore:1' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.871 * _default_ * mtlgEximiteSize ' range=':= 0.871 * _default_ * mtlgEximiteSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.871 * _default_ * mtlgEximiteSize ' range=':= 0.871 * _default_ * mtlgEximiteSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.758 * _default_ * mtlgEximiteFreq ' range=':= 0.758 * _default_ * mtlgEximiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.573 * _default_ * mtlgEximiteSize ' range=':= 0.573 * _default_ * mtlgEximiteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.573 * _default_ * mtlgEximiteSize ' range=':= 0.573 * _default_ * mtlgEximiteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.328 * _default_ * mtlgEximiteFreq ' range=':= 0.328 * _default_ * mtlgEximiteFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -5392,7 +5391,7 @@
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Veins name='mtlgEximiteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x607B5994' drawBoundBox='false' boundBoxColor='0x607B5994'>
+                            <Veins name='mtlgEximiteHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x605E5168' drawBoundBox='false' boundBoxColor='0x605E5168'>
                                 <Description>
                                     Single blocks, generously
                                     scattered through all heights
@@ -5413,7 +5412,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("Metallurgy:ender.ore")'> <OreBlock block='Metallurgy:ender.ore' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("Metallurgy:ender.ore:1")'> <OreBlock block='Metallurgy:ender.ore:1' weight='1.0' /> </IfCondition>
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -5426,16 +5425,16 @@
                 <!-- Starting Vanilla Preset for Eximite. -->
                 <ConfigSection>
                     <IfCondition condition=':= mtlgEximiteDist = "Vanilla"'>
-                        <StandardGen name='mtlgEximiteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x607B5994' drawBoundBox='false' boundBoxColor='0x607B5994'>
+                        <StandardGen name='mtlgEximiteStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x605E5168' drawBoundBox='false' boundBoxColor='0x605E5168'>
                             <Description>
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:ender.ore")'> <OreBlock block='Metallurgy:ender.ore' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("Metallurgy:ender.ore:1")'> <OreBlock block='Metallurgy:ender.ore:1' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.000 * mtlgEximiteSize ' range=':= _default_ * mtlgEximiteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 6.000 * mtlgEximiteFreq ' range=':= _default_ * mtlgEximiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 1.500 * mtlgEximiteSize ' range=':= 1.500 * mtlgEximiteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.500 * mtlgEximiteFreq ' range=':= 1.500 * mtlgEximiteFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>

--- a/src/main/resources/config/modules/MineChem.xml
+++ b/src/main/resources/config/modules/MineChem.xml
@@ -111,19 +111,19 @@
                             <IfCondition condition=':= ?blockExists("minechem:tile.oreUranium")'> <OreBlock block='minechem:tile.oreUranium' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.500 * _default_ * mchmUraniumFreq ' range=':= 0.500 * _default_ * mchmUraniumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.891 * _default_ * mchmUraniumSize ' range=':= 0.891 * _default_ * mchmUraniumSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.354 * _default_ * mchmUraniumFreq ' range=':= 0.354 * _default_ * mchmUraniumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.841 * _default_ * mchmUraniumSize ' range=':= 0.841 * _default_ * mchmUraniumSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 17.5 ' range=':= 12.5 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.707 * _default_ ' range=':= 0.707 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.595 * _default_ ' range=':= 0.595 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mchmUraniumSize ' range=':= _default_ * mchmUraniumSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.841 * _default_ * mchmUraniumSize ' range=':= 0.841 * _default_ * mchmUraniumSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.771 * _default_ * mchmUraniumSize ' range=':= 0.771 * _default_ * mchmUraniumSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -153,9 +153,9 @@
                             <IfCondition condition=':= ?blockExists("minechem:tile.oreUranium")'> <OreBlock block='minechem:tile.oreUranium' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.662 * _default_ * mchmUraniumSize ' range=':= 0.662 * _default_ * mchmUraniumSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.662 * _default_ * mchmUraniumSize ' range=':= 0.662 * _default_ * mchmUraniumSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.438 * _default_ * mchmUraniumFreq ' range=':= 0.438 * _default_ * mchmUraniumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.556 * _default_ * mchmUraniumSize ' range=':= 0.556 * _default_ * mchmUraniumSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.556 * _default_ * mchmUraniumSize ' range=':= 0.556 * _default_ * mchmUraniumSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.310 * _default_ * mchmUraniumFreq ' range=':= 0.310 * _default_ * mchmUraniumFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 17.5 ' range=':= 12.5 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -205,8 +205,8 @@
                             <IfCondition condition=':= ?blockExists("minechem:tile.oreUranium")'> <OreBlock block='minechem:tile.oreUranium' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.000 * mchmUraniumSize ' range=':= _default_ * mchmUraniumSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2.000 * mchmUraniumFreq ' range=':= _default_ * mchmUraniumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.000 * mchmUraniumSize ' range=':= 2.000 * mchmUraniumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.000 * mchmUraniumFreq ' range=':= 1.000 * mchmUraniumFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 17.5 ' range=':= 12.5 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>

--- a/src/main/resources/config/modules/MinecraftComesAlive.xml
+++ b/src/main/resources/config/modules/MinecraftComesAlive.xml
@@ -113,19 +113,19 @@
                             <IfCondition condition=':= ?blockExists("MCA:tile.roseGoldOre")'> <OreBlock block='MCA:tile.roseGoldOre' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * mccaRoseGoldFreq ' range=':= 0.969 * _default_ * mccaRoseGoldFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.995 * _default_ * mccaRoseGoldSize ' range=':= 0.995 * _default_ * mccaRoseGoldSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.685 * _default_ * mccaRoseGoldFreq ' range=':= 0.685 * _default_ * mccaRoseGoldFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.939 * _default_ * mccaRoseGoldSize ' range=':= 0.939 * _default_ * mccaRoseGoldSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 26 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.984 * _default_ ' range=':= 0.984 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.828 * _default_ ' range=':= 0.828 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * mccaRoseGoldSize ' range=':= _default_ * mccaRoseGoldSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.992 * _default_ * mccaRoseGoldSize ' range=':= 0.992 * _default_ * mccaRoseGoldSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.910 * _default_ * mccaRoseGoldSize ' range=':= 0.910 * _default_ * mccaRoseGoldSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -155,9 +155,9 @@
                             <IfCondition condition=':= ?blockExists("MCA:tile.roseGoldOre")'> <OreBlock block='MCA:tile.roseGoldOre' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.921 * _default_ * mccaRoseGoldSize ' range=':= 0.921 * _default_ * mccaRoseGoldSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.921 * _default_ * mccaRoseGoldSize ' range=':= 0.921 * _default_ * mccaRoseGoldSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.848 * _default_ * mccaRoseGoldFreq ' range=':= 0.848 * _default_ * mccaRoseGoldFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.774 * _default_ * mccaRoseGoldSize ' range=':= 0.774 * _default_ * mccaRoseGoldSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.774 * _default_ * mccaRoseGoldSize ' range=':= 0.774 * _default_ * mccaRoseGoldSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.600 * _default_ * mccaRoseGoldFreq ' range=':= 0.600 * _default_ * mccaRoseGoldFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 26 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -207,8 +207,8 @@
                             <IfCondition condition=':= ?blockExists("MCA:tile.roseGoldOre")'> <OreBlock block='MCA:tile.roseGoldOre' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 6.000 * mccaRoseGoldSize ' range=':= _default_ * mccaRoseGoldSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 5.000 * mccaRoseGoldFreq ' range=':= _default_ * mccaRoseGoldFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 3.000 * mccaRoseGoldSize ' range=':= 3.000 * mccaRoseGoldSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2.500 * mccaRoseGoldFreq ' range=':= 2.500 * mccaRoseGoldFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 26 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>

--- a/src/main/resources/config/modules/NetherOres.xml
+++ b/src/main/resources/config/modules/NetherOres.xml
@@ -1165,7 +1165,7 @@
                         <Replaces block='NetherOres:tile.netherores.ore.0:7' weight='1.0' />
                         <Replaces block='NetherOres:tile.netherores.ore.0:8' weight='1.0' />
                         <Replaces block='NetherOres:tile.netherores.ore.0:9' weight='1.0' />
-                        <Replaces block='NetherOres:tile.netherores.ore.1:0' weight='1.0' />
+                        <Replaces block='NetherOres:tile.netherores.ore.1' weight='1.0' />
                         <Replaces block='NetherOres:tile.netherores.ore.1:1' weight='1.0' />
                         <Replaces block='NetherOres:tile.netherores.ore.1:10' weight='1.0' />
                         <Replaces block='NetherOres:tile.netherores.ore.1:11' weight='1.0' />
@@ -1208,19 +1208,19 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0")'> <OreBlock block='NetherOres:tile.netherores.ore.0' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 4.900 * _default_ * nthoCoalFreq ' range=':= 4.900 * _default_ * nthoCoalFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeFrequency' avg=':= 3.465 * _default_ * nthoCoalFreq ' range=':= 3.465 * _default_ * nthoCoalFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoCoalSize ' range=':= 0 * _default_ * nthoCoalSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 2.214 * _default_ ' range=':= 2.214 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.861 * _default_ ' range=':= 1.861 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * nthoCoalSize ' range=':= _default_ * nthoCoalSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.488 * _default_ * nthoCoalSize ' range=':= 1.488 * _default_ * nthoCoalSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.364 * _default_ * nthoCoalSize ' range=':= 1.364 * _default_ * nthoCoalSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1250,9 +1250,9 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0")'> <OreBlock block='NetherOres:tile.netherores.ore.0' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.323 * _default_ * nthoCoalSize ' range=':= 1.323 * _default_ * nthoCoalSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.323 * _default_ * nthoCoalSize ' range=':= 1.323 * _default_ * nthoCoalSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.752 * _default_ * nthoCoalFreq ' range=':= 1.752 * _default_ * nthoCoalFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 1.113 * _default_ * nthoCoalSize ' range=':= 1.113 * _default_ * nthoCoalSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.113 * _default_ * nthoCoalSize ' range=':= 1.113 * _default_ * nthoCoalSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.239 * _default_ * nthoCoalFreq ' range=':= 1.239 * _default_ * nthoCoalFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1302,8 +1302,8 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0")'> <OreBlock block='NetherOres:tile.netherores.ore.0' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 16.000 * nthoCoalSize ' range=':= _default_ * nthoCoalSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 8.000 * nthoCoalFreq ' range=':= _default_ * nthoCoalFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 8.000 * nthoCoalSize ' range=':= 8.000 * nthoCoalSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4.000 * nthoCoalFreq ' range=':= 4.000 * nthoCoalFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -1327,19 +1327,19 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:1")'> <OreBlock block='NetherOres:tile.netherores.ore.0:1' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.935 * _default_ * nthoDiamondFreq ' range=':= 0.935 * _default_ * nthoDiamondFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.661 * _default_ * nthoDiamondFreq ' range=':= 0.661 * _default_ * nthoDiamondFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoDiamondSize ' range=':= 0 * _default_ * nthoDiamondSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.967 * _default_ ' range=':= 0.967 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.813 * _default_ ' range=':= 0.813 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * nthoDiamondSize ' range=':= _default_ * nthoDiamondSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.983 * _default_ * nthoDiamondSize ' range=':= 0.983 * _default_ * nthoDiamondSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.902 * _default_ * nthoDiamondSize ' range=':= 0.902 * _default_ * nthoDiamondSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1350,7 +1350,7 @@
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Replaces block='NetherOres:tile.netherores.ore.0:1' weight='1.0' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoDiamondSize  * 0.5 ' range=':= 0 * _default_ * nthoDiamondSize  * 0.5 ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.983 * _default_ * nthoDiamondSize  * 0.5 ' range=':= 0.983 * _default_ * nthoDiamondSize  * 0.5 ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.902 * _default_ * nthoDiamondSize  * 0.5 ' range=':= 0.902 * _default_ * nthoDiamondSize  * 0.5 ' type='normal' />
                             <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
                         </Veins>
                     </IfCondition>
@@ -1379,9 +1379,9 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:1")'> <OreBlock block='NetherOres:tile.netherores.ore.0:1' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.732 * _default_ * nthoDiamondSize ' range=':= 0.732 * _default_ * nthoDiamondSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.732 * _default_ * nthoDiamondSize ' range=':= 0.732 * _default_ * nthoDiamondSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.536 * _default_ * nthoDiamondFreq ' range=':= 0.536 * _default_ * nthoDiamondFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.616 * _default_ * nthoDiamondSize ' range=':= 0.616 * _default_ * nthoDiamondSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.616 * _default_ * nthoDiamondSize ' range=':= 0.616 * _default_ * nthoDiamondSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.379 * _default_ * nthoDiamondFreq ' range=':= 0.379 * _default_ * nthoDiamondFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1431,8 +1431,8 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:1")'> <OreBlock block='NetherOres:tile.netherores.ore.0:1' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3.000 * nthoDiamondSize ' range=':= _default_ * nthoDiamondSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 4.000 * nthoDiamondFreq ' range=':= _default_ * nthoDiamondFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 1.500 * nthoDiamondSize ' range=':= 1.500 * nthoDiamondSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2.000 * nthoDiamondFreq ' range=':= 2.000 * nthoDiamondFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -1456,19 +1456,19 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:2")'> <OreBlock block='NetherOres:tile.netherores.ore.0:2' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.226 * _default_ * nthoGoldFreq ' range=':= 1.226 * _default_ * nthoGoldFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.035 * _default_ * nthoGoldSize ' range=':= 1.035 * _default_ * nthoGoldSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.867 * _default_ * nthoGoldFreq ' range=':= 0.867 * _default_ * nthoGoldFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.976 * _default_ * nthoGoldSize ' range=':= 0.976 * _default_ * nthoGoldSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.107 * _default_ ' range=':= 1.107 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.931 * _default_ ' range=':= 0.931 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * nthoGoldSize ' range=':= _default_ * nthoGoldSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.052 * _default_ * nthoGoldSize ' range=':= 1.052 * _default_ * nthoGoldSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.965 * _default_ * nthoGoldSize ' range=':= 0.965 * _default_ * nthoGoldSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1498,9 +1498,9 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:2")'> <OreBlock block='NetherOres:tile.netherores.ore.0:2' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.036 * _default_ * nthoGoldSize ' range=':= 1.036 * _default_ * nthoGoldSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.036 * _default_ * nthoGoldSize ' range=':= 1.036 * _default_ * nthoGoldSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.073 * _default_ * nthoGoldFreq ' range=':= 1.073 * _default_ * nthoGoldFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.871 * _default_ * nthoGoldSize ' range=':= 0.871 * _default_ * nthoGoldSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.871 * _default_ * nthoGoldSize ' range=':= 0.871 * _default_ * nthoGoldSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.758 * _default_ * nthoGoldFreq ' range=':= 0.758 * _default_ * nthoGoldFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1550,8 +1550,8 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:2")'> <OreBlock block='NetherOres:tile.netherores.ore.0:2' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 6.000 * nthoGoldSize ' range=':= _default_ * nthoGoldSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 8.000 * nthoGoldFreq ' range=':= _default_ * nthoGoldFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 3.000 * nthoGoldSize ' range=':= 3.000 * nthoGoldSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4.000 * nthoGoldFreq ' range=':= 4.000 * nthoGoldFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -1575,19 +1575,19 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:3")'> <OreBlock block='NetherOres:tile.netherores.ore.0:3' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.416 * _default_ * nthoIronFreq ' range=':= 1.416 * _default_ * nthoIronFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.060 * _default_ * nthoIronSize ' range=':= 1.060 * _default_ * nthoIronSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.001 * _default_ * nthoIronFreq ' range=':= 1.001 * _default_ * nthoIronFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.000 * _default_ * nthoIronSize ' range=':= 1.000 * _default_ * nthoIronSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.190 * _default_ ' range=':= 1.190 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.000 * _default_ ' range=':= 1.000 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * nthoIronSize ' range=':= _default_ * nthoIronSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.091 * _default_ * nthoIronSize ' range=':= 1.091 * _default_ * nthoIronSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.000 * _default_ * nthoIronSize ' range=':= 1.000 * _default_ * nthoIronSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1617,9 +1617,9 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:3")'> <OreBlock block='NetherOres:tile.netherores.ore.0:3' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.113 * _default_ * nthoIronSize ' range=':= 1.113 * _default_ * nthoIronSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.113 * _default_ * nthoIronSize ' range=':= 1.113 * _default_ * nthoIronSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.239 * _default_ * nthoIronFreq ' range=':= 1.239 * _default_ * nthoIronFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.936 * _default_ * nthoIronSize ' range=':= 0.936 * _default_ * nthoIronSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.936 * _default_ * nthoIronSize ' range=':= 0.936 * _default_ * nthoIronSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.876 * _default_ * nthoIronFreq ' range=':= 0.876 * _default_ * nthoIronFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1669,8 +1669,8 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:3")'> <OreBlock block='NetherOres:tile.netherores.ore.0:3' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 8.000 * nthoIronSize ' range=':= _default_ * nthoIronSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 8.000 * nthoIronFreq ' range=':= _default_ * nthoIronFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.000 * nthoIronSize ' range=':= 4.000 * nthoIronSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4.000 * nthoIronFreq ' range=':= 4.000 * nthoIronFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -1694,7 +1694,7 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:4")'> <OreBlock block='NetherOres:tile.netherores.ore.0:4' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.929 * _default_ * nthoLapisLazuliFreq ' range=':= 1.929 * _default_ * nthoLapisLazuliFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.364 * _default_ * nthoLapisLazuliFreq ' range=':= 1.364 * _default_ * nthoLapisLazuliFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoLapisLazuliSize ' range=':= 0 * _default_ * nthoLapisLazuliSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1706,7 +1706,7 @@
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * nthoLapisLazuliSize ' range=':= _default_ * nthoLapisLazuliSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.389 * _default_ * nthoLapisLazuliSize ' range=':= 1.389 * _default_ * nthoLapisLazuliSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.168 * _default_ * nthoLapisLazuliSize ' range=':= 1.168 * _default_ * nthoLapisLazuliSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1737,9 +1737,9 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:4")'> <OreBlock block='NetherOres:tile.netherores.ore.0:4' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.964 * _default_ * nthoLapisLazuliSize ' range=':= 0.964 * _default_ * nthoLapisLazuliSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.964 * _default_ * nthoLapisLazuliSize ' range=':= 0.964 * _default_ * nthoLapisLazuliSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.929 * _default_ * nthoLapisLazuliFreq ' range=':= 0.929 * _default_ * nthoLapisLazuliFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.810 * _default_ * nthoLapisLazuliSize ' range=':= 0.810 * _default_ * nthoLapisLazuliSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.810 * _default_ * nthoLapisLazuliSize ' range=':= 0.810 * _default_ * nthoLapisLazuliSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.657 * _default_ * nthoLapisLazuliFreq ' range=':= 0.657 * _default_ * nthoLapisLazuliFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1789,8 +1789,8 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:4")'> <OreBlock block='NetherOres:tile.netherores.ore.0:4' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 6.000 * nthoLapisLazuliSize ' range=':= _default_ * nthoLapisLazuliSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 6.000 * nthoLapisLazuliFreq ' range=':= _default_ * nthoLapisLazuliFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 3.000 * nthoLapisLazuliSize ' range=':= 3.000 * nthoLapisLazuliSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 3.000 * nthoLapisLazuliFreq ' range=':= 3.000 * nthoLapisLazuliFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -1814,7 +1814,7 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:5")'> <OreBlock block='NetherOres:tile.netherores.ore.0:5' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 2.227 * _default_ * nthoRedstoneFreq ' range=':= 2.227 * _default_ * nthoRedstoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.575 * _default_ * nthoRedstoneFreq ' range=':= 1.575 * _default_ * nthoRedstoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoRedstoneSize ' range=':= 0 * _default_ * nthoRedstoneSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1826,7 +1826,7 @@
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * nthoRedstoneSize ' range=':= _default_ * nthoRedstoneSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.492 * _default_ * nthoRedstoneSize ' range=':= 1.492 * _default_ * nthoRedstoneSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.255 * _default_ * nthoRedstoneSize ' range=':= 1.255 * _default_ * nthoRedstoneSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1856,9 +1856,9 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:5")'> <OreBlock block='NetherOres:tile.netherores.ore.0:5' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.036 * _default_ * nthoRedstoneSize ' range=':= 1.036 * _default_ * nthoRedstoneSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.036 * _default_ * nthoRedstoneSize ' range=':= 1.036 * _default_ * nthoRedstoneSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.073 * _default_ * nthoRedstoneFreq ' range=':= 1.073 * _default_ * nthoRedstoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.871 * _default_ * nthoRedstoneSize ' range=':= 0.871 * _default_ * nthoRedstoneSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.871 * _default_ * nthoRedstoneSize ' range=':= 0.871 * _default_ * nthoRedstoneSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.758 * _default_ * nthoRedstoneFreq ' range=':= 0.758 * _default_ * nthoRedstoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1908,8 +1908,8 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:5")'> <OreBlock block='NetherOres:tile.netherores.ore.0:5' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 8.000 * nthoRedstoneSize ' range=':= _default_ * nthoRedstoneSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 6.000 * nthoRedstoneFreq ' range=':= _default_ * nthoRedstoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.000 * nthoRedstoneSize ' range=':= 4.000 * nthoRedstoneSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 3.000 * nthoRedstoneFreq ' range=':= 3.000 * nthoRedstoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -1933,19 +1933,19 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:6")'> <OreBlock block='NetherOres:tile.netherores.ore.0:6' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.416 * _default_ * nthoCopperFreq ' range=':= 1.416 * _default_ * nthoCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.060 * _default_ * nthoCopperSize ' range=':= 1.060 * _default_ * nthoCopperSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.001 * _default_ * nthoCopperFreq ' range=':= 1.001 * _default_ * nthoCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.000 * _default_ * nthoCopperSize ' range=':= 1.000 * _default_ * nthoCopperSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.190 * _default_ ' range=':= 1.190 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.000 * _default_ ' range=':= 1.000 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * nthoCopperSize ' range=':= _default_ * nthoCopperSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.091 * _default_ * nthoCopperSize ' range=':= 1.091 * _default_ * nthoCopperSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.000 * _default_ * nthoCopperSize ' range=':= 1.000 * _default_ * nthoCopperSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1975,9 +1975,9 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:6")'> <OreBlock block='NetherOres:tile.netherores.ore.0:6' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.113 * _default_ * nthoCopperSize ' range=':= 1.113 * _default_ * nthoCopperSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.113 * _default_ * nthoCopperSize ' range=':= 1.113 * _default_ * nthoCopperSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.239 * _default_ * nthoCopperFreq ' range=':= 1.239 * _default_ * nthoCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.936 * _default_ * nthoCopperSize ' range=':= 0.936 * _default_ * nthoCopperSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.936 * _default_ * nthoCopperSize ' range=':= 0.936 * _default_ * nthoCopperSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.876 * _default_ * nthoCopperFreq ' range=':= 0.876 * _default_ * nthoCopperFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2027,8 +2027,8 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:6")'> <OreBlock block='NetherOres:tile.netherores.ore.0:6' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 8.000 * nthoCopperSize ' range=':= _default_ * nthoCopperSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 8.000 * nthoCopperFreq ' range=':= _default_ * nthoCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.000 * nthoCopperSize ' range=':= 4.000 * nthoCopperSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4.000 * nthoCopperFreq ' range=':= 4.000 * nthoCopperFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -2052,19 +2052,19 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:7")'> <OreBlock block='NetherOres:tile.netherores.ore.0:7' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.416 * _default_ * nthoTinFreq ' range=':= 1.416 * _default_ * nthoTinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.060 * _default_ * nthoTinSize ' range=':= 1.060 * _default_ * nthoTinSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.001 * _default_ * nthoTinFreq ' range=':= 1.001 * _default_ * nthoTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.000 * _default_ * nthoTinSize ' range=':= 1.000 * _default_ * nthoTinSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.190 * _default_ ' range=':= 1.190 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.000 * _default_ ' range=':= 1.000 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * nthoTinSize ' range=':= _default_ * nthoTinSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.091 * _default_ * nthoTinSize ' range=':= 1.091 * _default_ * nthoTinSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.000 * _default_ * nthoTinSize ' range=':= 1.000 * _default_ * nthoTinSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -2094,9 +2094,9 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:7")'> <OreBlock block='NetherOres:tile.netherores.ore.0:7' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.113 * _default_ * nthoTinSize ' range=':= 1.113 * _default_ * nthoTinSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.113 * _default_ * nthoTinSize ' range=':= 1.113 * _default_ * nthoTinSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.239 * _default_ * nthoTinFreq ' range=':= 1.239 * _default_ * nthoTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.936 * _default_ * nthoTinSize ' range=':= 0.936 * _default_ * nthoTinSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.936 * _default_ * nthoTinSize ' range=':= 0.936 * _default_ * nthoTinSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.876 * _default_ * nthoTinFreq ' range=':= 0.876 * _default_ * nthoTinFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2146,8 +2146,8 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:7")'> <OreBlock block='NetherOres:tile.netherores.ore.0:7' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 8.000 * nthoTinSize ' range=':= _default_ * nthoTinSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 8.000 * nthoTinFreq ' range=':= _default_ * nthoTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.000 * nthoTinSize ' range=':= 4.000 * nthoTinSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4.000 * nthoTinFreq ' range=':= 4.000 * nthoTinFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -2171,19 +2171,19 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:8")'> <OreBlock block='NetherOres:tile.netherores.ore.0:8' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.661 * _default_ * nthoEmeraldFreq ' range=':= 0.661 * _default_ * nthoEmeraldFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.468 * _default_ * nthoEmeraldFreq ' range=':= 0.468 * _default_ * nthoEmeraldFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoEmeraldSize ' range=':= 0 * _default_ * nthoEmeraldSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.813 * _default_ ' range=':= 0.813 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.684 * _default_ ' range=':= 0.684 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * nthoEmeraldSize ' range=':= _default_ * nthoEmeraldSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.902 * _default_ * nthoEmeraldSize ' range=':= 0.902 * _default_ * nthoEmeraldSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.827 * _default_ * nthoEmeraldSize ' range=':= 0.827 * _default_ * nthoEmeraldSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -2194,7 +2194,7 @@
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Replaces block='NetherOres:tile.netherores.ore.0:8' weight='1.0' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoEmeraldSize  * 0.5 ' range=':= 0 * _default_ * nthoEmeraldSize  * 0.5 ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.902 * _default_ * nthoEmeraldSize  * 0.5 ' range=':= 0.902 * _default_ * nthoEmeraldSize  * 0.5 ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.827 * _default_ * nthoEmeraldSize  * 0.5 ' range=':= 0.827 * _default_ * nthoEmeraldSize  * 0.5 ' type='normal' />
                             <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
                         </Veins>
                     </IfCondition>
@@ -2223,9 +2223,9 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:8")'> <OreBlock block='NetherOres:tile.netherores.ore.0:8' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.616 * _default_ * nthoEmeraldSize ' range=':= 0.616 * _default_ * nthoEmeraldSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.616 * _default_ * nthoEmeraldSize ' range=':= 0.616 * _default_ * nthoEmeraldSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.379 * _default_ * nthoEmeraldFreq ' range=':= 0.379 * _default_ * nthoEmeraldFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.518 * _default_ * nthoEmeraldSize ' range=':= 0.518 * _default_ * nthoEmeraldSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.518 * _default_ * nthoEmeraldSize ' range=':= 0.518 * _default_ * nthoEmeraldSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.268 * _default_ * nthoEmeraldFreq ' range=':= 0.268 * _default_ * nthoEmeraldFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2275,8 +2275,8 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:8")'> <OreBlock block='NetherOres:tile.netherores.ore.0:8' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 2.000 * nthoEmeraldSize ' range=':= _default_ * nthoEmeraldSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 3.000 * nthoEmeraldFreq ' range=':= _default_ * nthoEmeraldFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 1.000 * nthoEmeraldSize ' range=':= 1.000 * nthoEmeraldSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.500 * nthoEmeraldFreq ' range=':= 1.500 * nthoEmeraldFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -2300,19 +2300,19 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:9")'> <OreBlock block='NetherOres:tile.netherores.ore.0:9' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.867 * _default_ * nthoSilverFreq ' range=':= 0.867 * _default_ * nthoSilverFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.976 * _default_ * nthoSilverSize ' range=':= 0.976 * _default_ * nthoSilverSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.613 * _default_ * nthoSilverFreq ' range=':= 0.613 * _default_ * nthoSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * nthoSilverSize ' range=':= 0.922 * _default_ * nthoSilverSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.931 * _default_ ' range=':= 0.931 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.783 * _default_ ' range=':= 0.783 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * nthoSilverSize ' range=':= _default_ * nthoSilverSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.965 * _default_ * nthoSilverSize ' range=':= 0.965 * _default_ * nthoSilverSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.885 * _default_ * nthoSilverSize ' range=':= 0.885 * _default_ * nthoSilverSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -2342,9 +2342,9 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:9")'> <OreBlock block='NetherOres:tile.netherores.ore.0:9' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.871 * _default_ * nthoSilverSize ' range=':= 0.871 * _default_ * nthoSilverSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.871 * _default_ * nthoSilverSize ' range=':= 0.871 * _default_ * nthoSilverSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.758 * _default_ * nthoSilverFreq ' range=':= 0.758 * _default_ * nthoSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.732 * _default_ * nthoSilverSize ' range=':= 0.732 * _default_ * nthoSilverSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.732 * _default_ * nthoSilverSize ' range=':= 0.732 * _default_ * nthoSilverSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.536 * _default_ * nthoSilverFreq ' range=':= 0.536 * _default_ * nthoSilverFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2394,8 +2394,8 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:9")'> <OreBlock block='NetherOres:tile.netherores.ore.0:9' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.000 * nthoSilverSize ' range=':= _default_ * nthoSilverSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 6.000 * nthoSilverFreq ' range=':= _default_ * nthoSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.000 * nthoSilverSize ' range=':= 2.000 * nthoSilverSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 3.000 * nthoSilverFreq ' range=':= 3.000 * nthoSilverFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -2419,19 +2419,19 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:10")'> <OreBlock block='NetherOres:tile.netherores.ore.0:10' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.062 * _default_ * nthoLeadFreq ' range=':= 1.062 * _default_ * nthoLeadFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.010 * _default_ * nthoLeadSize ' range=':= 1.010 * _default_ * nthoLeadSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.751 * _default_ * nthoLeadFreq ' range=':= 0.751 * _default_ * nthoLeadFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.953 * _default_ * nthoLeadSize ' range=':= 0.953 * _default_ * nthoLeadSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.030 * _default_ ' range=':= 1.030 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.866 * _default_ ' range=':= 0.866 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * nthoLeadSize ' range=':= _default_ * nthoLeadSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.015 * _default_ * nthoLeadSize ' range=':= 1.015 * _default_ * nthoLeadSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.931 * _default_ * nthoLeadSize ' range=':= 0.931 * _default_ * nthoLeadSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -2461,9 +2461,9 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:10")'> <OreBlock block='NetherOres:tile.netherores.ore.0:10' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.964 * _default_ * nthoLeadSize ' range=':= 0.964 * _default_ * nthoLeadSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.964 * _default_ * nthoLeadSize ' range=':= 0.964 * _default_ * nthoLeadSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.929 * _default_ * nthoLeadFreq ' range=':= 0.929 * _default_ * nthoLeadFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.810 * _default_ * nthoLeadSize ' range=':= 0.810 * _default_ * nthoLeadSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.810 * _default_ * nthoLeadSize ' range=':= 0.810 * _default_ * nthoLeadSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.657 * _default_ * nthoLeadFreq ' range=':= 0.657 * _default_ * nthoLeadFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2513,8 +2513,8 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:10")'> <OreBlock block='NetherOres:tile.netherores.ore.0:10' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 6.000 * nthoLeadSize ' range=':= _default_ * nthoLeadSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 6.000 * nthoLeadFreq ' range=':= _default_ * nthoLeadFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 3.000 * nthoLeadSize ' range=':= 3.000 * nthoLeadSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 3.000 * nthoLeadFreq ' range=':= 3.000 * nthoLeadFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -2545,19 +2545,19 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:11")'> <OreBlock block='NetherOres:tile.netherores.ore.0:11' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.061 * _default_ * nthoUraniumFreq ' range=':= 1.061 * _default_ * nthoUraniumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.750 * _default_ * nthoUraniumFreq ' range=':= 0.750 * _default_ * nthoUraniumFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoUraniumSize ' range=':= 0 * _default_ * nthoUraniumSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.030 * _default_ ' range=':= 1.030 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.866 * _default_ ' range=':= 0.866 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * nthoUraniumSize ' range=':= _default_ * nthoUraniumSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.015 * _default_ * nthoUraniumSize ' range=':= 1.015 * _default_ * nthoUraniumSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.931 * _default_ * nthoUraniumSize ' range=':= 0.931 * _default_ * nthoUraniumSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -2587,9 +2587,9 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:11")'> <OreBlock block='NetherOres:tile.netherores.ore.0:11' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.616 * _default_ * nthoUraniumSize ' range=':= 0.616 * _default_ * nthoUraniumSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.616 * _default_ * nthoUraniumSize ' range=':= 0.616 * _default_ * nthoUraniumSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.379 * _default_ * nthoUraniumFreq ' range=':= 0.379 * _default_ * nthoUraniumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.518 * _default_ * nthoUraniumSize ' range=':= 0.518 * _default_ * nthoUraniumSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.518 * _default_ * nthoUraniumSize ' range=':= 0.518 * _default_ * nthoUraniumSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.268 * _default_ * nthoUraniumFreq ' range=':= 0.268 * _default_ * nthoUraniumFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2639,8 +2639,8 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:11")'> <OreBlock block='NetherOres:tile.netherores.ore.0:11' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 2.000 * nthoUraniumSize ' range=':= _default_ * nthoUraniumSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 3.000 * nthoUraniumFreq ' range=':= _default_ * nthoUraniumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 1.000 * nthoUraniumSize ' range=':= 1.000 * nthoUraniumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.500 * nthoUraniumFreq ' range=':= 1.500 * nthoUraniumFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -2664,7 +2664,7 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:12")'> <OreBlock block='NetherOres:tile.netherores.ore.0:12' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.818 * _default_ * nthoNikoliteFreq ' range=':= 1.818 * _default_ * nthoNikoliteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.286 * _default_ * nthoNikoliteFreq ' range=':= 1.286 * _default_ * nthoNikoliteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoNikoliteSize ' range=':= 0 * _default_ * nthoNikoliteSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2676,7 +2676,7 @@
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * nthoNikoliteSize ' range=':= _default_ * nthoNikoliteSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.349 * _default_ * nthoNikoliteSize ' range=':= 1.349 * _default_ * nthoNikoliteSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.134 * _default_ * nthoNikoliteSize ' range=':= 1.134 * _default_ * nthoNikoliteSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -2706,9 +2706,9 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:12")'> <OreBlock block='NetherOres:tile.netherores.ore.0:12' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.936 * _default_ * nthoNikoliteSize ' range=':= 0.936 * _default_ * nthoNikoliteSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.936 * _default_ * nthoNikoliteSize ' range=':= 0.936 * _default_ * nthoNikoliteSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.876 * _default_ * nthoNikoliteFreq ' range=':= 0.876 * _default_ * nthoNikoliteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.787 * _default_ * nthoNikoliteSize ' range=':= 0.787 * _default_ * nthoNikoliteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.787 * _default_ * nthoNikoliteSize ' range=':= 0.787 * _default_ * nthoNikoliteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.619 * _default_ * nthoNikoliteFreq ' range=':= 0.619 * _default_ * nthoNikoliteFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2758,8 +2758,8 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:12")'> <OreBlock block='NetherOres:tile.netherores.ore.0:12' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.000 * nthoNikoliteSize ' range=':= _default_ * nthoNikoliteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 8.000 * nthoNikoliteFreq ' range=':= _default_ * nthoNikoliteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.000 * nthoNikoliteSize ' range=':= 2.000 * nthoNikoliteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4.000 * nthoNikoliteFreq ' range=':= 4.000 * nthoNikoliteFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -2783,19 +2783,19 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:13")'> <OreBlock block='NetherOres:tile.netherores.ore.0:13' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.145 * _default_ * nthoRubyFreq ' range=':= 1.145 * _default_ * nthoRubyFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.810 * _default_ * nthoRubyFreq ' range=':= 0.810 * _default_ * nthoRubyFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoRubySize ' range=':= 0 * _default_ * nthoRubySize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.070 * _default_ ' range=':= 1.070 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.900 * _default_ ' range=':= 0.900 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * nthoRubySize ' range=':= _default_ * nthoRubySize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.035 * _default_ * nthoRubySize ' range=':= 1.035 * _default_ * nthoRubySize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.949 * _default_ * nthoRubySize ' range=':= 0.949 * _default_ * nthoRubySize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -2806,7 +2806,7 @@
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Replaces block='NetherOres:tile.netherores.ore.0:13' weight='1.0' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoRubySize  * 0.5 ' range=':= 0 * _default_ * nthoRubySize  * 0.5 ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.035 * _default_ * nthoRubySize  * 0.5 ' range=':= 1.035 * _default_ * nthoRubySize  * 0.5 ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.949 * _default_ * nthoRubySize  * 0.5 ' range=':= 0.949 * _default_ * nthoRubySize  * 0.5 ' type='normal' />
                             <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
                         </Veins>
                     </IfCondition>
@@ -2835,9 +2835,9 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:13")'> <OreBlock block='NetherOres:tile.netherores.ore.0:13' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.810 * _default_ * nthoRubySize ' range=':= 0.810 * _default_ * nthoRubySize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.810 * _default_ * nthoRubySize ' range=':= 0.810 * _default_ * nthoRubySize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.657 * _default_ * nthoRubyFreq ' range=':= 0.657 * _default_ * nthoRubyFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.682 * _default_ * nthoRubySize ' range=':= 0.682 * _default_ * nthoRubySize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.682 * _default_ * nthoRubySize ' range=':= 0.682 * _default_ * nthoRubySize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.464 * _default_ * nthoRubyFreq ' range=':= 0.464 * _default_ * nthoRubyFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2887,8 +2887,8 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:13")'> <OreBlock block='NetherOres:tile.netherores.ore.0:13' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3.000 * nthoRubySize ' range=':= _default_ * nthoRubySize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 6.000 * nthoRubyFreq ' range=':= _default_ * nthoRubyFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 1.500 * nthoRubySize ' range=':= 1.500 * nthoRubySize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 3.000 * nthoRubyFreq ' range=':= 3.000 * nthoRubyFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -2912,19 +2912,19 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:14")'> <OreBlock block='NetherOres:tile.netherores.ore.0:14' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.145 * _default_ * nthoPeridotFreq ' range=':= 1.145 * _default_ * nthoPeridotFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.810 * _default_ * nthoPeridotFreq ' range=':= 0.810 * _default_ * nthoPeridotFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoPeridotSize ' range=':= 0 * _default_ * nthoPeridotSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.070 * _default_ ' range=':= 1.070 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.900 * _default_ ' range=':= 0.900 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * nthoPeridotSize ' range=':= _default_ * nthoPeridotSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.035 * _default_ * nthoPeridotSize ' range=':= 1.035 * _default_ * nthoPeridotSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.949 * _default_ * nthoPeridotSize ' range=':= 0.949 * _default_ * nthoPeridotSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -2935,7 +2935,7 @@
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Replaces block='NetherOres:tile.netherores.ore.0:14' weight='1.0' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoPeridotSize  * 0.5 ' range=':= 0 * _default_ * nthoPeridotSize  * 0.5 ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.035 * _default_ * nthoPeridotSize  * 0.5 ' range=':= 1.035 * _default_ * nthoPeridotSize  * 0.5 ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.949 * _default_ * nthoPeridotSize  * 0.5 ' range=':= 0.949 * _default_ * nthoPeridotSize  * 0.5 ' type='normal' />
                             <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
                         </Veins>
                     </IfCondition>
@@ -2964,9 +2964,9 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:14")'> <OreBlock block='NetherOres:tile.netherores.ore.0:14' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.810 * _default_ * nthoPeridotSize ' range=':= 0.810 * _default_ * nthoPeridotSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.810 * _default_ * nthoPeridotSize ' range=':= 0.810 * _default_ * nthoPeridotSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.657 * _default_ * nthoPeridotFreq ' range=':= 0.657 * _default_ * nthoPeridotFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.682 * _default_ * nthoPeridotSize ' range=':= 0.682 * _default_ * nthoPeridotSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.682 * _default_ * nthoPeridotSize ' range=':= 0.682 * _default_ * nthoPeridotSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.464 * _default_ * nthoPeridotFreq ' range=':= 0.464 * _default_ * nthoPeridotFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3016,8 +3016,8 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:14")'> <OreBlock block='NetherOres:tile.netherores.ore.0:14' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3.000 * nthoPeridotSize ' range=':= _default_ * nthoPeridotSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 6.000 * nthoPeridotFreq ' range=':= _default_ * nthoPeridotFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 1.500 * nthoPeridotSize ' range=':= 1.500 * nthoPeridotSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 3.000 * nthoPeridotFreq ' range=':= 3.000 * nthoPeridotFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -3041,19 +3041,19 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:15")'> <OreBlock block='NetherOres:tile.netherores.ore.0:15' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.145 * _default_ * nthoSapphireFreq ' range=':= 1.145 * _default_ * nthoSapphireFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.810 * _default_ * nthoSapphireFreq ' range=':= 0.810 * _default_ * nthoSapphireFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoSapphireSize ' range=':= 0 * _default_ * nthoSapphireSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.070 * _default_ ' range=':= 1.070 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.900 * _default_ ' range=':= 0.900 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * nthoSapphireSize ' range=':= _default_ * nthoSapphireSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.035 * _default_ * nthoSapphireSize ' range=':= 1.035 * _default_ * nthoSapphireSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.949 * _default_ * nthoSapphireSize ' range=':= 0.949 * _default_ * nthoSapphireSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -3064,7 +3064,7 @@
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Replaces block='NetherOres:tile.netherores.ore.0:15' weight='1.0' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoSapphireSize  * 0.5 ' range=':= 0 * _default_ * nthoSapphireSize  * 0.5 ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.035 * _default_ * nthoSapphireSize  * 0.5 ' range=':= 1.035 * _default_ * nthoSapphireSize  * 0.5 ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.949 * _default_ * nthoSapphireSize  * 0.5 ' range=':= 0.949 * _default_ * nthoSapphireSize  * 0.5 ' type='normal' />
                             <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
                         </Veins>
                     </IfCondition>
@@ -3093,9 +3093,9 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:15")'> <OreBlock block='NetherOres:tile.netherores.ore.0:15' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.810 * _default_ * nthoSapphireSize ' range=':= 0.810 * _default_ * nthoSapphireSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.810 * _default_ * nthoSapphireSize ' range=':= 0.810 * _default_ * nthoSapphireSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.657 * _default_ * nthoSapphireFreq ' range=':= 0.657 * _default_ * nthoSapphireFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.682 * _default_ * nthoSapphireSize ' range=':= 0.682 * _default_ * nthoSapphireSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.682 * _default_ * nthoSapphireSize ' range=':= 0.682 * _default_ * nthoSapphireSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.464 * _default_ * nthoSapphireFreq ' range=':= 0.464 * _default_ * nthoSapphireFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3145,8 +3145,8 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:15")'> <OreBlock block='NetherOres:tile.netherores.ore.0:15' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3.000 * nthoSapphireSize ' range=':= _default_ * nthoSapphireSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 6.000 * nthoSapphireFreq ' range=':= _default_ * nthoSapphireFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 1.500 * nthoSapphireSize ' range=':= 1.500 * nthoSapphireSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 3.000 * nthoSapphireFreq ' range=':= 3.000 * nthoSapphireFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -3167,22 +3167,22 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:0")'> <OreBlock block='NetherOres:tile.netherores.ore.1:0' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1")'> <OreBlock block='NetherOres:tile.netherores.ore.1' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.306 * _default_ * nthoPlatinumFreq ' range=':= 0.306 * _default_ * nthoPlatinumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.821 * _default_ * nthoPlatinumSize ' range=':= 0.821 * _default_ * nthoPlatinumSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.217 * _default_ * nthoPlatinumFreq ' range=':= 0.217 * _default_ * nthoPlatinumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.775 * _default_ * nthoPlatinumSize ' range=':= 0.775 * _default_ * nthoPlatinumSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.554 * _default_ ' range=':= 0.554 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.466 * _default_ ' range=':= 0.466 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * nthoPlatinumSize ' range=':= _default_ * nthoPlatinumSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.744 * _default_ * nthoPlatinumSize ' range=':= 0.744 * _default_ * nthoPlatinumSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.682 * _default_ * nthoPlatinumSize ' range=':= 0.682 * _default_ * nthoPlatinumSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -3209,12 +3209,12 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:0")'> <OreBlock block='NetherOres:tile.netherores.ore.1:0' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1")'> <OreBlock block='NetherOres:tile.netherores.ore.1' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.518 * _default_ * nthoPlatinumSize ' range=':= 0.518 * _default_ * nthoPlatinumSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.518 * _default_ * nthoPlatinumSize ' range=':= 0.518 * _default_ * nthoPlatinumSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.268 * _default_ * nthoPlatinumFreq ' range=':= 0.268 * _default_ * nthoPlatinumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.435 * _default_ * nthoPlatinumSize ' range=':= 0.435 * _default_ * nthoPlatinumSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.435 * _default_ * nthoPlatinumSize ' range=':= 0.435 * _default_ * nthoPlatinumSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.190 * _default_ * nthoPlatinumFreq ' range=':= 0.190 * _default_ * nthoPlatinumFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3243,7 +3243,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:0")'> <OreBlock block='NetherOres:tile.netherores.ore.1:0' weight='1.0' /> </IfCondition>
+                                <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1")'> <OreBlock block='NetherOres:tile.netherores.ore.1' weight='1.0' /> </IfCondition>
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -3261,11 +3261,11 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:0")'> <OreBlock block='NetherOres:tile.netherores.ore.1:0' weight='1.0' /> </IfCondition>
+                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1")'> <OreBlock block='NetherOres:tile.netherores.ore.1' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3.000 * nthoPlatinumSize ' range=':= _default_ * nthoPlatinumSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.000 * nthoPlatinumFreq ' range=':= _default_ * nthoPlatinumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 1.500 * nthoPlatinumSize ' range=':= 1.500 * nthoPlatinumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 0.500 * nthoPlatinumFreq ' range=':= 0.500 * nthoPlatinumFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -3289,19 +3289,19 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:1")'> <OreBlock block='NetherOres:tile.netherores.ore.1:1' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.867 * _default_ * nthoNickelFreq ' range=':= 0.867 * _default_ * nthoNickelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.976 * _default_ * nthoNickelSize ' range=':= 0.976 * _default_ * nthoNickelSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.613 * _default_ * nthoNickelFreq ' range=':= 0.613 * _default_ * nthoNickelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * nthoNickelSize ' range=':= 0.922 * _default_ * nthoNickelSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.931 * _default_ ' range=':= 0.931 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.783 * _default_ ' range=':= 0.783 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * nthoNickelSize ' range=':= _default_ * nthoNickelSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.965 * _default_ * nthoNickelSize ' range=':= 0.965 * _default_ * nthoNickelSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.885 * _default_ * nthoNickelSize ' range=':= 0.885 * _default_ * nthoNickelSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -3331,9 +3331,9 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:1")'> <OreBlock block='NetherOres:tile.netherores.ore.1:1' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.871 * _default_ * nthoNickelSize ' range=':= 0.871 * _default_ * nthoNickelSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.871 * _default_ * nthoNickelSize ' range=':= 0.871 * _default_ * nthoNickelSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.758 * _default_ * nthoNickelFreq ' range=':= 0.758 * _default_ * nthoNickelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.732 * _default_ * nthoNickelSize ' range=':= 0.732 * _default_ * nthoNickelSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.732 * _default_ * nthoNickelSize ' range=':= 0.732 * _default_ * nthoNickelSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.536 * _default_ * nthoNickelFreq ' range=':= 0.536 * _default_ * nthoNickelFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3383,8 +3383,8 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:1")'> <OreBlock block='NetherOres:tile.netherores.ore.1:1' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 6.000 * nthoNickelSize ' range=':= _default_ * nthoNickelSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 4.000 * nthoNickelFreq ' range=':= _default_ * nthoNickelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 3.000 * nthoNickelSize ' range=':= 3.000 * nthoNickelSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2.000 * nthoNickelFreq ' range=':= 2.000 * nthoNickelFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -3408,19 +3408,19 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:2")'> <OreBlock block='NetherOres:tile.netherores.ore.1:2' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.613 * _default_ * nthoSteelFreq ' range=':= 0.613 * _default_ * nthoSteelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * nthoSteelSize ' range=':= 0.922 * _default_ * nthoSteelSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.433 * _default_ * nthoSteelFreq ' range=':= 0.433 * _default_ * nthoSteelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.870 * _default_ * nthoSteelSize ' range=':= 0.870 * _default_ * nthoSteelSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.783 * _default_ ' range=':= 0.783 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.658 * _default_ ' range=':= 0.658 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * nthoSteelSize ' range=':= _default_ * nthoSteelSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.885 * _default_ * nthoSteelSize ' range=':= 0.885 * _default_ * nthoSteelSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.811 * _default_ * nthoSteelSize ' range=':= 0.811 * _default_ * nthoSteelSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -3450,9 +3450,9 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:2")'> <OreBlock block='NetherOres:tile.netherores.ore.1:2' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.732 * _default_ * nthoSteelSize ' range=':= 0.732 * _default_ * nthoSteelSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.732 * _default_ * nthoSteelSize ' range=':= 0.732 * _default_ * nthoSteelSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.536 * _default_ * nthoSteelFreq ' range=':= 0.536 * _default_ * nthoSteelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.616 * _default_ * nthoSteelSize ' range=':= 0.616 * _default_ * nthoSteelSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.616 * _default_ * nthoSteelSize ' range=':= 0.616 * _default_ * nthoSteelSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.379 * _default_ * nthoSteelFreq ' range=':= 0.379 * _default_ * nthoSteelFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3502,8 +3502,8 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:2")'> <OreBlock block='NetherOres:tile.netherores.ore.1:2' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.000 * nthoSteelSize ' range=':= _default_ * nthoSteelSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 3.000 * nthoSteelFreq ' range=':= _default_ * nthoSteelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.000 * nthoSteelSize ' range=':= 2.000 * nthoSteelSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.500 * nthoSteelFreq ' range=':= 1.500 * nthoSteelFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -3529,8 +3529,8 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:3")'> <OreBlock block='NetherOres:tile.netherores.ore.1:3' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.313 * _default_ * nthoIridiumFreq ' range=':= 0.313 * _default_ * nthoIridiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.824 * _default_ * nthoIridiumSize ' range=':= 0.824 * _default_ * nthoIridiumSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.221 * _default_ * nthoIridiumFreq ' range=':= 0.221 * _default_ * nthoIridiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.778 * _default_ * nthoIridiumSize ' range=':= 0.778 * _default_ * nthoIridiumSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3571,9 +3571,9 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:3")'> <OreBlock block='NetherOres:tile.netherores.ore.1:3' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.468 * _default_ * nthoIridiumSize ' range=':= 0.468 * _default_ * nthoIridiumSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.468 * _default_ * nthoIridiumSize ' range=':= 0.468 * _default_ * nthoIridiumSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.219 * _default_ * nthoIridiumFreq ' range=':= 0.219 * _default_ * nthoIridiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.393 * _default_ * nthoIridiumSize ' range=':= 0.393 * _default_ * nthoIridiumSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.393 * _default_ * nthoIridiumSize ' range=':= 0.393 * _default_ * nthoIridiumSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.155 * _default_ * nthoIridiumFreq ' range=':= 0.155 * _default_ * nthoIridiumFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3623,8 +3623,8 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:3")'> <OreBlock block='NetherOres:tile.netherores.ore.1:3' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 2.000 * nthoIridiumSize ' range=':= _default_ * nthoIridiumSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.000 * nthoIridiumFreq ' range=':= _default_ * nthoIridiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 1.000 * nthoIridiumSize ' range=':= 1.000 * nthoIridiumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 0.500 * nthoIridiumFreq ' range=':= 0.500 * nthoIridiumFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -3648,19 +3648,19 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:4")'> <OreBlock block='NetherOres:tile.netherores.ore.1:4' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.324 * _default_ * nthoOsmiumFreq ' range=':= 1.324 * _default_ * nthoOsmiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.048 * _default_ * nthoOsmiumSize ' range=':= 1.048 * _default_ * nthoOsmiumSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.936 * _default_ * nthoOsmiumFreq ' range=':= 0.936 * _default_ * nthoOsmiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.989 * _default_ * nthoOsmiumSize ' range=':= 0.989 * _default_ * nthoOsmiumSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.151 * _default_ ' range=':= 1.151 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.968 * _default_ ' range=':= 0.968 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * nthoOsmiumSize ' range=':= _default_ * nthoOsmiumSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.073 * _default_ * nthoOsmiumSize ' range=':= 1.073 * _default_ * nthoOsmiumSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.984 * _default_ * nthoOsmiumSize ' range=':= 0.984 * _default_ * nthoOsmiumSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -3690,9 +3690,9 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:4")'> <OreBlock block='NetherOres:tile.netherores.ore.1:4' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.076 * _default_ * nthoOsmiumSize ' range=':= 1.076 * _default_ * nthoOsmiumSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.076 * _default_ * nthoOsmiumSize ' range=':= 1.076 * _default_ * nthoOsmiumSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.159 * _default_ * nthoOsmiumFreq ' range=':= 1.159 * _default_ * nthoOsmiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.905 * _default_ * nthoOsmiumSize ' range=':= 0.905 * _default_ * nthoOsmiumSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.905 * _default_ * nthoOsmiumSize ' range=':= 0.905 * _default_ * nthoOsmiumSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.819 * _default_ * nthoOsmiumFreq ' range=':= 0.819 * _default_ * nthoOsmiumFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3742,8 +3742,8 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:4")'> <OreBlock block='NetherOres:tile.netherores.ore.1:4' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 7.000 * nthoOsmiumSize ' range=':= _default_ * nthoOsmiumSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 8.000 * nthoOsmiumFreq ' range=':= _default_ * nthoOsmiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 3.500 * nthoOsmiumSize ' range=':= 3.500 * nthoOsmiumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4.000 * nthoOsmiumFreq ' range=':= 4.000 * nthoOsmiumFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -3767,19 +3767,19 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:5")'> <OreBlock block='NetherOres:tile.netherores.ore.1:5' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 3.240 * _default_ * nthoSulfurFreq ' range=':= 3.240 * _default_ * nthoSulfurFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeFrequency' avg=':= 2.291 * _default_ * nthoSulfurFreq ' range=':= 2.291 * _default_ * nthoSulfurFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoSulfurSize ' range=':= 0 * _default_ * nthoSulfurSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.800 * _default_ ' range=':= 1.800 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.514 * _default_ ' range=':= 1.514 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * nthoSulfurSize ' range=':= _default_ * nthoSulfurSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.342 * _default_ * nthoSulfurSize ' range=':= 1.342 * _default_ * nthoSulfurSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.230 * _default_ * nthoSulfurSize ' range=':= 1.230 * _default_ * nthoSulfurSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -3790,7 +3790,7 @@
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Replaces block='NetherOres:tile.netherores.ore.1:5' weight='1.0' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoSulfurSize  * 0.5 ' range=':= 0 * _default_ * nthoSulfurSize  * 0.5 ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.342 * _default_ * nthoSulfurSize  * 0.5 ' range=':= 1.342 * _default_ * nthoSulfurSize  * 0.5 ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.230 * _default_ * nthoSulfurSize  * 0.5 ' range=':= 1.230 * _default_ * nthoSulfurSize  * 0.5 ' type='normal' />
                             <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
                         </Veins>
                     </IfCondition>
@@ -3819,9 +3819,9 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:5")'> <OreBlock block='NetherOres:tile.netherores.ore.1:5' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.363 * _default_ * nthoSulfurSize ' range=':= 1.363 * _default_ * nthoSulfurSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.363 * _default_ * nthoSulfurSize ' range=':= 1.363 * _default_ * nthoSulfurSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.858 * _default_ * nthoSulfurFreq ' range=':= 1.858 * _default_ * nthoSulfurFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 1.146 * _default_ * nthoSulfurSize ' range=':= 1.146 * _default_ * nthoSulfurSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.146 * _default_ * nthoSulfurSize ' range=':= 1.146 * _default_ * nthoSulfurSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.314 * _default_ * nthoSulfurFreq ' range=':= 1.314 * _default_ * nthoSulfurFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3871,8 +3871,8 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:5")'> <OreBlock block='NetherOres:tile.netherores.ore.1:5' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 12.000 * nthoSulfurSize ' range=':= _default_ * nthoSulfurSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 12.000 * nthoSulfurFreq ' range=':= _default_ * nthoSulfurFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 6.000 * nthoSulfurSize ' range=':= 6.000 * nthoSulfurSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 6.000 * nthoSulfurFreq ' range=':= 6.000 * nthoSulfurFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -3896,19 +3896,19 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:6")'> <OreBlock block='NetherOres:tile.netherores.ore.1:6' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.433 * _default_ * nthoTitaniumFreq ' range=':= 0.433 * _default_ * nthoTitaniumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.870 * _default_ * nthoTitaniumSize ' range=':= 0.870 * _default_ * nthoTitaniumSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.306 * _default_ * nthoTitaniumFreq ' range=':= 0.306 * _default_ * nthoTitaniumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.821 * _default_ * nthoTitaniumSize ' range=':= 0.821 * _default_ * nthoTitaniumSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.658 * _default_ ' range=':= 0.658 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.554 * _default_ ' range=':= 0.554 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * nthoTitaniumSize ' range=':= _default_ * nthoTitaniumSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.811 * _default_ * nthoTitaniumSize ' range=':= 0.811 * _default_ * nthoTitaniumSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.744 * _default_ * nthoTitaniumSize ' range=':= 0.744 * _default_ * nthoTitaniumSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -3938,9 +3938,9 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:6")'> <OreBlock block='NetherOres:tile.netherores.ore.1:6' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.616 * _default_ * nthoTitaniumSize ' range=':= 0.616 * _default_ * nthoTitaniumSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.616 * _default_ * nthoTitaniumSize ' range=':= 0.616 * _default_ * nthoTitaniumSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.379 * _default_ * nthoTitaniumFreq ' range=':= 0.379 * _default_ * nthoTitaniumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.518 * _default_ * nthoTitaniumSize ' range=':= 0.518 * _default_ * nthoTitaniumSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.518 * _default_ * nthoTitaniumSize ' range=':= 0.518 * _default_ * nthoTitaniumSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.268 * _default_ * nthoTitaniumFreq ' range=':= 0.268 * _default_ * nthoTitaniumFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3990,8 +3990,8 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:6")'> <OreBlock block='NetherOres:tile.netherores.ore.1:6' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 2.000 * nthoTitaniumSize ' range=':= _default_ * nthoTitaniumSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 3.000 * nthoTitaniumFreq ' range=':= _default_ * nthoTitaniumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 1.000 * nthoTitaniumSize ' range=':= 1.000 * nthoTitaniumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.500 * nthoTitaniumFreq ' range=':= 1.500 * nthoTitaniumFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -4015,19 +4015,19 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:7")'> <OreBlock block='NetherOres:tile.netherores.ore.1:7' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.062 * _default_ * nthoMithrilFreq ' range=':= 1.062 * _default_ * nthoMithrilFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.010 * _default_ * nthoMithrilSize ' range=':= 1.010 * _default_ * nthoMithrilSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.751 * _default_ * nthoMithrilFreq ' range=':= 0.751 * _default_ * nthoMithrilFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.953 * _default_ * nthoMithrilSize ' range=':= 0.953 * _default_ * nthoMithrilSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.030 * _default_ ' range=':= 1.030 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.866 * _default_ ' range=':= 0.866 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * nthoMithrilSize ' range=':= _default_ * nthoMithrilSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.015 * _default_ * nthoMithrilSize ' range=':= 1.015 * _default_ * nthoMithrilSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.931 * _default_ * nthoMithrilSize ' range=':= 0.931 * _default_ * nthoMithrilSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -4057,9 +4057,9 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:7")'> <OreBlock block='NetherOres:tile.netherores.ore.1:7' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.964 * _default_ * nthoMithrilSize ' range=':= 0.964 * _default_ * nthoMithrilSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.964 * _default_ * nthoMithrilSize ' range=':= 0.964 * _default_ * nthoMithrilSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.929 * _default_ * nthoMithrilFreq ' range=':= 0.929 * _default_ * nthoMithrilFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.810 * _default_ * nthoMithrilSize ' range=':= 0.810 * _default_ * nthoMithrilSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.810 * _default_ * nthoMithrilSize ' range=':= 0.810 * _default_ * nthoMithrilSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.657 * _default_ * nthoMithrilFreq ' range=':= 0.657 * _default_ * nthoMithrilFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4109,8 +4109,8 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:7")'> <OreBlock block='NetherOres:tile.netherores.ore.1:7' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 6.000 * nthoMithrilSize ' range=':= _default_ * nthoMithrilSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 6.000 * nthoMithrilFreq ' range=':= _default_ * nthoMithrilFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 3.000 * nthoMithrilSize ' range=':= 3.000 * nthoMithrilSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 3.000 * nthoMithrilFreq ' range=':= 3.000 * nthoMithrilFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -4134,19 +4134,19 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:8")'> <OreBlock block='NetherOres:tile.netherores.ore.1:8' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.791 * _default_ * nthoAdamantiumFreq ' range=':= 0.791 * _default_ * nthoAdamantiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.962 * _default_ * nthoAdamantiumSize ' range=':= 0.962 * _default_ * nthoAdamantiumSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.560 * _default_ * nthoAdamantiumFreq ' range=':= 0.560 * _default_ * nthoAdamantiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.908 * _default_ * nthoAdamantiumSize ' range=':= 0.908 * _default_ * nthoAdamantiumSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.890 * _default_ ' range=':= 0.890 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.748 * _default_ ' range=':= 0.748 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * nthoAdamantiumSize ' range=':= _default_ * nthoAdamantiumSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.943 * _default_ * nthoAdamantiumSize ' range=':= 0.943 * _default_ * nthoAdamantiumSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.865 * _default_ * nthoAdamantiumSize ' range=':= 0.865 * _default_ * nthoAdamantiumSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -4176,9 +4176,9 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:8")'> <OreBlock block='NetherOres:tile.netherores.ore.1:8' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.832 * _default_ * nthoAdamantiumSize ' range=':= 0.832 * _default_ * nthoAdamantiumSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.832 * _default_ * nthoAdamantiumSize ' range=':= 0.832 * _default_ * nthoAdamantiumSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.692 * _default_ * nthoAdamantiumFreq ' range=':= 0.692 * _default_ * nthoAdamantiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.700 * _default_ * nthoAdamantiumSize ' range=':= 0.700 * _default_ * nthoAdamantiumSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.700 * _default_ * nthoAdamantiumSize ' range=':= 0.700 * _default_ * nthoAdamantiumSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.490 * _default_ * nthoAdamantiumFreq ' range=':= 0.490 * _default_ * nthoAdamantiumFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4228,8 +4228,8 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:8")'> <OreBlock block='NetherOres:tile.netherores.ore.1:8' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.000 * nthoAdamantiumSize ' range=':= _default_ * nthoAdamantiumSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 5.000 * nthoAdamantiumFreq ' range=':= _default_ * nthoAdamantiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.000 * nthoAdamantiumSize ' range=':= 2.000 * nthoAdamantiumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2.500 * nthoAdamantiumFreq ' range=':= 2.500 * nthoAdamantiumFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -4253,19 +4253,19 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:9")'> <OreBlock block='NetherOres:tile.netherores.ore.1:9' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.613 * _default_ * nthoRutileFreq ' range=':= 0.613 * _default_ * nthoRutileFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * nthoRutileSize ' range=':= 0.922 * _default_ * nthoRutileSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.433 * _default_ * nthoRutileFreq ' range=':= 0.433 * _default_ * nthoRutileFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.870 * _default_ * nthoRutileSize ' range=':= 0.870 * _default_ * nthoRutileSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.783 * _default_ ' range=':= 0.783 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.658 * _default_ ' range=':= 0.658 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * nthoRutileSize ' range=':= _default_ * nthoRutileSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.885 * _default_ * nthoRutileSize ' range=':= 0.885 * _default_ * nthoRutileSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.811 * _default_ * nthoRutileSize ' range=':= 0.811 * _default_ * nthoRutileSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -4295,9 +4295,9 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:9")'> <OreBlock block='NetherOres:tile.netherores.ore.1:9' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.732 * _default_ * nthoRutileSize ' range=':= 0.732 * _default_ * nthoRutileSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.732 * _default_ * nthoRutileSize ' range=':= 0.732 * _default_ * nthoRutileSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.536 * _default_ * nthoRutileFreq ' range=':= 0.536 * _default_ * nthoRutileFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.616 * _default_ * nthoRutileSize ' range=':= 0.616 * _default_ * nthoRutileSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.616 * _default_ * nthoRutileSize ' range=':= 0.616 * _default_ * nthoRutileSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.379 * _default_ * nthoRutileFreq ' range=':= 0.379 * _default_ * nthoRutileFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4347,8 +4347,8 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:9")'> <OreBlock block='NetherOres:tile.netherores.ore.1:9' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.000 * nthoRutileSize ' range=':= _default_ * nthoRutileSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 3.000 * nthoRutileFreq ' range=':= _default_ * nthoRutileFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.000 * nthoRutileSize ' range=':= 2.000 * nthoRutileSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.500 * nthoRutileFreq ' range=':= 1.500 * nthoRutileFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -4372,19 +4372,19 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:10")'> <OreBlock block='NetherOres:tile.netherores.ore.1:10' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.416 * _default_ * nthoTungstenFreq ' range=':= 1.416 * _default_ * nthoTungstenFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.060 * _default_ * nthoTungstenSize ' range=':= 1.060 * _default_ * nthoTungstenSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.001 * _default_ * nthoTungstenFreq ' range=':= 1.001 * _default_ * nthoTungstenFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.000 * _default_ * nthoTungstenSize ' range=':= 1.000 * _default_ * nthoTungstenSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.190 * _default_ ' range=':= 1.190 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.000 * _default_ ' range=':= 1.000 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * nthoTungstenSize ' range=':= _default_ * nthoTungstenSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.091 * _default_ * nthoTungstenSize ' range=':= 1.091 * _default_ * nthoTungstenSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.000 * _default_ * nthoTungstenSize ' range=':= 1.000 * _default_ * nthoTungstenSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -4414,9 +4414,9 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:10")'> <OreBlock block='NetherOres:tile.netherores.ore.1:10' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.113 * _default_ * nthoTungstenSize ' range=':= 1.113 * _default_ * nthoTungstenSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.113 * _default_ * nthoTungstenSize ' range=':= 1.113 * _default_ * nthoTungstenSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.239 * _default_ * nthoTungstenFreq ' range=':= 1.239 * _default_ * nthoTungstenFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.936 * _default_ * nthoTungstenSize ' range=':= 0.936 * _default_ * nthoTungstenSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.936 * _default_ * nthoTungstenSize ' range=':= 0.936 * _default_ * nthoTungstenSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.876 * _default_ * nthoTungstenFreq ' range=':= 0.876 * _default_ * nthoTungstenFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4466,8 +4466,8 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:10")'> <OreBlock block='NetherOres:tile.netherores.ore.1:10' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 8.000 * nthoTungstenSize ' range=':= _default_ * nthoTungstenSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 8.000 * nthoTungstenFreq ' range=':= _default_ * nthoTungstenFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.000 * nthoTungstenSize ' range=':= 4.000 * nthoTungstenSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4.000 * nthoTungstenFreq ' range=':= 4.000 * nthoTungstenFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -4498,19 +4498,19 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:11")'> <OreBlock block='NetherOres:tile.netherores.ore.1:11' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 2.372 * _default_ * nthoAmberFreq ' range=':= 2.372 * _default_ * nthoAmberFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.678 * _default_ * nthoAmberFreq ' range=':= 1.678 * _default_ * nthoAmberFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoAmberSize ' range=':= 0 * _default_ * nthoAmberSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.540 * _default_ ' range=':= 1.540 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.295 * _default_ ' range=':= 1.295 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * nthoAmberSize ' range=':= _default_ * nthoAmberSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.241 * _default_ * nthoAmberSize ' range=':= 1.241 * _default_ * nthoAmberSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.138 * _default_ * nthoAmberSize ' range=':= 1.138 * _default_ * nthoAmberSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -4540,9 +4540,9 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:11")'> <OreBlock block='NetherOres:tile.netherores.ore.1:11' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.921 * _default_ * nthoAmberSize ' range=':= 0.921 * _default_ * nthoAmberSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.921 * _default_ * nthoAmberSize ' range=':= 0.921 * _default_ * nthoAmberSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.848 * _default_ * nthoAmberFreq ' range=':= 0.848 * _default_ * nthoAmberFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.774 * _default_ * nthoAmberSize ' range=':= 0.774 * _default_ * nthoAmberSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.774 * _default_ * nthoAmberSize ' range=':= 0.774 * _default_ * nthoAmberSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.600 * _default_ * nthoAmberFreq ' range=':= 0.600 * _default_ * nthoAmberFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4592,8 +4592,8 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:11")'> <OreBlock block='NetherOres:tile.netherores.ore.1:11' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 6.000 * nthoAmberSize ' range=':= _default_ * nthoAmberSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 5.000 * nthoAmberFreq ' range=':= _default_ * nthoAmberFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 3.000 * nthoAmberSize ' range=':= 3.000 * nthoAmberSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2.500 * nthoAmberFreq ' range=':= 2.500 * nthoAmberFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -4617,19 +4617,19 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:12")'> <OreBlock block='NetherOres:tile.netherores.ore.1:12' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.416 * _default_ * nthoTennantiteFreq ' range=':= 1.416 * _default_ * nthoTennantiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.060 * _default_ * nthoTennantiteSize ' range=':= 1.060 * _default_ * nthoTennantiteSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.001 * _default_ * nthoTennantiteFreq ' range=':= 1.001 * _default_ * nthoTennantiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.000 * _default_ * nthoTennantiteSize ' range=':= 1.000 * _default_ * nthoTennantiteSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.190 * _default_ ' range=':= 1.190 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.000 * _default_ ' range=':= 1.000 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * nthoTennantiteSize ' range=':= _default_ * nthoTennantiteSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.091 * _default_ * nthoTennantiteSize ' range=':= 1.091 * _default_ * nthoTennantiteSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.000 * _default_ * nthoTennantiteSize ' range=':= 1.000 * _default_ * nthoTennantiteSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -4659,9 +4659,9 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:12")'> <OreBlock block='NetherOres:tile.netherores.ore.1:12' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.113 * _default_ * nthoTennantiteSize ' range=':= 1.113 * _default_ * nthoTennantiteSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.113 * _default_ * nthoTennantiteSize ' range=':= 1.113 * _default_ * nthoTennantiteSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.239 * _default_ * nthoTennantiteFreq ' range=':= 1.239 * _default_ * nthoTennantiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.936 * _default_ * nthoTennantiteSize ' range=':= 0.936 * _default_ * nthoTennantiteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.936 * _default_ * nthoTennantiteSize ' range=':= 0.936 * _default_ * nthoTennantiteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.876 * _default_ * nthoTennantiteFreq ' range=':= 0.876 * _default_ * nthoTennantiteFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4711,8 +4711,8 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:12")'> <OreBlock block='NetherOres:tile.netherores.ore.1:12' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 8.000 * nthoTennantiteSize ' range=':= _default_ * nthoTennantiteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 8.000 * nthoTennantiteFreq ' range=':= _default_ * nthoTennantiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.000 * nthoTennantiteSize ' range=':= 4.000 * nthoTennantiteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4.000 * nthoTennantiteFreq ' range=':= 4.000 * nthoTennantiteFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -4743,19 +4743,19 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:13")'> <OreBlock block='NetherOres:tile.netherores.ore.1:13' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 2.166 * _default_ * nthoSaltFreq ' range=':= 2.166 * _default_ * nthoSaltFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.531 * _default_ * nthoSaltFreq ' range=':= 1.531 * _default_ * nthoSaltFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoSaltSize ' range=':= 0 * _default_ * nthoSaltSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.472 * _default_ ' range=':= 1.472 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.237 * _default_ ' range=':= 1.237 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * nthoSaltSize ' range=':= _default_ * nthoSaltSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.213 * _default_ * nthoSaltSize ' range=':= 1.213 * _default_ * nthoSaltSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.112 * _default_ * nthoSaltSize ' range=':= 1.112 * _default_ * nthoSaltSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -4785,9 +4785,9 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:13")'> <OreBlock block='NetherOres:tile.netherores.ore.1:13' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.880 * _default_ * nthoSaltSize ' range=':= 0.880 * _default_ * nthoSaltSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.880 * _default_ * nthoSaltSize ' range=':= 0.880 * _default_ * nthoSaltSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.774 * _default_ * nthoSaltFreq ' range=':= 0.774 * _default_ * nthoSaltFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.740 * _default_ * nthoSaltSize ' range=':= 0.740 * _default_ * nthoSaltSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.740 * _default_ * nthoSaltSize ' range=':= 0.740 * _default_ * nthoSaltSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.547 * _default_ * nthoSaltFreq ' range=':= 0.547 * _default_ * nthoSaltFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4837,8 +4837,8 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:13")'> <OreBlock block='NetherOres:tile.netherores.ore.1:13' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 5.000 * nthoSaltSize ' range=':= _default_ * nthoSaltSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 5.000 * nthoSaltFreq ' range=':= _default_ * nthoSaltFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.500 * nthoSaltSize ' range=':= 2.500 * nthoSaltSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2.500 * nthoSaltFreq ' range=':= 2.500 * nthoSaltFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -4869,19 +4869,19 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:14")'> <OreBlock block='NetherOres:tile.netherores.ore.1:14' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 2.122 * _default_ * nthoSaltpeterFreq ' range=':= 2.122 * _default_ * nthoSaltpeterFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.500 * _default_ * nthoSaltpeterFreq ' range=':= 1.500 * _default_ * nthoSaltpeterFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoSaltpeterSize ' range=':= 0 * _default_ * nthoSaltpeterSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.457 * _default_ ' range=':= 1.457 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.225 * _default_ ' range=':= 1.225 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * nthoSaltpeterSize ' range=':= _default_ * nthoSaltpeterSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.207 * _default_ * nthoSaltpeterSize ' range=':= 1.207 * _default_ * nthoSaltpeterSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.107 * _default_ * nthoSaltpeterSize ' range=':= 1.107 * _default_ * nthoSaltpeterSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -4911,9 +4911,9 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:14")'> <OreBlock block='NetherOres:tile.netherores.ore.1:14' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.871 * _default_ * nthoSaltpeterSize ' range=':= 0.871 * _default_ * nthoSaltpeterSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.871 * _default_ * nthoSaltpeterSize ' range=':= 0.871 * _default_ * nthoSaltpeterSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.758 * _default_ * nthoSaltpeterFreq ' range=':= 0.758 * _default_ * nthoSaltpeterFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.732 * _default_ * nthoSaltpeterSize ' range=':= 0.732 * _default_ * nthoSaltpeterSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.732 * _default_ * nthoSaltpeterSize ' range=':= 0.732 * _default_ * nthoSaltpeterSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.536 * _default_ * nthoSaltpeterFreq ' range=':= 0.536 * _default_ * nthoSaltpeterFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4963,8 +4963,8 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:14")'> <OreBlock block='NetherOres:tile.netherores.ore.1:14' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.000 * nthoSaltpeterSize ' range=':= _default_ * nthoSaltpeterSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 6.000 * nthoSaltpeterFreq ' range=':= _default_ * nthoSaltpeterFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.000 * nthoSaltpeterSize ' range=':= 2.000 * nthoSaltpeterSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 3.000 * nthoSaltpeterFreq ' range=':= 3.000 * nthoSaltpeterFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -4995,19 +4995,19 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:15")'> <OreBlock block='NetherOres:tile.netherores.ore.1:15' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.937 * _default_ * nthoMagnesiumFreq ' range=':= 1.937 * _default_ * nthoMagnesiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.370 * _default_ * nthoMagnesiumFreq ' range=':= 1.370 * _default_ * nthoMagnesiumFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoMagnesiumSize ' range=':= 0 * _default_ * nthoMagnesiumSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.392 * _default_ ' range=':= 1.392 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.170 * _default_ ' range=':= 1.170 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * nthoMagnesiumSize ' range=':= _default_ * nthoMagnesiumSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.180 * _default_ * nthoMagnesiumSize ' range=':= 1.180 * _default_ * nthoMagnesiumSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.082 * _default_ * nthoMagnesiumSize ' range=':= 1.082 * _default_ * nthoMagnesiumSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -5037,9 +5037,9 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:15")'> <OreBlock block='NetherOres:tile.netherores.ore.1:15' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.832 * _default_ * nthoMagnesiumSize ' range=':= 0.832 * _default_ * nthoMagnesiumSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.832 * _default_ * nthoMagnesiumSize ' range=':= 0.832 * _default_ * nthoMagnesiumSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.692 * _default_ * nthoMagnesiumFreq ' range=':= 0.692 * _default_ * nthoMagnesiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.700 * _default_ * nthoMagnesiumSize ' range=':= 0.700 * _default_ * nthoMagnesiumSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.700 * _default_ * nthoMagnesiumSize ' range=':= 0.700 * _default_ * nthoMagnesiumSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.490 * _default_ * nthoMagnesiumFreq ' range=':= 0.490 * _default_ * nthoMagnesiumFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -5089,8 +5089,8 @@
                             <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:15")'> <OreBlock block='NetherOres:tile.netherores.ore.1:15' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 5.000 * nthoMagnesiumSize ' range=':= _default_ * nthoMagnesiumSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 4.000 * nthoMagnesiumFreq ' range=':= _default_ * nthoMagnesiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.500 * nthoMagnesiumSize ' range=':= 2.500 * nthoMagnesiumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2.000 * nthoMagnesiumFreq ' range=':= 2.000 * nthoMagnesiumFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>

--- a/src/main/resources/config/modules/Netherrocks.xml
+++ b/src/main/resources/config/modules/Netherrocks.xml
@@ -292,19 +292,19 @@
                             <IfCondition condition=':= ?blockExists("netherrocks:fyrite_ore")'> <OreBlock block='netherrocks:fyrite_ore' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.371 * _default_ * nthrFyriteFreq ' range=':= 1.371 * _default_ * nthrFyriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.054 * _default_ * nthrFyriteSize ' range=':= 1.054 * _default_ * nthrFyriteSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * nthrFyriteFreq ' range=':= 0.969 * _default_ * nthrFyriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.995 * _default_ * nthrFyriteSize ' range=':= 0.995 * _default_ * nthrFyriteSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.171 * _default_ ' range=':= 1.171 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.984 * _default_ ' range=':= 0.984 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * nthrFyriteSize ' range=':= _default_ * nthrFyriteSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.082 * _default_ * nthrFyriteSize ' range=':= 1.082 * _default_ * nthrFyriteSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.992 * _default_ * nthrFyriteSize ' range=':= 0.992 * _default_ * nthrFyriteSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -334,9 +334,9 @@
                             <IfCondition condition=':= ?blockExists("netherrocks:fyrite_ore")'> <OreBlock block='netherrocks:fyrite_ore' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.095 * _default_ * nthrFyriteSize ' range=':= 1.095 * _default_ * nthrFyriteSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.095 * _default_ * nthrFyriteSize ' range=':= 1.095 * _default_ * nthrFyriteSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.199 * _default_ * nthrFyriteFreq ' range=':= 1.199 * _default_ * nthrFyriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.921 * _default_ * nthrFyriteSize ' range=':= 0.921 * _default_ * nthrFyriteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.921 * _default_ * nthrFyriteSize ' range=':= 0.921 * _default_ * nthrFyriteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.848 * _default_ * nthrFyriteFreq ' range=':= 0.848 * _default_ * nthrFyriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -386,8 +386,8 @@
                             <IfCondition condition=':= ?blockExists("netherrocks:fyrite_ore")'> <OreBlock block='netherrocks:fyrite_ore' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 6.000 * nthrFyriteSize ' range=':= _default_ * nthrFyriteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 10.000 * nthrFyriteFreq ' range=':= _default_ * nthrFyriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 3.000 * nthrFyriteSize ' range=':= 3.000 * nthrFyriteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 5.000 * nthrFyriteFreq ' range=':= 5.000 * nthrFyriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -411,19 +411,19 @@
                             <IfCondition condition=':= ?blockExists("netherrocks:malachite_ore")'> <OreBlock block='netherrocks:malachite_ore' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.480 * _default_ * nthrMalachiteFreq ' range=':= 1.480 * _default_ * nthrMalachiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.068 * _default_ * nthrMalachiteSize ' range=':= 1.068 * _default_ * nthrMalachiteSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.047 * _default_ * nthrMalachiteFreq ' range=':= 1.047 * _default_ * nthrMalachiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.008 * _default_ * nthrMalachiteSize ' range=':= 1.008 * _default_ * nthrMalachiteSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.217 * _default_ ' range=':= 1.217 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.023 * _default_ ' range=':= 1.023 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * nthrMalachiteSize ' range=':= _default_ * nthrMalachiteSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.103 * _default_ * nthrMalachiteSize ' range=':= 1.103 * _default_ * nthrMalachiteSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.012 * _default_ * nthrMalachiteSize ' range=':= 1.012 * _default_ * nthrMalachiteSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -453,9 +453,9 @@
                             <IfCondition condition=':= ?blockExists("netherrocks:malachite_ore")'> <OreBlock block='netherrocks:malachite_ore' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.138 * _default_ * nthrMalachiteSize ' range=':= 1.138 * _default_ * nthrMalachiteSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.138 * _default_ * nthrMalachiteSize ' range=':= 1.138 * _default_ * nthrMalachiteSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.295 * _default_ * nthrMalachiteFreq ' range=':= 1.295 * _default_ * nthrMalachiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.957 * _default_ * nthrMalachiteSize ' range=':= 0.957 * _default_ * nthrMalachiteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.957 * _default_ * nthrMalachiteSize ' range=':= 0.957 * _default_ * nthrMalachiteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.916 * _default_ * nthrMalachiteFreq ' range=':= 0.916 * _default_ * nthrMalachiteFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -505,8 +505,8 @@
                             <IfCondition condition=':= ?blockExists("netherrocks:malachite_ore")'> <OreBlock block='netherrocks:malachite_ore' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 7.000 * nthrMalachiteSize ' range=':= _default_ * nthrMalachiteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 10.000 * nthrMalachiteFreq ' range=':= _default_ * nthrMalachiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 3.500 * nthrMalachiteSize ' range=':= 3.500 * nthrMalachiteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 5.000 * nthrMalachiteFreq ' range=':= 5.000 * nthrMalachiteFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -530,19 +530,19 @@
                             <IfCondition condition=':= ?blockExists("netherrocks:ashstone_ore")'> <OreBlock block='netherrocks:ashstone_ore' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.251 * _default_ * nthrAshtoneFreq ' range=':= 1.251 * _default_ * nthrAshtoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.038 * _default_ * nthrAshtoneSize ' range=':= 1.038 * _default_ * nthrAshtoneSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.885 * _default_ * nthrAshtoneFreq ' range=':= 0.885 * _default_ * nthrAshtoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.980 * _default_ * nthrAshtoneSize ' range=':= 0.980 * _default_ * nthrAshtoneSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.119 * _default_ ' range=':= 1.119 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.941 * _default_ ' range=':= 0.941 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * nthrAshtoneSize ' range=':= _default_ * nthrAshtoneSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.058 * _default_ * nthrAshtoneSize ' range=':= 1.058 * _default_ * nthrAshtoneSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.970 * _default_ * nthrAshtoneSize ' range=':= 0.970 * _default_ * nthrAshtoneSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -572,9 +572,9 @@
                             <IfCondition condition=':= ?blockExists("netherrocks:ashstone_ore")'> <OreBlock block='netherrocks:ashstone_ore' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.046 * _default_ * nthrAshtoneSize ' range=':= 1.046 * _default_ * nthrAshtoneSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.046 * _default_ * nthrAshtoneSize ' range=':= 1.046 * _default_ * nthrAshtoneSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.095 * _default_ * nthrAshtoneFreq ' range=':= 1.095 * _default_ * nthrAshtoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.880 * _default_ * nthrAshtoneSize ' range=':= 0.880 * _default_ * nthrAshtoneSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.880 * _default_ * nthrAshtoneSize ' range=':= 0.880 * _default_ * nthrAshtoneSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.774 * _default_ * nthrAshtoneFreq ' range=':= 0.774 * _default_ * nthrAshtoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -624,8 +624,8 @@
                             <IfCondition condition=':= ?blockExists("netherrocks:ashstone_ore")'> <OreBlock block='netherrocks:ashstone_ore' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 5.000 * nthrAshtoneSize ' range=':= _default_ * nthrAshtoneSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 10.000 * nthrAshtoneFreq ' range=':= _default_ * nthrAshtoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.500 * nthrAshtoneSize ' range=':= 2.500 * nthrAshtoneSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 5.000 * nthrAshtoneFreq ' range=':= 5.000 * nthrAshtoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -649,8 +649,8 @@
                             <IfCondition condition=':= ?blockExists("netherrocks:illumenite_ore")'> <OreBlock block='netherrocks:illumenite_ore' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:glowstone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 15.000 * nthrIllumeniteSize ' range=':= _default_ * nthrIllumeniteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 350.000 * nthrIllumeniteFreq ' range=':= _default_ * nthrIllumeniteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 7.500 * nthrIllumeniteSize ' range=':= 7.500 * nthrIllumeniteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 175.000 * nthrIllumeniteFreq ' range=':= 175.000 * nthrIllumeniteFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -666,7 +666,7 @@
                 <!-- Starting LayeredVeins Preset for Dragonstone. -->
                 <ConfigSection>
                     <IfCondition condition=':= nthrDragonstoneDist = "LayeredVeins"'>
-                        <Veins name='nthrDragonstoneVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x600F0035' drawBoundBox='false' boundBoxColor='0x602F0E0F'>
+                        <Veins name='nthrDragonstoneVeins'  inherits='PresetLayeredVeins' drawWireframe='true' wireframeColor='0x600F0035' drawBoundBox='false' boundBoxColor='0x600F0035'>
                             <Description>
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
@@ -674,19 +674,19 @@
                             <IfCondition condition=':= ?blockExists("netherrocks:dragonstone_ore")'> <OreBlock block='netherrocks:dragonstone_ore' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * nthrDragonstoneFreq ' range=':= 0.969 * _default_ * nthrDragonstoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.995 * _default_ * nthrDragonstoneSize ' range=':= 0.995 * _default_ * nthrDragonstoneSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.685 * _default_ * nthrDragonstoneFreq ' range=':= 0.685 * _default_ * nthrDragonstoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.939 * _default_ * nthrDragonstoneSize ' range=':= 0.939 * _default_ * nthrDragonstoneSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.984 * _default_ ' range=':= 0.984 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.828 * _default_ ' range=':= 0.828 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * nthrDragonstoneSize ' range=':= _default_ * nthrDragonstoneSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.992 * _default_ * nthrDragonstoneSize ' range=':= 0.992 * _default_ * nthrDragonstoneSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.910 * _default_ * nthrDragonstoneSize ' range=':= 0.910 * _default_ * nthrDragonstoneSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -698,7 +698,7 @@
                 <!-- Starting Cloud Preset for Dragonstone. -->
                 <ConfigSection>
                     <IfCondition condition=':= nthrDragonstoneDist = "Cloud"'>
-                        <Cloud name='nthrDragonstoneCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x600F0035' drawBoundBox='false' boundBoxColor='0x602F0E0F'>
+                        <Cloud name='nthrDragonstoneCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x600F0035' drawBoundBox='false' boundBoxColor='0x600F0035'>
                             <Description>
                                 Large irregular clouds filled  lightly
                                 with ore.  These are  huge, spanning
@@ -716,9 +716,9 @@
                             <IfCondition condition=':= ?blockExists("netherrocks:dragonstone_ore")'> <OreBlock block='netherrocks:dragonstone_ore' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.921 * _default_ * nthrDragonstoneSize ' range=':= 0.921 * _default_ * nthrDragonstoneSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.921 * _default_ * nthrDragonstoneSize ' range=':= 0.921 * _default_ * nthrDragonstoneSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.848 * _default_ * nthrDragonstoneFreq ' range=':= 0.848 * _default_ * nthrDragonstoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.774 * _default_ * nthrDragonstoneSize ' range=':= 0.774 * _default_ * nthrDragonstoneSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.774 * _default_ * nthrDragonstoneSize ' range=':= 0.774 * _default_ * nthrDragonstoneSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.600 * _default_ * nthrDragonstoneFreq ' range=':= 0.600 * _default_ * nthrDragonstoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -726,7 +726,7 @@
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Veins name='nthrDragonstoneHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x600F0035' drawBoundBox='false' boundBoxColor='0x602F0E0F'>
+                            <Veins name='nthrDragonstoneHintVeins'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x600F0035' drawBoundBox='false' boundBoxColor='0x600F0035'>
                                 <Description>
                                     Single blocks, generously
                                     scattered through all heights
@@ -760,7 +760,7 @@
                 <!-- Starting Vanilla Preset for Dragonstone. -->
                 <ConfigSection>
                     <IfCondition condition=':= nthrDragonstoneDist = "Vanilla"'>
-                        <StandardGen name='nthrDragonstoneStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x600F0035' drawBoundBox='false' boundBoxColor='0x602F0E0F'>
+                        <StandardGen name='nthrDragonstoneStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x600F0035' drawBoundBox='false' boundBoxColor='0x600F0035'>
                             <Description>
                                 A master preset for standardgen  ore
                                 distributions.
@@ -768,8 +768,8 @@
                             <IfCondition condition=':= ?blockExists("netherrocks:dragonstone_ore")'> <OreBlock block='netherrocks:dragonstone_ore' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 5.000 * nthrDragonstoneSize ' range=':= _default_ * nthrDragonstoneSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 6.000 * nthrDragonstoneFreq ' range=':= _default_ * nthrDragonstoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.500 * nthrDragonstoneSize ' range=':= 2.500 * nthrDragonstoneSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 3.000 * nthrDragonstoneFreq ' range=':= 3.000 * nthrDragonstoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -793,19 +793,19 @@
                             <IfCondition condition=':= ?blockExists("netherrocks:argonite_ore")'> <OreBlock block='netherrocks:argonite_ore' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.371 * _default_ * nthrArgoniteFreq ' range=':= 1.371 * _default_ * nthrArgoniteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.054 * _default_ * nthrArgoniteSize ' range=':= 1.054 * _default_ * nthrArgoniteSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * nthrArgoniteFreq ' range=':= 0.969 * _default_ * nthrArgoniteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.995 * _default_ * nthrArgoniteSize ' range=':= 0.995 * _default_ * nthrArgoniteSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.171 * _default_ ' range=':= 1.171 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.984 * _default_ ' range=':= 0.984 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * nthrArgoniteSize ' range=':= _default_ * nthrArgoniteSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.082 * _default_ * nthrArgoniteSize ' range=':= 1.082 * _default_ * nthrArgoniteSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.992 * _default_ * nthrArgoniteSize ' range=':= 0.992 * _default_ * nthrArgoniteSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -835,9 +835,9 @@
                             <IfCondition condition=':= ?blockExists("netherrocks:argonite_ore")'> <OreBlock block='netherrocks:argonite_ore' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.095 * _default_ * nthrArgoniteSize ' range=':= 1.095 * _default_ * nthrArgoniteSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.095 * _default_ * nthrArgoniteSize ' range=':= 1.095 * _default_ * nthrArgoniteSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.199 * _default_ * nthrArgoniteFreq ' range=':= 1.199 * _default_ * nthrArgoniteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.921 * _default_ * nthrArgoniteSize ' range=':= 0.921 * _default_ * nthrArgoniteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.921 * _default_ * nthrArgoniteSize ' range=':= 0.921 * _default_ * nthrArgoniteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.848 * _default_ * nthrArgoniteFreq ' range=':= 0.848 * _default_ * nthrArgoniteFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -887,8 +887,8 @@
                             <IfCondition condition=':= ?blockExists("netherrocks:argonite_ore")'> <OreBlock block='netherrocks:argonite_ore' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 6.000 * nthrArgoniteSize ' range=':= _default_ * nthrArgoniteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 10.000 * nthrArgoniteFreq ' range=':= _default_ * nthrArgoniteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 3.000 * nthrArgoniteSize ' range=':= 3.000 * nthrArgoniteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 5.000 * nthrArgoniteFreq ' range=':= 5.000 * nthrArgoniteFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>

--- a/src/main/resources/config/modules/PamsHarvestCraft.xml
+++ b/src/main/resources/config/modules/PamsHarvestCraft.xml
@@ -119,19 +119,19 @@
                             <IfCondition condition=':= ?blockExists("harvestcraft:salt")'> <OreBlock block='harvestcraft:salt' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 5.305 * _default_ * hvstSaltFreq ' range=':= 5.305 * _default_ * hvstSaltFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeFrequency' avg=':= 3.751 * _default_ * hvstSaltFreq ' range=':= 3.751 * _default_ * hvstSaltFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * hvstSaltSize ' range=':= 0 * _default_ * hvstSaltSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 2.303 * _default_ ' range=':= 2.303 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.937 * _default_ ' range=':= 1.937 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * hvstSaltSize ' range=':= _default_ * hvstSaltSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.518 * _default_ * hvstSaltSize ' range=':= 1.518 * _default_ * hvstSaltSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.392 * _default_ * hvstSaltSize ' range=':= 1.392 * _default_ * hvstSaltSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -161,9 +161,9 @@
                             <IfCondition condition=':= ?blockExists("harvestcraft:salt")'> <OreBlock block='harvestcraft:salt' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.377 * _default_ * hvstSaltSize ' range=':= 1.377 * _default_ * hvstSaltSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.377 * _default_ * hvstSaltSize ' range=':= 1.377 * _default_ * hvstSaltSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.896 * _default_ * hvstSaltFreq ' range=':= 1.896 * _default_ * hvstSaltFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 1.158 * _default_ * hvstSaltSize ' range=':= 1.158 * _default_ * hvstSaltSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.158 * _default_ * hvstSaltSize ' range=':= 1.158 * _default_ * hvstSaltSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.341 * _default_ * hvstSaltFreq ' range=':= 1.341 * _default_ * hvstSaltFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -213,8 +213,8 @@
                             <IfCondition condition=':= ?blockExists("harvestcraft:salt")'> <OreBlock block='harvestcraft:salt' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 5.000 * hvstSaltSize ' range=':= _default_ * hvstSaltSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 30.000 * hvstSaltFreq ' range=':= _default_ * hvstSaltFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.500 * hvstSaltSize ' range=':= 2.500 * hvstSaltSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 15.000 * hvstSaltFreq ' range=':= 15.000 * hvstSaltFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>

--- a/src/main/resources/config/modules/ProjectRed.xml
+++ b/src/main/resources/config/modules/ProjectRed.xml
@@ -357,19 +357,19 @@
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.270 * _default_ * predRubyFreq ' range=':= 0.270 * _default_ * predRubyFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.191 * _default_ * predRubyFreq ' range=':= 0.191 * _default_ * predRubyFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * predRubySize ' range=':= 0 * _default_ * predRubySize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 16 ' range=':= 4 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.520 * _default_ ' range=':= 0.520 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.437 * _default_ ' range=':= 0.437 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * predRubySize ' range=':= _default_ * predRubySize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.721 * _default_ * predRubySize ' range=':= 0.721 * _default_ * predRubySize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.661 * _default_ * predRubySize ' range=':= 0.661 * _default_ * predRubySize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -380,7 +380,7 @@
                             <ReplacesOre block='stone' weight='1.0' />
                             <Replaces block='ProjRed|Exploration:projectred.exploration.ore' weight='1.0' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * predRubySize  * 0.5 ' range=':= 0 * _default_ * predRubySize  * 0.5 ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.721 * _default_ * predRubySize  * 0.5 ' range=':= 0.721 * _default_ * predRubySize  * 0.5 ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.661 * _default_ * predRubySize  * 0.5 ' range=':= 0.661 * _default_ * predRubySize  * 0.5 ' type='normal' />
                             <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
                         </Veins>
                     </IfCondition>
@@ -409,9 +409,9 @@
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.393 * _default_ * predRubySize ' range=':= 0.393 * _default_ * predRubySize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.393 * _default_ * predRubySize ' range=':= 0.393 * _default_ * predRubySize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.155 * _default_ * predRubyFreq ' range=':= 0.155 * _default_ * predRubyFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.331 * _default_ * predRubySize ' range=':= 0.331 * _default_ * predRubySize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.331 * _default_ * predRubySize ' range=':= 0.331 * _default_ * predRubySize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.109 * _default_ * predRubyFreq ' range=':= 0.109 * _default_ * predRubyFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 16 ' range=':= 4 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -461,8 +461,8 @@
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 1.000 * predRubySize ' range=':= _default_ * predRubySize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.000 * predRubyFreq ' range=':= _default_ * predRubyFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 0.500 * predRubySize ' range=':= 0.500 * predRubySize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 0.500 * predRubyFreq ' range=':= 0.500 * predRubyFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 16 ' range=':= 4 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -486,19 +486,19 @@
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:1")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:1' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.270 * _default_ * predSapphireFreq ' range=':= 0.270 * _default_ * predSapphireFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.191 * _default_ * predSapphireFreq ' range=':= 0.191 * _default_ * predSapphireFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * predSapphireSize ' range=':= 0 * _default_ * predSapphireSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 16 ' range=':= 4 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.520 * _default_ ' range=':= 0.520 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.437 * _default_ ' range=':= 0.437 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * predSapphireSize ' range=':= _default_ * predSapphireSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.721 * _default_ * predSapphireSize ' range=':= 0.721 * _default_ * predSapphireSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.661 * _default_ * predSapphireSize ' range=':= 0.661 * _default_ * predSapphireSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -509,7 +509,7 @@
                             <ReplacesOre block='stone' weight='1.0' />
                             <Replaces block='ProjRed|Exploration:projectred.exploration.ore:1' weight='1.0' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * predSapphireSize  * 0.5 ' range=':= 0 * _default_ * predSapphireSize  * 0.5 ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.721 * _default_ * predSapphireSize  * 0.5 ' range=':= 0.721 * _default_ * predSapphireSize  * 0.5 ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.661 * _default_ * predSapphireSize  * 0.5 ' range=':= 0.661 * _default_ * predSapphireSize  * 0.5 ' type='normal' />
                             <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
                         </Veins>
                     </IfCondition>
@@ -538,9 +538,9 @@
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:1")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:1' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.393 * _default_ * predSapphireSize ' range=':= 0.393 * _default_ * predSapphireSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.393 * _default_ * predSapphireSize ' range=':= 0.393 * _default_ * predSapphireSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.155 * _default_ * predSapphireFreq ' range=':= 0.155 * _default_ * predSapphireFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.331 * _default_ * predSapphireSize ' range=':= 0.331 * _default_ * predSapphireSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.331 * _default_ * predSapphireSize ' range=':= 0.331 * _default_ * predSapphireSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.109 * _default_ * predSapphireFreq ' range=':= 0.109 * _default_ * predSapphireFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 16 ' range=':= 4 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -590,8 +590,8 @@
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:1")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:1' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 1.000 * predSapphireSize ' range=':= _default_ * predSapphireSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.000 * predSapphireFreq ' range=':= _default_ * predSapphireFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 0.500 * predSapphireSize ' range=':= 0.500 * predSapphireSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 0.500 * predSapphireFreq ' range=':= 0.500 * predSapphireFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 16 ' range=':= 4 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -615,19 +615,19 @@
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:2")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:2' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.270 * _default_ * predPeridotFreq ' range=':= 0.270 * _default_ * predPeridotFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.191 * _default_ * predPeridotFreq ' range=':= 0.191 * _default_ * predPeridotFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * predPeridotSize ' range=':= 0 * _default_ * predPeridotSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 22 ' range=':= 6 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.520 * _default_ ' range=':= 0.520 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.437 * _default_ ' range=':= 0.437 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * predPeridotSize ' range=':= _default_ * predPeridotSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.721 * _default_ * predPeridotSize ' range=':= 0.721 * _default_ * predPeridotSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.661 * _default_ * predPeridotSize ' range=':= 0.661 * _default_ * predPeridotSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -638,7 +638,7 @@
                             <ReplacesOre block='stone' weight='1.0' />
                             <Replaces block='ProjRed|Exploration:projectred.exploration.ore:2' weight='1.0' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * predPeridotSize  * 0.5 ' range=':= 0 * _default_ * predPeridotSize  * 0.5 ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.721 * _default_ * predPeridotSize  * 0.5 ' range=':= 0.721 * _default_ * predPeridotSize  * 0.5 ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.661 * _default_ * predPeridotSize  * 0.5 ' range=':= 0.661 * _default_ * predPeridotSize  * 0.5 ' type='normal' />
                             <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
                         </Veins>
                     </IfCondition>
@@ -667,9 +667,9 @@
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:2")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:2' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.393 * _default_ * predPeridotSize ' range=':= 0.393 * _default_ * predPeridotSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.393 * _default_ * predPeridotSize ' range=':= 0.393 * _default_ * predPeridotSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.155 * _default_ * predPeridotFreq ' range=':= 0.155 * _default_ * predPeridotFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.331 * _default_ * predPeridotSize ' range=':= 0.331 * _default_ * predPeridotSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.331 * _default_ * predPeridotSize ' range=':= 0.331 * _default_ * predPeridotSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.109 * _default_ * predPeridotFreq ' range=':= 0.109 * _default_ * predPeridotFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 22 ' range=':= 6 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -719,8 +719,8 @@
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:2")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:2' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 1.000 * predPeridotSize ' range=':= _default_ * predPeridotSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.000 * predPeridotFreq ' range=':= _default_ * predPeridotFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 0.500 * predPeridotSize ' range=':= 0.500 * predPeridotSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 0.500 * predPeridotFreq ' range=':= 0.500 * predPeridotFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 22 ' range=':= 6 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -744,19 +744,19 @@
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:3")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:3' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.416 * _default_ * predCopperFreq ' range=':= 1.416 * _default_ * predCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.060 * _default_ * predCopperSize ' range=':= 1.060 * _default_ * predCopperSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.001 * _default_ * predCopperFreq ' range=':= 1.001 * _default_ * predCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.000 * _default_ * predCopperSize ' range=':= 1.000 * _default_ * predCopperSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 35 ' range=':= 29 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.190 * _default_ ' range=':= 1.190 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.000 * _default_ ' range=':= 1.000 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * predCopperSize ' range=':= _default_ * predCopperSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.091 * _default_ * predCopperSize ' range=':= 1.091 * _default_ * predCopperSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.000 * _default_ * predCopperSize ' range=':= 1.000 * _default_ * predCopperSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -786,9 +786,9 @@
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:3")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:3' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.113 * _default_ * predCopperSize ' range=':= 1.113 * _default_ * predCopperSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.113 * _default_ * predCopperSize ' range=':= 1.113 * _default_ * predCopperSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.239 * _default_ * predCopperFreq ' range=':= 1.239 * _default_ * predCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.936 * _default_ * predCopperSize ' range=':= 0.936 * _default_ * predCopperSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.936 * _default_ * predCopperSize ' range=':= 0.936 * _default_ * predCopperSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.876 * _default_ * predCopperFreq ' range=':= 0.876 * _default_ * predCopperFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 35 ' range=':= 29 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -838,8 +838,8 @@
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:3")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:3' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 8.000 * predCopperSize ' range=':= _default_ * predCopperSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 8.000 * predCopperFreq ' range=':= _default_ * predCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.000 * predCopperSize ' range=':= 4.000 * predCopperSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4.000 * predCopperFreq ' range=':= 4.000 * predCopperFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 35 ' range=':= 29 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -863,19 +863,19 @@
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:4")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:4' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.119 * _default_ * predTinFreq ' range=':= 1.119 * _default_ * predTinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.019 * _default_ * predTinSize ' range=':= 1.019 * _default_ * predTinSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.791 * _default_ * predTinFreq ' range=':= 0.791 * _default_ * predTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.962 * _default_ * predTinSize ' range=':= 0.962 * _default_ * predTinSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 27 ' range=':= 21 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.058 * _default_ ' range=':= 1.058 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.890 * _default_ ' range=':= 0.890 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * predTinSize ' range=':= _default_ * predTinSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.029 * _default_ * predTinSize ' range=':= 1.029 * _default_ * predTinSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.943 * _default_ * predTinSize ' range=':= 0.943 * _default_ * predTinSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -905,9 +905,9 @@
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:4")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:4' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.990 * _default_ * predTinSize ' range=':= 0.990 * _default_ * predTinSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.990 * _default_ * predTinSize ' range=':= 0.990 * _default_ * predTinSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.979 * _default_ * predTinFreq ' range=':= 0.979 * _default_ * predTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.832 * _default_ * predTinSize ' range=':= 0.832 * _default_ * predTinSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.832 * _default_ * predTinSize ' range=':= 0.832 * _default_ * predTinSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.692 * _default_ * predTinFreq ' range=':= 0.692 * _default_ * predTinFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 27 ' range=':= 21 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -957,8 +957,8 @@
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:4")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:4' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 8.000 * predTinSize ' range=':= _default_ * predTinSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 5.000 * predTinFreq ' range=':= _default_ * predTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.000 * predTinSize ' range=':= 4.000 * predTinSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2.500 * predTinFreq ' range=':= 2.500 * predTinFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 27 ' range=':= 21 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -982,19 +982,19 @@
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:5")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:5' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.354 * _default_ * predSilverFreq ' range=':= 0.354 * _default_ * predSilverFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.841 * _default_ * predSilverSize ' range=':= 0.841 * _default_ * predSilverSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.250 * _default_ * predSilverFreq ' range=':= 0.250 * _default_ * predSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.794 * _default_ * predSilverSize ' range=':= 0.794 * _default_ * predSilverSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.595 * _default_ ' range=':= 0.595 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.500 * _default_ ' range=':= 0.500 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * predSilverSize ' range=':= _default_ * predSilverSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.771 * _default_ * predSilverSize ' range=':= 0.771 * _default_ * predSilverSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.707 * _default_ * predSilverSize ' range=':= 0.707 * _default_ * predSilverSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1024,9 +1024,9 @@
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:5")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:5' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.556 * _default_ * predSilverSize ' range=':= 0.556 * _default_ * predSilverSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.556 * _default_ * predSilverSize ' range=':= 0.556 * _default_ * predSilverSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.310 * _default_ * predSilverFreq ' range=':= 0.310 * _default_ * predSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.468 * _default_ * predSilverSize ' range=':= 0.468 * _default_ * predSilverSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.468 * _default_ * predSilverSize ' range=':= 0.468 * _default_ * predSilverSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.219 * _default_ * predSilverFreq ' range=':= 0.219 * _default_ * predSilverFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1076,8 +1076,8 @@
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:5")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:5' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.000 * predSilverSize ' range=':= _default_ * predSilverSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.000 * predSilverFreq ' range=':= _default_ * predSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.000 * predSilverSize ' range=':= 2.000 * predSilverSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 0.500 * predSilverFreq ' range=':= 0.500 * predSilverFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -1101,7 +1101,7 @@
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:6")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:6' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.286 * _default_ * predElectrotineFreq ' range=':= 1.286 * _default_ * predElectrotineFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.909 * _default_ * predElectrotineFreq ' range=':= 0.909 * _default_ * predElectrotineFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * predElectrotineSize ' range=':= 0 * _default_ * predElectrotineSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 11 ' range=':= 5 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1113,7 +1113,7 @@
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * predElectrotineSize ' range=':= _default_ * predElectrotineSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.134 * _default_ * predElectrotineSize ' range=':= 1.134 * _default_ * predElectrotineSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.954 * _default_ * predElectrotineSize ' range=':= 0.954 * _default_ * predElectrotineSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1143,9 +1143,9 @@
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:6")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:6' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.787 * _default_ * predElectrotineSize ' range=':= 0.787 * _default_ * predElectrotineSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.787 * _default_ * predElectrotineSize ' range=':= 0.787 * _default_ * predElectrotineSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.619 * _default_ * predElectrotineFreq ' range=':= 0.619 * _default_ * predElectrotineFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.662 * _default_ * predElectrotineSize ' range=':= 0.662 * _default_ * predElectrotineSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.662 * _default_ * predElectrotineSize ' range=':= 0.662 * _default_ * predElectrotineSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.438 * _default_ * predElectrotineFreq ' range=':= 0.438 * _default_ * predElectrotineFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 11 ' range=':= 5 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1195,8 +1195,8 @@
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:6")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:6' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 8.000 * predElectrotineSize ' range=':= _default_ * predElectrotineSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2.000 * predElectrotineFreq ' range=':= _default_ * predElectrotineFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.000 * predElectrotineSize ' range=':= 4.000 * predElectrotineSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.000 * predElectrotineFreq ' range=':= 1.000 * predElectrotineFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 11 ' range=':= 5 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -1220,19 +1220,19 @@
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.stone")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.stone' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.708 * _default_ * predMarbleFreq ' range=':= 0.708 * _default_ * predMarbleFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.944 * _default_ * predMarbleSize ' range=':= 0.944 * _default_ * predMarbleSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.500 * _default_ * predMarbleFreq ' range=':= 0.500 * _default_ * predMarbleFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.891 * _default_ * predMarbleSize ' range=':= 0.891 * _default_ * predMarbleSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 48 ' range=':= 16 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.841 * _default_ ' range=':= 0.841 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.707 * _default_ ' range=':= 0.707 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * predMarbleSize ' range=':= _default_ * predMarbleSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.917 * _default_ * predMarbleSize ' range=':= 0.917 * _default_ * predMarbleSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.841 * _default_ * predMarbleSize ' range=':= 0.841 * _default_ * predMarbleSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1262,9 +1262,9 @@
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.stone")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.stone' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.787 * _default_ * predMarbleSize ' range=':= 0.787 * _default_ * predMarbleSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.787 * _default_ * predMarbleSize ' range=':= 0.787 * _default_ * predMarbleSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.619 * _default_ * predMarbleFreq ' range=':= 0.619 * _default_ * predMarbleFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.662 * _default_ * predMarbleSize ' range=':= 0.662 * _default_ * predMarbleSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.662 * _default_ * predMarbleSize ' range=':= 0.662 * _default_ * predMarbleSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.438 * _default_ * predMarbleFreq ' range=':= 0.438 * _default_ * predMarbleFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 48 ' range=':= 16 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1314,8 +1314,8 @@
                             <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.stone")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.stone' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 16.000 * predMarbleSize ' range=':= _default_ * predMarbleSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.000 * predMarbleFreq ' range=':= _default_ * predMarbleFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 8.000 * predMarbleSize ' range=':= 8.000 * predMarbleSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 0.500 * predMarbleFreq ' range=':= 0.500 * predMarbleFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 48 ' range=':= 16 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>

--- a/src/main/resources/config/modules/RailCraft.xml
+++ b/src/main/resources/config/modules/RailCraft.xml
@@ -493,19 +493,19 @@
                             <IfCondition condition=':= ?blockExists("Railcraft:ore:7")'> <OreBlock block='Railcraft:ore:7' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 9.801 * _default_ * rlcrPoorIronFreq ' range=':= 9.801 * _default_ * rlcrPoorIronFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeFrequency' avg=':= 6.930 * _default_ * rlcrPoorIronFreq ' range=':= 6.930 * _default_ * rlcrPoorIronFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * rlcrPoorIronSize ' range=':= 0 * _default_ * rlcrPoorIronSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 40 ' range=':= 4 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 3.131 * _default_ ' range=':= 3.131 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 2.633 * _default_ ' range=':= 2.633 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * rlcrPoorIronSize ' range=':= _default_ * rlcrPoorIronSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.769 * _default_ * rlcrPoorIronSize ' range=':= 1.769 * _default_ * rlcrPoorIronSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.623 * _default_ * rlcrPoorIronSize ' range=':= 1.623 * _default_ * rlcrPoorIronSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -535,9 +535,9 @@
                             <IfCondition condition=':= ?blockExists("Railcraft:ore:7")'> <OreBlock block='Railcraft:ore:7' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.872 * _default_ * rlcrPoorIronSize ' range=':= 1.872 * _default_ * rlcrPoorIronSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.872 * _default_ * rlcrPoorIronSize ' range=':= 1.872 * _default_ * rlcrPoorIronSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 3.503 * _default_ * rlcrPoorIronFreq ' range=':= 3.503 * _default_ * rlcrPoorIronFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 1.574 * _default_ * rlcrPoorIronSize ' range=':= 1.574 * _default_ * rlcrPoorIronSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.574 * _default_ * rlcrPoorIronSize ' range=':= 1.574 * _default_ * rlcrPoorIronSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 2.477 * _default_ * rlcrPoorIronFreq ' range=':= 2.477 * _default_ * rlcrPoorIronFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 40 ' range=':= 4 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -587,8 +587,8 @@
                             <IfCondition condition=':= ?blockExists("Railcraft:ore:7")'> <OreBlock block='Railcraft:ore:7' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 16.000 * rlcrPoorIronSize ' range=':= _default_ * rlcrPoorIronSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 32.000 * rlcrPoorIronFreq ' range=':= _default_ * rlcrPoorIronFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 8.000 * rlcrPoorIronSize ' range=':= 8.000 * rlcrPoorIronSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 16.000 * rlcrPoorIronFreq ' range=':= 16.000 * rlcrPoorIronFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 40 ' range=':= 4 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -619,19 +619,19 @@
                             <IfCondition condition=':= ?blockExists("Railcraft:ore:8")'> <OreBlock block='Railcraft:ore:8' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 2.450 * _default_ * rlcrPoorGoldFreq ' range=':= 2.450 * _default_ * rlcrPoorGoldFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.733 * _default_ * rlcrPoorGoldFreq ' range=':= 1.733 * _default_ * rlcrPoorGoldFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * rlcrPoorGoldSize ' range=':= 0 * _default_ * rlcrPoorGoldSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 15 ' range=':= 1 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.565 * _default_ ' range=':= 1.565 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.316 * _default_ ' range=':= 1.316 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * rlcrPoorGoldSize ' range=':= _default_ * rlcrPoorGoldSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.251 * _default_ * rlcrPoorGoldSize ' range=':= 1.251 * _default_ * rlcrPoorGoldSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.147 * _default_ * rlcrPoorGoldSize ' range=':= 1.147 * _default_ * rlcrPoorGoldSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -661,9 +661,9 @@
                             <IfCondition condition=':= ?blockExists("Railcraft:ore:8")'> <OreBlock block='Railcraft:ore:8' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.936 * _default_ * rlcrPoorGoldSize ' range=':= 0.936 * _default_ * rlcrPoorGoldSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.936 * _default_ * rlcrPoorGoldSize ' range=':= 0.936 * _default_ * rlcrPoorGoldSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.876 * _default_ * rlcrPoorGoldFreq ' range=':= 0.876 * _default_ * rlcrPoorGoldFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.787 * _default_ * rlcrPoorGoldSize ' range=':= 0.787 * _default_ * rlcrPoorGoldSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.787 * _default_ * rlcrPoorGoldSize ' range=':= 0.787 * _default_ * rlcrPoorGoldSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.619 * _default_ * rlcrPoorGoldFreq ' range=':= 0.619 * _default_ * rlcrPoorGoldFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 15 ' range=':= 1 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -713,8 +713,8 @@
                             <IfCondition condition=':= ?blockExists("Railcraft:ore:8")'> <OreBlock block='Railcraft:ore:8' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 1.000 * rlcrPoorGoldSize ' range=':= _default_ * rlcrPoorGoldSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 32.000 * rlcrPoorGoldFreq ' range=':= _default_ * rlcrPoorGoldFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 0.500 * rlcrPoorGoldSize ' range=':= 0.500 * rlcrPoorGoldSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 16.000 * rlcrPoorGoldFreq ' range=':= 16.000 * rlcrPoorGoldFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 15 ' range=':= 1 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -745,19 +745,19 @@
                             <IfCondition condition=':= ?blockExists("Railcraft:ore:9")'> <OreBlock block='Railcraft:ore:9' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 6.930 * _default_ * rlcrPoorCopperFreq ' range=':= 6.930 * _default_ * rlcrPoorCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeFrequency' avg=':= 4.900 * _default_ * rlcrPoorCopperFreq ' range=':= 4.900 * _default_ * rlcrPoorCopperFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * rlcrPoorCopperSize ' range=':= 0 * _default_ * rlcrPoorCopperSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 60 ' range=':= 3 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 2.633 * _default_ ' range=':= 2.633 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 2.214 * _default_ ' range=':= 2.214 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * rlcrPoorCopperSize ' range=':= _default_ * rlcrPoorCopperSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.623 * _default_ * rlcrPoorCopperSize ' range=':= 1.623 * _default_ * rlcrPoorCopperSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.488 * _default_ * rlcrPoorCopperSize ' range=':= 1.488 * _default_ * rlcrPoorCopperSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -787,9 +787,9 @@
                             <IfCondition condition=':= ?blockExists("Railcraft:ore:9")'> <OreBlock block='Railcraft:ore:9' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.574 * _default_ * rlcrPoorCopperSize ' range=':= 1.574 * _default_ * rlcrPoorCopperSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.574 * _default_ * rlcrPoorCopperSize ' range=':= 1.574 * _default_ * rlcrPoorCopperSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 2.477 * _default_ * rlcrPoorCopperFreq ' range=':= 2.477 * _default_ * rlcrPoorCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 1.323 * _default_ * rlcrPoorCopperSize ' range=':= 1.323 * _default_ * rlcrPoorCopperSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.323 * _default_ * rlcrPoorCopperSize ' range=':= 1.323 * _default_ * rlcrPoorCopperSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.752 * _default_ * rlcrPoorCopperFreq ' range=':= 1.752 * _default_ * rlcrPoorCopperFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 60 ' range=':= 3 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -839,8 +839,8 @@
                             <IfCondition condition=':= ?blockExists("Railcraft:ore:9")'> <OreBlock block='Railcraft:ore:9' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 8.000 * rlcrPoorCopperSize ' range=':= _default_ * rlcrPoorCopperSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 32.000 * rlcrPoorCopperFreq ' range=':= _default_ * rlcrPoorCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.000 * rlcrPoorCopperSize ' range=':= 4.000 * rlcrPoorCopperSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 16.000 * rlcrPoorCopperFreq ' range=':= 16.000 * rlcrPoorCopperFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 60 ' range=':= 3 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -871,19 +871,19 @@
                             <IfCondition condition=':= ?blockExists("Railcraft:ore:10")'> <OreBlock block='Railcraft:ore:10' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 3.465 * _default_ * rlcrPoorTinFreq ' range=':= 3.465 * _default_ * rlcrPoorTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeFrequency' avg=':= 2.450 * _default_ * rlcrPoorTinFreq ' range=':= 2.450 * _default_ * rlcrPoorTinFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * rlcrPoorTinSize ' range=':= 0 * _default_ * rlcrPoorTinSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 50 ' range=':= 2 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.861 * _default_ ' range=':= 1.861 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.565 * _default_ ' range=':= 1.565 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * rlcrPoorTinSize ' range=':= _default_ * rlcrPoorTinSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.364 * _default_ * rlcrPoorTinSize ' range=':= 1.364 * _default_ * rlcrPoorTinSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.251 * _default_ * rlcrPoorTinSize ' range=':= 1.251 * _default_ * rlcrPoorTinSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -913,9 +913,9 @@
                             <IfCondition condition=':= ?blockExists("Railcraft:ore:10")'> <OreBlock block='Railcraft:ore:10' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.113 * _default_ * rlcrPoorTinSize ' range=':= 1.113 * _default_ * rlcrPoorTinSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.113 * _default_ * rlcrPoorTinSize ' range=':= 1.113 * _default_ * rlcrPoorTinSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.239 * _default_ * rlcrPoorTinFreq ' range=':= 1.239 * _default_ * rlcrPoorTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.936 * _default_ * rlcrPoorTinSize ' range=':= 0.936 * _default_ * rlcrPoorTinSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.936 * _default_ * rlcrPoorTinSize ' range=':= 0.936 * _default_ * rlcrPoorTinSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.876 * _default_ * rlcrPoorTinFreq ' range=':= 0.876 * _default_ * rlcrPoorTinFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 50 ' range=':= 2 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -965,8 +965,8 @@
                             <IfCondition condition=':= ?blockExists("Railcraft:ore:10")'> <OreBlock block='Railcraft:ore:10' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 2.000 * rlcrPoorTinSize ' range=':= _default_ * rlcrPoorTinSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 32.000 * rlcrPoorTinFreq ' range=':= _default_ * rlcrPoorTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 1.000 * rlcrPoorTinSize ' range=':= 1.000 * rlcrPoorTinSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 16.000 * rlcrPoorTinFreq ' range=':= 16.000 * rlcrPoorTinFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 50 ' range=':= 2 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -997,19 +997,19 @@
                             <IfCondition condition=':= ?blockExists("Railcraft:ore:11")'> <OreBlock block='Railcraft:ore:11' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 6.002 * _default_ * rlcrPoorLeadFreq ' range=':= 6.002 * _default_ * rlcrPoorLeadFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeFrequency' avg=':= 4.244 * _default_ * rlcrPoorLeadFreq ' range=':= 4.244 * _default_ * rlcrPoorLeadFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * rlcrPoorLeadSize ' range=':= 0 * _default_ * rlcrPoorLeadSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 30 ' range=':= 3 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 2.450 * _default_ ' range=':= 2.450 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 2.060 * _default_ ' range=':= 2.060 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * rlcrPoorLeadSize ' range=':= _default_ * rlcrPoorLeadSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.565 * _default_ * rlcrPoorLeadSize ' range=':= 1.565 * _default_ * rlcrPoorLeadSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.435 * _default_ * rlcrPoorLeadSize ' range=':= 1.435 * _default_ * rlcrPoorLeadSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1039,9 +1039,9 @@
                             <IfCondition condition=':= ?blockExists("Railcraft:ore:11")'> <OreBlock block='Railcraft:ore:11' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.465 * _default_ * rlcrPoorLeadSize ' range=':= 1.465 * _default_ * rlcrPoorLeadSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.465 * _default_ * rlcrPoorLeadSize ' range=':= 1.465 * _default_ * rlcrPoorLeadSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 2.145 * _default_ * rlcrPoorLeadFreq ' range=':= 2.145 * _default_ * rlcrPoorLeadFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 1.232 * _default_ * rlcrPoorLeadSize ' range=':= 1.232 * _default_ * rlcrPoorLeadSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.232 * _default_ * rlcrPoorLeadSize ' range=':= 1.232 * _default_ * rlcrPoorLeadSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.517 * _default_ * rlcrPoorLeadFreq ' range=':= 1.517 * _default_ * rlcrPoorLeadFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 30 ' range=':= 3 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1091,8 +1091,8 @@
                             <IfCondition condition=':= ?blockExists("Railcraft:ore:11")'> <OreBlock block='Railcraft:ore:11' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 6.000 * rlcrPoorLeadSize ' range=':= _default_ * rlcrPoorLeadSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 32.000 * rlcrPoorLeadFreq ' range=':= _default_ * rlcrPoorLeadFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 3.000 * rlcrPoorLeadSize ' range=':= 3.000 * rlcrPoorLeadSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 16.000 * rlcrPoorLeadFreq ' range=':= 16.000 * rlcrPoorLeadFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 30 ' range=':= 3 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -1124,19 +1124,19 @@
                             <ReplacesOre block='sand' weight='1.0' />
                             <Replaces block='minecraft:sandstone' weight='1.0' />
                             <BiomeType name='Desert'  minRainfall='0' maxRainfall='0.1' minTemperature='1.5' maxTemperature='2.0' />
-                            <Setting name='MotherlodeFrequency' avg=':= 3.465 * _default_ * rlcrSaltpeterFreq ' range=':= 3.465 * _default_ * rlcrSaltpeterFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeFrequency' avg=':= 2.450 * _default_ * rlcrSaltpeterFreq ' range=':= 2.450 * _default_ * rlcrSaltpeterFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * rlcrSaltpeterSize ' range=':= 0 * _default_ * rlcrSaltpeterSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 64 ' range=':= 5 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.861 * _default_ ' range=':= 1.861 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.565 * _default_ ' range=':= 1.565 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * rlcrSaltpeterSize ' range=':= _default_ * rlcrSaltpeterSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.364 * _default_ * rlcrSaltpeterSize ' range=':= 1.364 * _default_ * rlcrSaltpeterSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.251 * _default_ * rlcrSaltpeterSize ' range=':= 1.251 * _default_ * rlcrSaltpeterSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1167,9 +1167,9 @@
                             <ReplacesOre block='sand' weight='1.0' />
                             <Replaces block='minecraft:sandstone' weight='1.0' />
                             <BiomeType name='Desert'  minRainfall='0' maxRainfall='0.1' minTemperature='1.5' maxTemperature='2.0' />
-                            <Setting name='CloudRadius' avg=':= 1.113 * _default_ * rlcrSaltpeterSize ' range=':= 1.113 * _default_ * rlcrSaltpeterSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.113 * _default_ * rlcrSaltpeterSize ' range=':= 1.113 * _default_ * rlcrSaltpeterSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.239 * _default_ * rlcrSaltpeterFreq ' range=':= 1.239 * _default_ * rlcrSaltpeterFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.936 * _default_ * rlcrSaltpeterSize ' range=':= 0.936 * _default_ * rlcrSaltpeterSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.936 * _default_ * rlcrSaltpeterSize ' range=':= 0.936 * _default_ * rlcrSaltpeterSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.876 * _default_ * rlcrSaltpeterFreq ' range=':= 0.876 * _default_ * rlcrSaltpeterFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 64 ' range=':= 5 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1220,8 +1220,8 @@
                             <ReplacesOre block='sand' weight='1.0' />
                             <Replaces block='minecraft:sandstone' weight='1.0' />
                             <BiomeType name='Desert'  minRainfall='0' maxRainfall='0.1' minTemperature='1.5' maxTemperature='2.0' />
-                            <Setting name='Size' avg=':= 1.000 * rlcrSaltpeterSize ' range=':= _default_ * rlcrSaltpeterSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 64.000 * rlcrSaltpeterFreq ' range=':= _default_ * rlcrSaltpeterFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 0.500 * rlcrSaltpeterSize ' range=':= 0.500 * rlcrSaltpeterSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 32.000 * rlcrSaltpeterFreq ' range=':= 32.000 * rlcrSaltpeterFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 64 ' range=':= 5 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -1245,19 +1245,19 @@
                             <IfCondition condition=':= ?blockExists("Railcraft:ore")'> <OreBlock block='Railcraft:ore' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.707 * _default_ * rlcrSulfurFreq ' range=':= 1.707 * _default_ * rlcrSulfurFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.207 * _default_ * rlcrSulfurFreq ' range=':= 1.207 * _default_ * rlcrSulfurFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * rlcrSulfurSize ' range=':= 0 * _default_ * rlcrSulfurSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 11 ' range=':= 5 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.307 * _default_ ' range=':= 1.307 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.099 * _default_ ' range=':= 1.099 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * rlcrSulfurSize ' range=':= _default_ * rlcrSulfurSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.143 * _default_ * rlcrSulfurSize ' range=':= 1.143 * _default_ * rlcrSulfurSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.048 * _default_ * rlcrSulfurSize ' range=':= 1.048 * _default_ * rlcrSulfurSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1268,7 +1268,7 @@
                             <ReplacesOre block='stone' weight='1.0' />
                             <Replaces block='Railcraft:ore' weight='1.0' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * rlcrSulfurSize  * 0.5 ' range=':= 0 * _default_ * rlcrSulfurSize  * 0.5 ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.143 * _default_ * rlcrSulfurSize  * 0.5 ' range=':= 1.143 * _default_ * rlcrSulfurSize  * 0.5 ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.048 * _default_ * rlcrSulfurSize  * 0.5 ' range=':= 1.048 * _default_ * rlcrSulfurSize  * 0.5 ' type='normal' />
                             <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
                         </Veins>
                     </IfCondition>
@@ -1297,9 +1297,9 @@
                             <IfCondition condition=':= ?blockExists("Railcraft:ore")'> <OreBlock block='Railcraft:ore' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.990 * _default_ * rlcrSulfurSize ' range=':= 0.990 * _default_ * rlcrSulfurSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.990 * _default_ * rlcrSulfurSize ' range=':= 0.990 * _default_ * rlcrSulfurSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.979 * _default_ * rlcrSulfurFreq ' range=':= 0.979 * _default_ * rlcrSulfurFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.832 * _default_ * rlcrSulfurSize ' range=':= 0.832 * _default_ * rlcrSulfurSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.832 * _default_ * rlcrSulfurSize ' range=':= 0.832 * _default_ * rlcrSulfurSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.692 * _default_ * rlcrSulfurFreq ' range=':= 0.692 * _default_ * rlcrSulfurFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 11 ' range=':= 5 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1349,8 +1349,8 @@
                             <IfCondition condition=':= ?blockExists("Railcraft:ore")'> <OreBlock block='Railcraft:ore' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 10.000 * rlcrSulfurSize ' range=':= _default_ * rlcrSulfurSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 4.000 * rlcrSulfurFreq ' range=':= _default_ * rlcrSulfurFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 5.000 * rlcrSulfurSize ' range=':= 5.000 * rlcrSulfurSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2.000 * rlcrSulfurFreq ' range=':= 2.000 * rlcrSulfurFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 11 ' range=':= 5 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -1375,8 +1375,8 @@
 
                 <!-- Starting Original "Nether" Block Removal -->
 
-                <IfCondition condition=':= ?blockExists("minecraft:stone")'>
-                    <Substitute name='rlcrNetherBlockSubstitute0' block='minecraft:stone'>
+                <IfCondition condition=':= ?blockExists("minecraft:netherrack")'>
+                    <Substitute name='rlcrNetherBlockSubstitute0' block='minecraft:netherrack'>
                         <Description>
                             Replace vanilla-generated ore clusters.
                         </Description>
@@ -1406,10 +1406,10 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Railcraft:ore:5")'> <OreBlock block='Railcraft:ore:5' weight='1.0' /> </IfCondition>
-                            <ReplacesOre block='stone' weight='1.0' />
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.221 * _default_ * rlcrFirestoneFreq ' range=':= 0.221 * _default_ * rlcrFirestoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.778 * _default_ * rlcrFirestoneSize ' range=':= 0.778 * _default_ * rlcrFirestoneSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.157 * _default_ * rlcrFirestoneFreq ' range=':= 0.157 * _default_ * rlcrFirestoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.734 * _default_ * rlcrFirestoneSize ' range=':= 0.734 * _default_ * rlcrFirestoneSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 16 ' range=':= 15 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1448,11 +1448,11 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Railcraft:ore:5")'> <OreBlock block='Railcraft:ore:5' weight='1.0' /> </IfCondition>
-                            <ReplacesOre block='stone' weight='1.0' />
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.393 * _default_ * rlcrFirestoneSize ' range=':= 0.393 * _default_ * rlcrFirestoneSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.393 * _default_ * rlcrFirestoneSize ' range=':= 0.393 * _default_ * rlcrFirestoneSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.155 * _default_ * rlcrFirestoneFreq ' range=':= 0.155 * _default_ * rlcrFirestoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.331 * _default_ * rlcrFirestoneSize ' range=':= 0.331 * _default_ * rlcrFirestoneSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.331 * _default_ * rlcrFirestoneSize ' range=':= 0.331 * _default_ * rlcrFirestoneSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.109 * _default_ * rlcrFirestoneFreq ' range=':= 0.109 * _default_ * rlcrFirestoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 16 ' range=':= 15 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1500,10 +1500,10 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("Railcraft:ore:5")'> <OreBlock block='Railcraft:ore:5' weight='1.0' /> </IfCondition>
-                            <ReplacesOre block='stone' weight='1.0' />
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 1.000 * rlcrFirestoneSize ' range=':= _default_ * rlcrFirestoneSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.000 * rlcrFirestoneFreq ' range=':= _default_ * rlcrFirestoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 0.500 * rlcrFirestoneSize ' range=':= 0.500 * rlcrFirestoneSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 0.500 * rlcrFirestoneFreq ' range=':= 0.500 * rlcrFirestoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 16 ' range=':= 15 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>

--- a/src/main/resources/config/modules/ReactorCraft.xml
+++ b/src/main/resources/config/modules/ReactorCraft.xml
@@ -681,19 +681,19 @@
                             <BiomeType name='Mushroom'  />
                             <BiomeType name='Ocean'  />
                             <BiomeType name='River'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 3.001 * _default_ * recrPitchblendeFreq ' range=':= 3.001 * _default_ * recrPitchblendeFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeFrequency' avg=':= 2.122 * _default_ * recrPitchblendeFreq ' range=':= 2.122 * _default_ * recrPitchblendeFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * recrPitchblendeSize ' range=':= 0 * _default_ * recrPitchblendeSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 16 ' range=':= 8 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.732 * _default_ ' range=':= 1.732 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.457 * _default_ ' range=':= 1.457 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * recrPitchblendeSize ' range=':= _default_ * recrPitchblendeSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.316 * _default_ * recrPitchblendeSize ' range=':= 1.316 * _default_ * recrPitchblendeSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.207 * _default_ * recrPitchblendeSize ' range=':= 1.207 * _default_ * recrPitchblendeSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -715,8 +715,8 @@
                             <BiomeType name='Mushroom'  />
                             <BiomeType name='Ocean'  />
                             <BiomeType name='River'  />
-                            <Setting name='Size' avg=':= 16.000 * recrPitchblendeSize ' range=':= _default_ * recrPitchblendeSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 3.000 * recrPitchblendeFreq ' range=':= _default_ * recrPitchblendeFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 8.000 * recrPitchblendeSize ' range=':= 8.000 * recrPitchblendeSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.500 * recrPitchblendeFreq ' range=':= 1.500 * recrPitchblendeFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 16 ' range=':= 8 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -748,9 +748,9 @@
                             <BiomeType name='Mushroom'  />
                             <BiomeType name='Ocean'  />
                             <BiomeType name='River'  />
-                            <Setting name='CloudRadius' avg=':= 1.036 * _default_ * recrPitchblendeSize ' range=':= 1.036 * _default_ * recrPitchblendeSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.036 * _default_ * recrPitchblendeSize ' range=':= 1.036 * _default_ * recrPitchblendeSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.073 * _default_ * recrPitchblendeFreq ' range=':= 1.073 * _default_ * recrPitchblendeFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.871 * _default_ * recrPitchblendeSize ' range=':= 0.871 * _default_ * recrPitchblendeSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.871 * _default_ * recrPitchblendeSize ' range=':= 0.871 * _default_ * recrPitchblendeSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.758 * _default_ * recrPitchblendeFreq ' range=':= 0.758 * _default_ * recrPitchblendeFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 16 ' range=':= 8 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -804,19 +804,19 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:2")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:2' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.919 * _default_ * recrCadmiumFreq ' range=':= 0.919 * _default_ * recrCadmiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.986 * _default_ * recrCadmiumSize ' range=':= 0.986 * _default_ * recrCadmiumSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.650 * _default_ * recrCadmiumFreq ' range=':= 0.650 * _default_ * recrCadmiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.931 * _default_ * recrCadmiumSize ' range=':= 0.931 * _default_ * recrCadmiumSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 22 ' range=':= 10 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.959 * _default_ ' range=':= 0.959 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.806 * _default_ ' range=':= 0.806 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * recrCadmiumSize ' range=':= _default_ * recrCadmiumSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.979 * _default_ * recrCadmiumSize ' range=':= 0.979 * _default_ * recrCadmiumSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.898 * _default_ * recrCadmiumSize ' range=':= 0.898 * _default_ * recrCadmiumSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -836,8 +836,8 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:2")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:2' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 9.000 * recrCadmiumSize ' range=':= _default_ * recrCadmiumSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 3.000 * recrCadmiumFreq ' range=':= _default_ * recrCadmiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.500 * recrCadmiumSize ' range=':= 4.500 * recrCadmiumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.500 * recrCadmiumFreq ' range=':= 1.500 * recrCadmiumFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 22 ' range=':= 10 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -867,9 +867,9 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:2")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:2' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.897 * _default_ * recrCadmiumSize ' range=':= 0.897 * _default_ * recrCadmiumSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.897 * _default_ * recrCadmiumSize ' range=':= 0.897 * _default_ * recrCadmiumSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.804 * _default_ * recrCadmiumFreq ' range=':= 0.804 * _default_ * recrCadmiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.754 * _default_ * recrCadmiumSize ' range=':= 0.754 * _default_ * recrCadmiumSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.754 * _default_ * recrCadmiumSize ' range=':= 0.754 * _default_ * recrCadmiumSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.569 * _default_ * recrCadmiumFreq ' range=':= 0.569 * _default_ * recrCadmiumFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 22 ' range=':= 10 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -923,19 +923,19 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:3")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:3' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.662 * _default_ * recrIndiumFreq ' range=':= 0.662 * _default_ * recrIndiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.934 * _default_ * recrIndiumSize ' range=':= 0.934 * _default_ * recrIndiumSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.468 * _default_ * recrIndiumFreq ' range=':= 0.468 * _default_ * recrIndiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.881 * _default_ * recrIndiumSize ' range=':= 0.881 * _default_ * recrIndiumSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 11 ' range=':= 5 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.814 * _default_ ' range=':= 0.814 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.684 * _default_ ' range=':= 0.684 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * recrIndiumSize ' range=':= _default_ * recrIndiumSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.902 * _default_ * recrIndiumSize ' range=':= 0.902 * _default_ * recrIndiumSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.827 * _default_ * recrIndiumSize ' range=':= 0.827 * _default_ * recrIndiumSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -955,8 +955,8 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:3")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:3' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 7.000 * recrIndiumSize ' range=':= _default_ * recrIndiumSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2.000 * recrIndiumFreq ' range=':= _default_ * recrIndiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 3.500 * recrIndiumSize ' range=':= 3.500 * recrIndiumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.000 * recrIndiumFreq ' range=':= 1.000 * recrIndiumFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 11 ' range=':= 5 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -986,9 +986,9 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:3")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:3' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.761 * _default_ * recrIndiumSize ' range=':= 0.761 * _default_ * recrIndiumSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.761 * _default_ * recrIndiumSize ' range=':= 0.761 * _default_ * recrIndiumSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.579 * _default_ * recrIndiumFreq ' range=':= 0.579 * _default_ * recrIndiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.640 * _default_ * recrIndiumSize ' range=':= 0.640 * _default_ * recrIndiumSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.640 * _default_ * recrIndiumSize ' range=':= 0.640 * _default_ * recrIndiumSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.410 * _default_ * recrIndiumFreq ' range=':= 0.410 * _default_ * recrIndiumFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 11 ' range=':= 5 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1042,19 +1042,19 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:4")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:4' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.751 * _default_ * recrSilverFreq ' range=':= 0.751 * _default_ * recrSilverFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.953 * _default_ * recrSilverSize ' range=':= 0.953 * _default_ * recrSilverSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.531 * _default_ * recrSilverFreq ' range=':= 0.531 * _default_ * recrSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.900 * _default_ * recrSilverSize ' range=':= 0.900 * _default_ * recrSilverSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 28 ' range=':= 12 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.866 * _default_ ' range=':= 0.866 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.729 * _default_ ' range=':= 0.729 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * recrSilverSize ' range=':= _default_ * recrSilverSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.931 * _default_ * recrSilverSize ' range=':= 0.931 * _default_ * recrSilverSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.854 * _default_ * recrSilverSize ' range=':= 0.854 * _default_ * recrSilverSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1074,8 +1074,8 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:4")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:4' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 9.000 * recrSilverSize ' range=':= _default_ * recrSilverSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2.000 * recrSilverFreq ' range=':= _default_ * recrSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.500 * recrSilverSize ' range=':= 4.500 * recrSilverSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.000 * recrSilverFreq ' range=':= 1.000 * recrSilverFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 28 ' range=':= 12 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -1105,9 +1105,9 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:4")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:4' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.810 * _default_ * recrSilverSize ' range=':= 0.810 * _default_ * recrSilverSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.810 * _default_ * recrSilverSize ' range=':= 0.810 * _default_ * recrSilverSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.657 * _default_ * recrSilverFreq ' range=':= 0.657 * _default_ * recrSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.682 * _default_ * recrSilverSize ' range=':= 0.682 * _default_ * recrSilverSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.682 * _default_ * recrSilverSize ' range=':= 0.682 * _default_ * recrSilverSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.464 * _default_ * recrSilverFreq ' range=':= 0.464 * _default_ * recrSilverFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 28 ' range=':= 12 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1168,19 +1168,19 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:7")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:7' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 3.001 * _default_ * recrCalciteFreq ' range=':= 3.001 * _default_ * recrCalciteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeFrequency' avg=':= 2.122 * _default_ * recrCalciteFreq ' range=':= 2.122 * _default_ * recrCalciteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * recrCalciteSize ' range=':= 0 * _default_ * recrCalciteSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.732 * _default_ ' range=':= 1.732 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.457 * _default_ ' range=':= 1.457 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * recrCalciteSize ' range=':= _default_ * recrCalciteSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.316 * _default_ * recrCalciteSize ' range=':= 1.316 * _default_ * recrCalciteSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.207 * _default_ * recrCalciteSize ' range=':= 1.207 * _default_ * recrCalciteSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1200,8 +1200,8 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:7")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:7' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.000 * recrCalciteSize ' range=':= _default_ * recrCalciteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 12.000 * recrCalciteFreq ' range=':= _default_ * recrCalciteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.000 * recrCalciteSize ' range=':= 2.000 * recrCalciteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 6.000 * recrCalciteFreq ' range=':= 6.000 * recrCalciteFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -1231,9 +1231,9 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:7")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:7' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.036 * _default_ * recrCalciteSize ' range=':= 1.036 * _default_ * recrCalciteSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.036 * _default_ * recrCalciteSize ' range=':= 1.036 * _default_ * recrCalciteSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.073 * _default_ * recrCalciteFreq ' range=':= 1.073 * _default_ * recrCalciteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.871 * _default_ * recrCalciteSize ' range=':= 0.871 * _default_ * recrCalciteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.871 * _default_ * recrCalciteSize ' range=':= 0.871 * _default_ * recrCalciteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.758 * _default_ * recrCalciteFreq ' range=':= 0.758 * _default_ * recrCalciteFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1294,19 +1294,19 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:8")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:8' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 4.584 * _default_ * recrMagnetiteFreq ' range=':= 4.584 * _default_ * recrMagnetiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeFrequency' avg=':= 3.241 * _default_ * recrMagnetiteFreq ' range=':= 3.241 * _default_ * recrMagnetiteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * recrMagnetiteSize ' range=':= 0 * _default_ * recrMagnetiteSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 94 ' range=':= 34 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 2.141 * _default_ ' range=':= 2.141 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.800 * _default_ ' range=':= 1.800 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * recrMagnetiteSize ' range=':= _default_ * recrMagnetiteSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.463 * _default_ * recrMagnetiteSize ' range=':= 1.463 * _default_ * recrMagnetiteSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.342 * _default_ * recrMagnetiteSize ' range=':= 1.342 * _default_ * recrMagnetiteSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1326,8 +1326,8 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:8")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:8' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 16.000 * recrMagnetiteSize ' range=':= _default_ * recrMagnetiteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 7.000 * recrMagnetiteFreq ' range=':= _default_ * recrMagnetiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 8.000 * recrMagnetiteSize ' range=':= 8.000 * recrMagnetiteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 3.500 * recrMagnetiteFreq ' range=':= 3.500 * recrMagnetiteFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 94 ' range=':= 34 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -1357,9 +1357,9 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:8")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:8' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.280 * _default_ * recrMagnetiteSize ' range=':= 1.280 * _default_ * recrMagnetiteSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.280 * _default_ * recrMagnetiteSize ' range=':= 1.280 * _default_ * recrMagnetiteSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.638 * _default_ * recrMagnetiteFreq ' range=':= 1.638 * _default_ * recrMagnetiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 1.076 * _default_ * recrMagnetiteSize ' range=':= 1.076 * _default_ * recrMagnetiteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.076 * _default_ * recrMagnetiteSize ' range=':= 1.076 * _default_ * recrMagnetiteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.159 * _default_ * recrMagnetiteFreq ' range=':= 1.159 * _default_ * recrMagnetiteFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 94 ' range=':= 34 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1413,19 +1413,19 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.613 * _default_ * recrBlueFluoriteFreq ' range=':= 0.613 * _default_ * recrBlueFluoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * recrBlueFluoriteSize ' range=':= 0.922 * _default_ * recrBlueFluoriteSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.226 * _default_ * recrBlueFluoriteFreq ' range=':= 1.226 * _default_ * recrBlueFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.035 * _default_ * recrBlueFluoriteSize ' range=':= 1.035 * _default_ * recrBlueFluoriteSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.783 * _default_ ' range=':= 0.783 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.107 * _default_ ' range=':= 1.107 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * recrBlueFluoriteSize ' range=':= _default_ * recrBlueFluoriteSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.885 * _default_ * recrBlueFluoriteSize ' range=':= 0.885 * _default_ * recrBlueFluoriteSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.052 * _default_ * recrBlueFluoriteSize ' range=':= 1.052 * _default_ * recrBlueFluoriteSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1446,8 +1446,8 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 1.000 * recrBlueFluoriteSize ' range=':= _default_ * recrBlueFluoriteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.500 * recrBlueFluoriteFreq ' range=':= _default_ * recrBlueFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.000 * recrBlueFluoriteSize ' range=':= 4.000 * recrBlueFluoriteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 6.000 * recrBlueFluoriteFreq ' range=':= 6.000 * recrBlueFluoriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -1477,9 +1477,9 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.732 * _default_ * recrBlueFluoriteSize ' range=':= 0.732 * _default_ * recrBlueFluoriteSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.732 * _default_ * recrBlueFluoriteSize ' range=':= 0.732 * _default_ * recrBlueFluoriteSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.536 * _default_ * recrBlueFluoriteFreq ' range=':= 0.536 * _default_ * recrBlueFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 1.036 * _default_ * recrBlueFluoriteSize ' range=':= 1.036 * _default_ * recrBlueFluoriteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.036 * _default_ * recrBlueFluoriteSize ' range=':= 1.036 * _default_ * recrBlueFluoriteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.073 * _default_ * recrBlueFluoriteFreq ' range=':= 1.073 * _default_ * recrBlueFluoriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1533,19 +1533,19 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:1")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:1' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.613 * _default_ * recrPinkFluoriteFreq ' range=':= 0.613 * _default_ * recrPinkFluoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * recrPinkFluoriteSize ' range=':= 0.922 * _default_ * recrPinkFluoriteSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.226 * _default_ * recrPinkFluoriteFreq ' range=':= 1.226 * _default_ * recrPinkFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.035 * _default_ * recrPinkFluoriteSize ' range=':= 1.035 * _default_ * recrPinkFluoriteSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.783 * _default_ ' range=':= 0.783 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.107 * _default_ ' range=':= 1.107 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * recrPinkFluoriteSize ' range=':= _default_ * recrPinkFluoriteSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.885 * _default_ * recrPinkFluoriteSize ' range=':= 0.885 * _default_ * recrPinkFluoriteSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.052 * _default_ * recrPinkFluoriteSize ' range=':= 1.052 * _default_ * recrPinkFluoriteSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1566,8 +1566,8 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:1")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:1' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 1.000 * recrPinkFluoriteSize ' range=':= _default_ * recrPinkFluoriteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.500 * recrPinkFluoriteFreq ' range=':= _default_ * recrPinkFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.000 * recrPinkFluoriteSize ' range=':= 4.000 * recrPinkFluoriteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 6.000 * recrPinkFluoriteFreq ' range=':= 6.000 * recrPinkFluoriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -1597,9 +1597,9 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:1")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:1' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.732 * _default_ * recrPinkFluoriteSize ' range=':= 0.732 * _default_ * recrPinkFluoriteSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.732 * _default_ * recrPinkFluoriteSize ' range=':= 0.732 * _default_ * recrPinkFluoriteSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.536 * _default_ * recrPinkFluoriteFreq ' range=':= 0.536 * _default_ * recrPinkFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 1.036 * _default_ * recrPinkFluoriteSize ' range=':= 1.036 * _default_ * recrPinkFluoriteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.036 * _default_ * recrPinkFluoriteSize ' range=':= 1.036 * _default_ * recrPinkFluoriteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.073 * _default_ * recrPinkFluoriteFreq ' range=':= 1.073 * _default_ * recrPinkFluoriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1653,19 +1653,19 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:2")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:2' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.613 * _default_ * recrOrangeFluoriteFreq ' range=':= 0.613 * _default_ * recrOrangeFluoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * recrOrangeFluoriteSize ' range=':= 0.922 * _default_ * recrOrangeFluoriteSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.226 * _default_ * recrOrangeFluoriteFreq ' range=':= 1.226 * _default_ * recrOrangeFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.035 * _default_ * recrOrangeFluoriteSize ' range=':= 1.035 * _default_ * recrOrangeFluoriteSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.783 * _default_ ' range=':= 0.783 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.107 * _default_ ' range=':= 1.107 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * recrOrangeFluoriteSize ' range=':= _default_ * recrOrangeFluoriteSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.885 * _default_ * recrOrangeFluoriteSize ' range=':= 0.885 * _default_ * recrOrangeFluoriteSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.052 * _default_ * recrOrangeFluoriteSize ' range=':= 1.052 * _default_ * recrOrangeFluoriteSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1686,8 +1686,8 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:2")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:2' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 1.000 * recrOrangeFluoriteSize ' range=':= _default_ * recrOrangeFluoriteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.500 * recrOrangeFluoriteFreq ' range=':= _default_ * recrOrangeFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.000 * recrOrangeFluoriteSize ' range=':= 4.000 * recrOrangeFluoriteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 6.000 * recrOrangeFluoriteFreq ' range=':= 6.000 * recrOrangeFluoriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -1717,9 +1717,9 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:2")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:2' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.732 * _default_ * recrOrangeFluoriteSize ' range=':= 0.732 * _default_ * recrOrangeFluoriteSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.732 * _default_ * recrOrangeFluoriteSize ' range=':= 0.732 * _default_ * recrOrangeFluoriteSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.536 * _default_ * recrOrangeFluoriteFreq ' range=':= 0.536 * _default_ * recrOrangeFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 1.036 * _default_ * recrOrangeFluoriteSize ' range=':= 1.036 * _default_ * recrOrangeFluoriteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.036 * _default_ * recrOrangeFluoriteSize ' range=':= 1.036 * _default_ * recrOrangeFluoriteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.073 * _default_ * recrOrangeFluoriteFreq ' range=':= 1.073 * _default_ * recrOrangeFluoriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1774,19 +1774,19 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:3")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:3' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.613 * _default_ * recrMagentaFluoriteFreq ' range=':= 0.613 * _default_ * recrMagentaFluoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * recrMagentaFluoriteSize ' range=':= 0.922 * _default_ * recrMagentaFluoriteSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.226 * _default_ * recrMagentaFluoriteFreq ' range=':= 1.226 * _default_ * recrMagentaFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.035 * _default_ * recrMagentaFluoriteSize ' range=':= 1.035 * _default_ * recrMagentaFluoriteSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.783 * _default_ ' range=':= 0.783 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.107 * _default_ ' range=':= 1.107 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * recrMagentaFluoriteSize ' range=':= _default_ * recrMagentaFluoriteSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.885 * _default_ * recrMagentaFluoriteSize ' range=':= 0.885 * _default_ * recrMagentaFluoriteSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.052 * _default_ * recrMagentaFluoriteSize ' range=':= 1.052 * _default_ * recrMagentaFluoriteSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1807,8 +1807,8 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:3")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:3' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 1.000 * recrMagentaFluoriteSize ' range=':= _default_ * recrMagentaFluoriteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.500 * recrMagentaFluoriteFreq ' range=':= _default_ * recrMagentaFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.000 * recrMagentaFluoriteSize ' range=':= 4.000 * recrMagentaFluoriteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 6.000 * recrMagentaFluoriteFreq ' range=':= 6.000 * recrMagentaFluoriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -1838,9 +1838,9 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:3")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:3' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.732 * _default_ * recrMagentaFluoriteSize ' range=':= 0.732 * _default_ * recrMagentaFluoriteSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.732 * _default_ * recrMagentaFluoriteSize ' range=':= 0.732 * _default_ * recrMagentaFluoriteSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.536 * _default_ * recrMagentaFluoriteFreq ' range=':= 0.536 * _default_ * recrMagentaFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 1.036 * _default_ * recrMagentaFluoriteSize ' range=':= 1.036 * _default_ * recrMagentaFluoriteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.036 * _default_ * recrMagentaFluoriteSize ' range=':= 1.036 * _default_ * recrMagentaFluoriteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.073 * _default_ * recrMagentaFluoriteFreq ' range=':= 1.073 * _default_ * recrMagentaFluoriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1894,19 +1894,19 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:4")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:4' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.613 * _default_ * recrGreenFluoriteFreq ' range=':= 0.613 * _default_ * recrGreenFluoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * recrGreenFluoriteSize ' range=':= 0.922 * _default_ * recrGreenFluoriteSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.226 * _default_ * recrGreenFluoriteFreq ' range=':= 1.226 * _default_ * recrGreenFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.035 * _default_ * recrGreenFluoriteSize ' range=':= 1.035 * _default_ * recrGreenFluoriteSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.783 * _default_ ' range=':= 0.783 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.107 * _default_ ' range=':= 1.107 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * recrGreenFluoriteSize ' range=':= _default_ * recrGreenFluoriteSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.885 * _default_ * recrGreenFluoriteSize ' range=':= 0.885 * _default_ * recrGreenFluoriteSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.052 * _default_ * recrGreenFluoriteSize ' range=':= 1.052 * _default_ * recrGreenFluoriteSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1927,8 +1927,8 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:4")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:4' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 1.000 * recrGreenFluoriteSize ' range=':= _default_ * recrGreenFluoriteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.500 * recrGreenFluoriteFreq ' range=':= _default_ * recrGreenFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.000 * recrGreenFluoriteSize ' range=':= 4.000 * recrGreenFluoriteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 6.000 * recrGreenFluoriteFreq ' range=':= 6.000 * recrGreenFluoriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -1958,9 +1958,9 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:4")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:4' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.732 * _default_ * recrGreenFluoriteSize ' range=':= 0.732 * _default_ * recrGreenFluoriteSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.732 * _default_ * recrGreenFluoriteSize ' range=':= 0.732 * _default_ * recrGreenFluoriteSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.536 * _default_ * recrGreenFluoriteFreq ' range=':= 0.536 * _default_ * recrGreenFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 1.036 * _default_ * recrGreenFluoriteSize ' range=':= 1.036 * _default_ * recrGreenFluoriteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.036 * _default_ * recrGreenFluoriteSize ' range=':= 1.036 * _default_ * recrGreenFluoriteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.073 * _default_ * recrGreenFluoriteFreq ' range=':= 1.073 * _default_ * recrGreenFluoriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2014,19 +2014,19 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:5")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:5' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.613 * _default_ * recrRedFluoriteFreq ' range=':= 0.613 * _default_ * recrRedFluoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * recrRedFluoriteSize ' range=':= 0.922 * _default_ * recrRedFluoriteSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.226 * _default_ * recrRedFluoriteFreq ' range=':= 1.226 * _default_ * recrRedFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.035 * _default_ * recrRedFluoriteSize ' range=':= 1.035 * _default_ * recrRedFluoriteSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.783 * _default_ ' range=':= 0.783 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.107 * _default_ ' range=':= 1.107 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * recrRedFluoriteSize ' range=':= _default_ * recrRedFluoriteSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.885 * _default_ * recrRedFluoriteSize ' range=':= 0.885 * _default_ * recrRedFluoriteSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.052 * _default_ * recrRedFluoriteSize ' range=':= 1.052 * _default_ * recrRedFluoriteSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -2046,8 +2046,8 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:5")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:5' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 1.000 * recrRedFluoriteSize ' range=':= _default_ * recrRedFluoriteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.500 * recrRedFluoriteFreq ' range=':= _default_ * recrRedFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.000 * recrRedFluoriteSize ' range=':= 4.000 * recrRedFluoriteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 6.000 * recrRedFluoriteFreq ' range=':= 6.000 * recrRedFluoriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -2077,9 +2077,9 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:5")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:5' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.732 * _default_ * recrRedFluoriteSize ' range=':= 0.732 * _default_ * recrRedFluoriteSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.732 * _default_ * recrRedFluoriteSize ' range=':= 0.732 * _default_ * recrRedFluoriteSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.536 * _default_ * recrRedFluoriteFreq ' range=':= 0.536 * _default_ * recrRedFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 1.036 * _default_ * recrRedFluoriteSize ' range=':= 1.036 * _default_ * recrRedFluoriteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.036 * _default_ * recrRedFluoriteSize ' range=':= 1.036 * _default_ * recrRedFluoriteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.073 * _default_ * recrRedFluoriteFreq ' range=':= 1.073 * _default_ * recrRedFluoriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2133,19 +2133,19 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:6")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:6' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.613 * _default_ * recrWhiteFluoriteFreq ' range=':= 0.613 * _default_ * recrWhiteFluoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * recrWhiteFluoriteSize ' range=':= 0.922 * _default_ * recrWhiteFluoriteSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.226 * _default_ * recrWhiteFluoriteFreq ' range=':= 1.226 * _default_ * recrWhiteFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.035 * _default_ * recrWhiteFluoriteSize ' range=':= 1.035 * _default_ * recrWhiteFluoriteSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.783 * _default_ ' range=':= 0.783 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.107 * _default_ ' range=':= 1.107 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * recrWhiteFluoriteSize ' range=':= _default_ * recrWhiteFluoriteSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.885 * _default_ * recrWhiteFluoriteSize ' range=':= 0.885 * _default_ * recrWhiteFluoriteSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.052 * _default_ * recrWhiteFluoriteSize ' range=':= 1.052 * _default_ * recrWhiteFluoriteSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -2166,8 +2166,8 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:6")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:6' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 1.000 * recrWhiteFluoriteSize ' range=':= _default_ * recrWhiteFluoriteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.500 * recrWhiteFluoriteFreq ' range=':= _default_ * recrWhiteFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.000 * recrWhiteFluoriteSize ' range=':= 4.000 * recrWhiteFluoriteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 6.000 * recrWhiteFluoriteFreq ' range=':= 6.000 * recrWhiteFluoriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -2197,9 +2197,9 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:6")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:6' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.732 * _default_ * recrWhiteFluoriteSize ' range=':= 0.732 * _default_ * recrWhiteFluoriteSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.732 * _default_ * recrWhiteFluoriteSize ' range=':= 0.732 * _default_ * recrWhiteFluoriteSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.536 * _default_ * recrWhiteFluoriteFreq ' range=':= 0.536 * _default_ * recrWhiteFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 1.036 * _default_ * recrWhiteFluoriteSize ' range=':= 1.036 * _default_ * recrWhiteFluoriteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.036 * _default_ * recrWhiteFluoriteSize ' range=':= 1.036 * _default_ * recrWhiteFluoriteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.073 * _default_ * recrWhiteFluoriteFreq ' range=':= 1.073 * _default_ * recrWhiteFluoriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2253,19 +2253,19 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:7")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:7' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.613 * _default_ * recrYellowFluoriteFreq ' range=':= 0.613 * _default_ * recrYellowFluoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * recrYellowFluoriteSize ' range=':= 0.922 * _default_ * recrYellowFluoriteSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.226 * _default_ * recrYellowFluoriteFreq ' range=':= 1.226 * _default_ * recrYellowFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.035 * _default_ * recrYellowFluoriteSize ' range=':= 1.035 * _default_ * recrYellowFluoriteSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.783 * _default_ ' range=':= 0.783 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.107 * _default_ ' range=':= 1.107 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * recrYellowFluoriteSize ' range=':= _default_ * recrYellowFluoriteSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.885 * _default_ * recrYellowFluoriteSize ' range=':= 0.885 * _default_ * recrYellowFluoriteSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.052 * _default_ * recrYellowFluoriteSize ' range=':= 1.052 * _default_ * recrYellowFluoriteSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -2286,8 +2286,8 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:7")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:7' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 1.000 * recrYellowFluoriteSize ' range=':= _default_ * recrYellowFluoriteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.500 * recrYellowFluoriteFreq ' range=':= _default_ * recrYellowFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.000 * recrYellowFluoriteSize ' range=':= 4.000 * recrYellowFluoriteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 6.000 * recrYellowFluoriteFreq ' range=':= 6.000 * recrYellowFluoriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -2317,9 +2317,9 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:7")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:7' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.732 * _default_ * recrYellowFluoriteSize ' range=':= 0.732 * _default_ * recrYellowFluoriteSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.732 * _default_ * recrYellowFluoriteSize ' range=':= 0.732 * _default_ * recrYellowFluoriteSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.536 * _default_ * recrYellowFluoriteFreq ' range=':= 0.536 * _default_ * recrYellowFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 1.036 * _default_ * recrYellowFluoriteSize ' range=':= 1.036 * _default_ * recrYellowFluoriteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.036 * _default_ * recrYellowFluoriteSize ' range=':= 1.036 * _default_ * recrYellowFluoriteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.073 * _default_ * recrYellowFluoriteFreq ' range=':= 1.073 * _default_ * recrYellowFluoriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2374,8 +2374,23 @@
 
                 <!-- Starting Original "Nether" Block Removal -->
 
+                <IfCondition condition=':= ?blockExists("minecraft:netherrack")'>
+                    <Substitute name='recrNetherBlockSubstitute0' block='minecraft:netherrack'>
+                        <Description>
+                            Replace vanilla-generated ore clusters.
+                        </Description>
+                        <Comment>
+                            The global option  deferredPopulationRange
+                            must be large  enough to catch all ore
+                            clusters (>=  32).
+                        </Comment>
+                        <Replaces block='ReactorCraft:reactorcraft_block_ore:9' weight='1.0' />
+                    </Substitute>
+                </IfCondition>
+
+
                 <IfCondition condition=':= ?blockExists("minecraft:stone")'>
-                    <Substitute name='recrNetherBlockSubstitute0' block='minecraft:stone'>
+                    <Substitute name='recrNetherBlockSubstitute1' block='minecraft:stone'>
                         <Description>
                             Replace vanilla-generated ore clusters.
                         </Description>
@@ -2385,7 +2400,6 @@
                             clusters (>=  32).
                         </Comment>
                         <Replaces block='ReactorCraft:reactorcraft_block_ore:6' weight='1.0' />
-                        <Replaces block='ReactorCraft:reactorcraft_block_ore:9' weight='1.0' />
                     </Substitute>
                 </IfCondition>
 
@@ -2414,19 +2428,19 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:6")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:6' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 3.001 * _default_ * recrAmmoniumChlorideFreq ' range=':= 3.001 * _default_ * recrAmmoniumChlorideFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeFrequency' avg=':= 2.122 * _default_ * recrAmmoniumChlorideFreq ' range=':= 2.122 * _default_ * recrAmmoniumChlorideFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * recrAmmoniumChlorideSize ' range=':= 0 * _default_ * recrAmmoniumChlorideSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 32 ' range=':= 0 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.732 * _default_ ' range=':= 1.732 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.457 * _default_ ' range=':= 1.457 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * recrAmmoniumChlorideSize ' range=':= _default_ * recrAmmoniumChlorideSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.316 * _default_ * recrAmmoniumChlorideSize ' range=':= 1.316 * _default_ * recrAmmoniumChlorideSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.207 * _default_ * recrAmmoniumChlorideSize ' range=':= 1.207 * _default_ * recrAmmoniumChlorideSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -2447,8 +2461,8 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:6")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:6' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 8.000 * recrAmmoniumChlorideSize ' range=':= _default_ * recrAmmoniumChlorideSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 6.000 * recrAmmoniumChlorideFreq ' range=':= _default_ * recrAmmoniumChlorideFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.000 * recrAmmoniumChlorideSize ' range=':= 4.000 * recrAmmoniumChlorideSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 3.000 * recrAmmoniumChlorideFreq ' range=':= 3.000 * recrAmmoniumChlorideFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 32 ' range=':= 0 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -2478,9 +2492,9 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:6")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:6' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.036 * _default_ * recrAmmoniumChlorideSize ' range=':= 1.036 * _default_ * recrAmmoniumChlorideSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.036 * _default_ * recrAmmoniumChlorideSize ' range=':= 1.036 * _default_ * recrAmmoniumChlorideSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.073 * _default_ * recrAmmoniumChlorideFreq ' range=':= 1.073 * _default_ * recrAmmoniumChlorideFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.871 * _default_ * recrAmmoniumChlorideSize ' range=':= 0.871 * _default_ * recrAmmoniumChlorideSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.871 * _default_ * recrAmmoniumChlorideSize ' range=':= 0.871 * _default_ * recrAmmoniumChlorideSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.758 * _default_ * recrAmmoniumChlorideFreq ' range=':= 0.758 * _default_ * recrAmmoniumChlorideFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 32 ' range=':= 0 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2532,21 +2546,21 @@
                                 2-4 horizontal veins each.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:9")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:9' weight='1.0' /> </IfCondition>
-                            <ReplacesOre block='stone' weight='1.0' />
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 2.122 * _default_ * recrThoriteFreq ' range=':= 2.122 * _default_ * recrThoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.500 * _default_ * recrThoriteFreq ' range=':= 1.500 * _default_ * recrThoriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * recrThoriteSize ' range=':= 0 * _default_ * recrThoriteSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 18.5 ' range=':= 13.5 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.457 * _default_ ' range=':= 1.457 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.225 * _default_ ' range=':= 1.225 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * recrThoriteSize ' range=':= _default_ * recrThoriteSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.207 * _default_ * recrThoriteSize ' range=':= 1.207 * _default_ * recrThoriteSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.107 * _default_ * recrThoriteSize ' range=':= 1.107 * _default_ * recrThoriteSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -2564,10 +2578,10 @@
                                 distributions.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:9")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:9' weight='1.0' /> </IfCondition>
-                            <ReplacesOre block='stone' weight='1.0' />
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 24.000 * recrThoriteSize ' range=':= _default_ * recrThoriteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.000 * recrThoriteFreq ' range=':= _default_ * recrThoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 12.000 * recrThoriteSize ' range=':= 12.000 * recrThoriteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 0.500 * recrThoriteFreq ' range=':= 0.500 * recrThoriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 18.5 ' range=':= 13.5 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -2595,11 +2609,11 @@
                                 actually mining  the ore.
                             </Description>
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:9")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:9' weight='1.0' /> </IfCondition>
-                            <ReplacesOre block='stone' weight='1.0' />
+                            <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.871 * _default_ * recrThoriteSize ' range=':= 0.871 * _default_ * recrThoriteSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.871 * _default_ * recrThoriteSize ' range=':= 0.871 * _default_ * recrThoriteSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.758 * _default_ * recrThoriteFreq ' range=':= 0.758 * _default_ * recrThoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.732 * _default_ * recrThoriteSize ' range=':= 0.732 * _default_ * recrThoriteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.732 * _default_ * recrThoriteSize ' range=':= 0.732 * _default_ * recrThoriteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.536 * _default_ * recrThoriteFreq ' range=':= 0.536 * _default_ * recrThoriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 18.5 ' range=':= 13.5 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2692,19 +2706,19 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:5")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:5' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 4.244 * _default_ * recrEndPitchblendeFreq ' range=':= 4.244 * _default_ * recrEndPitchblendeFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeFrequency' avg=':= 3.001 * _default_ * recrEndPitchblendeFreq ' range=':= 3.001 * _default_ * recrEndPitchblendeFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * recrEndPitchblendeSize ' range=':= 0 * _default_ * recrEndPitchblendeSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 34.5 ' range=':= 29.5 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 2.060 * _default_ ' range=':= 2.060 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.732 * _default_ ' range=':= 1.732 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * recrEndPitchblendeSize ' range=':= _default_ * recrEndPitchblendeSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.435 * _default_ * recrEndPitchblendeSize ' range=':= 1.435 * _default_ * recrEndPitchblendeSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.316 * _default_ * recrEndPitchblendeSize ' range=':= 1.316 * _default_ * recrEndPitchblendeSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -2725,8 +2739,8 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:5")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:5' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 16.000 * recrEndPitchblendeSize ' range=':= _default_ * recrEndPitchblendeSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 6.000 * recrEndPitchblendeFreq ' range=':= _default_ * recrEndPitchblendeFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 8.000 * recrEndPitchblendeSize ' range=':= 8.000 * recrEndPitchblendeSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 3.000 * recrEndPitchblendeFreq ' range=':= 3.000 * recrEndPitchblendeFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 34.5 ' range=':= 29.5 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -2756,9 +2770,9 @@
                             <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:5")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:5' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.232 * _default_ * recrEndPitchblendeSize ' range=':= 1.232 * _default_ * recrEndPitchblendeSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.232 * _default_ * recrEndPitchblendeSize ' range=':= 1.232 * _default_ * recrEndPitchblendeSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.517 * _default_ * recrEndPitchblendeFreq ' range=':= 1.517 * _default_ * recrEndPitchblendeFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 1.036 * _default_ * recrEndPitchblendeSize ' range=':= 1.036 * _default_ * recrEndPitchblendeSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.036 * _default_ * recrEndPitchblendeSize ' range=':= 1.036 * _default_ * recrEndPitchblendeSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.073 * _default_ * recrEndPitchblendeFreq ' range=':= 1.073 * _default_ * recrEndPitchblendeFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 34.5 ' range=':= 29.5 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />

--- a/src/main/resources/config/modules/SimpleOres.xml
+++ b/src/main/resources/config/modules/SimpleOres.xml
@@ -250,19 +250,19 @@
                             <IfCondition condition=':= ?blockExists("simpleores:copper_ore")'> <OreBlock block='simpleores:copper_ore' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 2.770 * _default_ * smpoCopperFreq ' range=':= 2.770 * _default_ * smpoCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.185 * _default_ * smpoCopperSize ' range=':= 1.185 * _default_ * smpoCopperSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.958 * _default_ * smpoCopperFreq ' range=':= 1.958 * _default_ * smpoCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.119 * _default_ * smpoCopperSize ' range=':= 1.119 * _default_ * smpoCopperSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 48 ' range=':= 42 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.664 * _default_ ' range=':= 1.664 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.399 * _default_ ' range=':= 1.399 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * smpoCopperSize ' range=':= _default_ * smpoCopperSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.290 * _default_ * smpoCopperSize ' range=':= 1.290 * _default_ * smpoCopperSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.183 * _default_ * smpoCopperSize ' range=':= 1.183 * _default_ * smpoCopperSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -292,9 +292,9 @@
                             <IfCondition condition=':= ?blockExists("simpleores:copper_ore")'> <OreBlock block='simpleores:copper_ore' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.557 * _default_ * smpoCopperSize ' range=':= 1.557 * _default_ * smpoCopperSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.557 * _default_ * smpoCopperSize ' range=':= 1.557 * _default_ * smpoCopperSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 2.423 * _default_ * smpoCopperFreq ' range=':= 2.423 * _default_ * smpoCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 1.309 * _default_ * smpoCopperSize ' range=':= 1.309 * _default_ * smpoCopperSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.309 * _default_ * smpoCopperSize ' range=':= 1.309 * _default_ * smpoCopperSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.714 * _default_ * smpoCopperFreq ' range=':= 1.714 * _default_ * smpoCopperFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 48 ' range=':= 42 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -344,8 +344,8 @@
                             <IfCondition condition=':= ?blockExists("simpleores:copper_ore")'> <OreBlock block='simpleores:copper_ore' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 7.000 * smpoCopperSize ' range=':= _default_ * smpoCopperSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 35.000 * smpoCopperFreq ' range=':= _default_ * smpoCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 3.500 * smpoCopperSize ' range=':= 3.500 * smpoCopperSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 17.500 * smpoCopperFreq ' range=':= 17.500 * smpoCopperFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 48 ' range=':= 42 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -369,19 +369,19 @@
                             <IfCondition condition=':= ?blockExists("simpleores:tin_ore")'> <OreBlock block='simpleores:tin_ore' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 2.564 * _default_ * smpoTinFreq ' range=':= 2.564 * _default_ * smpoTinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.170 * _default_ * smpoTinSize ' range=':= 1.170 * _default_ * smpoTinSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.813 * _default_ * smpoTinFreq ' range=':= 1.813 * _default_ * smpoTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.104 * _default_ * smpoTinSize ' range=':= 1.104 * _default_ * smpoTinSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 48 ' range=':= 42 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.601 * _default_ ' range=':= 1.601 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.347 * _default_ ' range=':= 1.347 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * smpoTinSize ' range=':= _default_ * smpoTinSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.265 * _default_ * smpoTinSize ' range=':= 1.265 * _default_ * smpoTinSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.160 * _default_ * smpoTinSize ' range=':= 1.160 * _default_ * smpoTinSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -411,9 +411,9 @@
                             <IfCondition condition=':= ?blockExists("simpleores:tin_ore")'> <OreBlock block='simpleores:tin_ore' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.498 * _default_ * smpoTinSize ' range=':= 1.498 * _default_ * smpoTinSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.498 * _default_ * smpoTinSize ' range=':= 1.498 * _default_ * smpoTinSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 2.244 * _default_ * smpoTinFreq ' range=':= 2.244 * _default_ * smpoTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 1.260 * _default_ * smpoTinSize ' range=':= 1.260 * _default_ * smpoTinSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.260 * _default_ * smpoTinSize ' range=':= 1.260 * _default_ * smpoTinSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.586 * _default_ * smpoTinFreq ' range=':= 1.586 * _default_ * smpoTinFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 48 ' range=':= 42 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -463,8 +463,8 @@
                             <IfCondition condition=':= ?blockExists("simpleores:tin_ore")'> <OreBlock block='simpleores:tin_ore' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 7.000 * smpoTinSize ' range=':= _default_ * smpoTinSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 30.000 * smpoTinFreq ' range=':= _default_ * smpoTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 3.500 * smpoTinSize ' range=':= 3.500 * smpoTinSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 15.000 * smpoTinFreq ' range=':= 15.000 * smpoTinFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 48 ' range=':= 42 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -488,19 +488,19 @@
                             <IfCondition condition=':= ?blockExists("simpleores:mythril_ore")'> <OreBlock block='simpleores:mythril_ore' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.001 * _default_ * smpoMythrilFreq ' range=':= 1.001 * _default_ * smpoMythrilFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.000 * _default_ * smpoMythrilSize ' range=':= 1.000 * _default_ * smpoMythrilSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.708 * _default_ * smpoMythrilFreq ' range=':= 0.708 * _default_ * smpoMythrilFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.944 * _default_ * smpoMythrilSize ' range=':= 0.944 * _default_ * smpoMythrilSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 20 ' range=':= 15 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.000 * _default_ ' range=':= 1.000 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.841 * _default_ ' range=':= 0.841 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * smpoMythrilSize ' range=':= _default_ * smpoMythrilSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.000 * _default_ * smpoMythrilSize ' range=':= 1.000 * _default_ * smpoMythrilSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.917 * _default_ * smpoMythrilSize ' range=':= 0.917 * _default_ * smpoMythrilSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -530,9 +530,9 @@
                             <IfCondition condition=':= ?blockExists("simpleores:mythril_ore")'> <OreBlock block='simpleores:mythril_ore' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.936 * _default_ * smpoMythrilSize ' range=':= 0.936 * _default_ * smpoMythrilSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.936 * _default_ * smpoMythrilSize ' range=':= 0.936 * _default_ * smpoMythrilSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.876 * _default_ * smpoMythrilFreq ' range=':= 0.876 * _default_ * smpoMythrilFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.787 * _default_ * smpoMythrilSize ' range=':= 0.787 * _default_ * smpoMythrilSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.787 * _default_ * smpoMythrilSize ' range=':= 0.787 * _default_ * smpoMythrilSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.619 * _default_ * smpoMythrilFreq ' range=':= 0.619 * _default_ * smpoMythrilFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 20 ' range=':= 15 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -582,8 +582,8 @@
                             <IfCondition condition=':= ?blockExists("simpleores:mythril_ore")'> <OreBlock block='simpleores:mythril_ore' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.000 * smpoMythrilSize ' range=':= _default_ * smpoMythrilSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 8.000 * smpoMythrilFreq ' range=':= _default_ * smpoMythrilFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.000 * smpoMythrilSize ' range=':= 2.000 * smpoMythrilSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4.000 * smpoMythrilFreq ' range=':= 4.000 * smpoMythrilFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 20 ' range=':= 15 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -607,19 +607,19 @@
                             <IfCondition condition=':= ?blockExists("simpleores:adamantium_ore")'> <OreBlock block='simpleores:adamantium_ore' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.708 * _default_ * smpoAdamantiumFreq ' range=':= 0.708 * _default_ * smpoAdamantiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.944 * _default_ * smpoAdamantiumSize ' range=':= 0.944 * _default_ * smpoAdamantiumSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.500 * _default_ * smpoAdamantiumFreq ' range=':= 0.500 * _default_ * smpoAdamantiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.891 * _default_ * smpoAdamantiumSize ' range=':= 0.891 * _default_ * smpoAdamantiumSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 13 ' range=':= 7 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.841 * _default_ ' range=':= 0.841 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.707 * _default_ ' range=':= 0.707 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * smpoAdamantiumSize ' range=':= _default_ * smpoAdamantiumSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.917 * _default_ * smpoAdamantiumSize ' range=':= 0.917 * _default_ * smpoAdamantiumSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.841 * _default_ * smpoAdamantiumSize ' range=':= 0.841 * _default_ * smpoAdamantiumSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -649,9 +649,9 @@
                             <IfCondition condition=':= ?blockExists("simpleores:adamantium_ore")'> <OreBlock block='simpleores:adamantium_ore' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.787 * _default_ * smpoAdamantiumSize ' range=':= 0.787 * _default_ * smpoAdamantiumSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.787 * _default_ * smpoAdamantiumSize ' range=':= 0.787 * _default_ * smpoAdamantiumSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.619 * _default_ * smpoAdamantiumFreq ' range=':= 0.619 * _default_ * smpoAdamantiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.662 * _default_ * smpoAdamantiumSize ' range=':= 0.662 * _default_ * smpoAdamantiumSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.662 * _default_ * smpoAdamantiumSize ' range=':= 0.662 * _default_ * smpoAdamantiumSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.438 * _default_ * smpoAdamantiumFreq ' range=':= 0.438 * _default_ * smpoAdamantiumFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 13 ' range=':= 7 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -701,8 +701,8 @@
                             <IfCondition condition=':= ?blockExists("simpleores:adamantium_ore")'> <OreBlock block='simpleores:adamantium_ore' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.000 * smpoAdamantiumSize ' range=':= _default_ * smpoAdamantiumSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 4.000 * smpoAdamantiumFreq ' range=':= _default_ * smpoAdamantiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.000 * smpoAdamantiumSize ' range=':= 2.000 * smpoAdamantiumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2.000 * smpoAdamantiumFreq ' range=':= 2.000 * smpoAdamantiumFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 13 ' range=':= 7 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -758,19 +758,19 @@
                             <IfCondition condition=':= ?blockExists("simpleores:onyx_ore")'> <OreBlock block='simpleores:onyx_ore' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.597 * _default_ * smpoOnyxFreq ' range=':= 1.597 * _default_ * smpoOnyxFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.129 * _default_ * smpoOnyxFreq ' range=':= 1.129 * _default_ * smpoOnyxFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * smpoOnyxSize ' range=':= 0 * _default_ * smpoOnyxSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 72 ' range=':= 56 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.264 * _default_ ' range=':= 1.264 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.063 * _default_ ' range=':= 1.063 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * smpoOnyxSize ' range=':= _default_ * smpoOnyxSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.124 * _default_ * smpoOnyxSize ' range=':= 1.124 * _default_ * smpoOnyxSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.031 * _default_ * smpoOnyxSize ' range=':= 1.031 * _default_ * smpoOnyxSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -781,7 +781,7 @@
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Replaces block='simpleores:onyx_ore' weight='1.0' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * smpoOnyxSize  * 0.5 ' range=':= 0 * _default_ * smpoOnyxSize  * 0.5 ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.124 * _default_ * smpoOnyxSize  * 0.5 ' range=':= 1.124 * _default_ * smpoOnyxSize  * 0.5 ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.031 * _default_ * smpoOnyxSize  * 0.5 ' range=':= 1.031 * _default_ * smpoOnyxSize  * 0.5 ' type='normal' />
                             <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
                         </Veins>
                     </IfCondition>
@@ -810,9 +810,9 @@
                             <IfCondition condition=':= ?blockExists("simpleores:onyx_ore")'> <OreBlock block='simpleores:onyx_ore' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.957 * _default_ * smpoOnyxSize ' range=':= 0.957 * _default_ * smpoOnyxSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.957 * _default_ * smpoOnyxSize ' range=':= 0.957 * _default_ * smpoOnyxSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.916 * _default_ * smpoOnyxFreq ' range=':= 0.916 * _default_ * smpoOnyxFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.805 * _default_ * smpoOnyxSize ' range=':= 0.805 * _default_ * smpoOnyxSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.805 * _default_ * smpoOnyxSize ' range=':= 0.805 * _default_ * smpoOnyxSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.648 * _default_ * smpoOnyxFreq ' range=':= 0.648 * _default_ * smpoOnyxFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 72 ' range=':= 56 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -862,8 +862,8 @@
                             <IfCondition condition=':= ?blockExists("simpleores:onyx_ore")'> <OreBlock block='simpleores:onyx_ore' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 7.000 * smpoOnyxSize ' range=':= _default_ * smpoOnyxSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 5.000 * smpoOnyxFreq ' range=':= _default_ * smpoOnyxFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 3.500 * smpoOnyxSize ' range=':= 3.500 * smpoOnyxSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2.500 * smpoOnyxFreq ' range=':= 2.500 * smpoOnyxFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 72 ' range=':= 56 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>

--- a/src/main/resources/config/modules/Thaumcraft4.xml
+++ b/src/main/resources/config/modules/Thaumcraft4.xml
@@ -367,19 +367,19 @@
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:7")'> <OreBlock block='Thaumcraft:blockCustomOre:7' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.225 * _default_ * thm4AmberBearingStoneFreq ' range=':= 1.225 * _default_ * thm4AmberBearingStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.866 * _default_ * thm4AmberBearingStoneFreq ' range=':= 0.866 * _default_ * thm4AmberBearingStoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * thm4AmberBearingStoneSize ' range=':= 0 * _default_ * thm4AmberBearingStoneSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 50 ' range=':= 16 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.107 * _default_ ' range=':= 1.107 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.931 * _default_ ' range=':= 0.931 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * thm4AmberBearingStoneSize ' range=':= _default_ * thm4AmberBearingStoneSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.052 * _default_ * thm4AmberBearingStoneSize ' range=':= 1.052 * _default_ * thm4AmberBearingStoneSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.965 * _default_ * thm4AmberBearingStoneSize ' range=':= 0.965 * _default_ * thm4AmberBearingStoneSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -410,9 +410,9 @@
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:7")'> <OreBlock block='Thaumcraft:blockCustomOre:7' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.662 * _default_ * thm4AmberBearingStoneSize ' range=':= 0.662 * _default_ * thm4AmberBearingStoneSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.662 * _default_ * thm4AmberBearingStoneSize ' range=':= 0.662 * _default_ * thm4AmberBearingStoneSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.438 * _default_ * thm4AmberBearingStoneFreq ' range=':= 0.438 * _default_ * thm4AmberBearingStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.556 * _default_ * thm4AmberBearingStoneSize ' range=':= 0.556 * _default_ * thm4AmberBearingStoneSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.556 * _default_ * thm4AmberBearingStoneSize ' range=':= 0.556 * _default_ * thm4AmberBearingStoneSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.310 * _default_ * thm4AmberBearingStoneFreq ' range=':= 0.310 * _default_ * thm4AmberBearingStoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 50 ' range=':= 16 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -462,8 +462,8 @@
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:7")'> <OreBlock block='Thaumcraft:blockCustomOre:7' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 1.000 * thm4AmberBearingStoneSize ' range=':= _default_ * thm4AmberBearingStoneSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 8.000 * thm4AmberBearingStoneFreq ' range=':= _default_ * thm4AmberBearingStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 0.500 * thm4AmberBearingStoneSize ' range=':= 0.500 * thm4AmberBearingStoneSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4.000 * thm4AmberBearingStoneFreq ' range=':= 4.000 * thm4AmberBearingStoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 50 ' range=':= 16 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -495,19 +495,19 @@
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre")'> <OreBlock block='Thaumcraft:blockCustomOre' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.500 * _default_ * thm4CinnabarFreq ' range=':= 1.500 * _default_ * thm4CinnabarFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.061 * _default_ * thm4CinnabarFreq ' range=':= 1.061 * _default_ * thm4CinnabarFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * thm4CinnabarSize ' range=':= 0 * _default_ * thm4CinnabarSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.225 * _default_ ' range=':= 1.225 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.030 * _default_ ' range=':= 1.030 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * thm4CinnabarSize ' range=':= _default_ * thm4CinnabarSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.107 * _default_ * thm4CinnabarSize ' range=':= 1.107 * _default_ * thm4CinnabarSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.015 * _default_ * thm4CinnabarSize ' range=':= 1.015 * _default_ * thm4CinnabarSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -537,9 +537,9 @@
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre")'> <OreBlock block='Thaumcraft:blockCustomOre' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.732 * _default_ * thm4CinnabarSize ' range=':= 0.732 * _default_ * thm4CinnabarSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.732 * _default_ * thm4CinnabarSize ' range=':= 0.732 * _default_ * thm4CinnabarSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.536 * _default_ * thm4CinnabarFreq ' range=':= 0.536 * _default_ * thm4CinnabarFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.616 * _default_ * thm4CinnabarSize ' range=':= 0.616 * _default_ * thm4CinnabarSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.616 * _default_ * thm4CinnabarSize ' range=':= 0.616 * _default_ * thm4CinnabarSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.379 * _default_ * thm4CinnabarFreq ' range=':= 0.379 * _default_ * thm4CinnabarFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -589,8 +589,8 @@
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre")'> <OreBlock block='Thaumcraft:blockCustomOre' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 1.000 * thm4CinnabarSize ' range=':= _default_ * thm4CinnabarSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 12.000 * thm4CinnabarFreq ' range=':= _default_ * thm4CinnabarFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 0.500 * thm4CinnabarSize ' range=':= 0.500 * thm4CinnabarSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 6.000 * thm4CinnabarFreq ' range=':= 6.000 * thm4CinnabarFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -622,19 +622,19 @@
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:1")'> <OreBlock block='Thaumcraft:blockCustomOre:1' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * thm4AirInfusedStoneFreq ' range=':= 0.969 * _default_ * thm4AirInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.685 * _default_ * thm4AirInfusedStoneFreq ' range=':= 0.685 * _default_ * thm4AirInfusedStoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * thm4AirInfusedStoneSize ' range=':= 0 * _default_ * thm4AirInfusedStoneSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.984 * _default_ ' range=':= 0.984 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.828 * _default_ ' range=':= 0.828 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * thm4AirInfusedStoneSize ' range=':= _default_ * thm4AirInfusedStoneSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.992 * _default_ * thm4AirInfusedStoneSize ' range=':= 0.992 * _default_ * thm4AirInfusedStoneSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.910 * _default_ * thm4AirInfusedStoneSize ' range=':= 0.910 * _default_ * thm4AirInfusedStoneSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -648,19 +648,19 @@
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:1")'> <OreBlock block='Thaumcraft:blockCustomOre:1' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Plains'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * thm4AirInfusedStoneFreq ' range=':= 0.969 * _default_ * thm4AirInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.685 * _default_ * thm4AirInfusedStoneFreq ' range=':= 0.685 * _default_ * thm4AirInfusedStoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * thm4AirInfusedStoneSize ' range=':= 0 * _default_ * thm4AirInfusedStoneSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.984 * _default_ ' range=':= 0.984 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.828 * _default_ ' range=':= 0.828 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * thm4AirInfusedStoneSize ' range=':= _default_ * thm4AirInfusedStoneSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.992 * _default_ * thm4AirInfusedStoneSize ' range=':= 0.992 * _default_ * thm4AirInfusedStoneSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.910 * _default_ * thm4AirInfusedStoneSize ' range=':= 0.910 * _default_ * thm4AirInfusedStoneSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -693,9 +693,9 @@
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:1")'> <OreBlock block='Thaumcraft:blockCustomOre:1' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.588 * _default_ * thm4AirInfusedStoneSize ' range=':= 0.588 * _default_ * thm4AirInfusedStoneSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.588 * _default_ * thm4AirInfusedStoneSize ' range=':= 0.588 * _default_ * thm4AirInfusedStoneSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.346 * _default_ * thm4AirInfusedStoneFreq ' range=':= 0.346 * _default_ * thm4AirInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.495 * _default_ * thm4AirInfusedStoneSize ' range=':= 0.495 * _default_ * thm4AirInfusedStoneSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.495 * _default_ * thm4AirInfusedStoneSize ' range=':= 0.495 * _default_ * thm4AirInfusedStoneSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.245 * _default_ * thm4AirInfusedStoneFreq ' range=':= 0.245 * _default_ * thm4AirInfusedStoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -739,9 +739,9 @@
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:1")'> <OreBlock block='Thaumcraft:blockCustomOre:1' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Plains'  />
-                            <Setting name='CloudRadius' avg=':= 0.588 * _default_ * thm4AirInfusedStoneSize ' range=':= 0.588 * _default_ * thm4AirInfusedStoneSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.588 * _default_ * thm4AirInfusedStoneSize ' range=':= 0.588 * _default_ * thm4AirInfusedStoneSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.346 * _default_ * thm4AirInfusedStoneFreq ' range=':= 0.346 * _default_ * thm4AirInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.495 * _default_ * thm4AirInfusedStoneSize ' range=':= 0.495 * _default_ * thm4AirInfusedStoneSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.495 * _default_ * thm4AirInfusedStoneSize ' range=':= 0.495 * _default_ * thm4AirInfusedStoneSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.245 * _default_ * thm4AirInfusedStoneFreq ' range=':= 0.245 * _default_ * thm4AirInfusedStoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -777,8 +777,8 @@
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:1")'> <OreBlock block='Thaumcraft:blockCustomOre:1' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 5.000 * thm4AirInfusedStoneSize ' range=':= _default_ * thm4AirInfusedStoneSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.000 * thm4AirInfusedStoneFreq ' range=':= _default_ * thm4AirInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.500 * thm4AirInfusedStoneSize ' range=':= 2.500 * thm4AirInfusedStoneSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 0.500 * thm4AirInfusedStoneFreq ' range=':= 0.500 * thm4AirInfusedStoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -810,19 +810,19 @@
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:2")'> <OreBlock block='Thaumcraft:blockCustomOre:2' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * thm4FireInfusedStoneFreq ' range=':= 0.969 * _default_ * thm4FireInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.685 * _default_ * thm4FireInfusedStoneFreq ' range=':= 0.685 * _default_ * thm4FireInfusedStoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * thm4FireInfusedStoneSize ' range=':= 0 * _default_ * thm4FireInfusedStoneSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.984 * _default_ ' range=':= 0.984 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.828 * _default_ ' range=':= 0.828 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * thm4FireInfusedStoneSize ' range=':= _default_ * thm4FireInfusedStoneSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.992 * _default_ * thm4FireInfusedStoneSize ' range=':= 0.992 * _default_ * thm4FireInfusedStoneSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.910 * _default_ * thm4FireInfusedStoneSize ' range=':= 0.910 * _default_ * thm4FireInfusedStoneSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -836,19 +836,19 @@
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:2")'> <OreBlock block='Thaumcraft:blockCustomOre:2' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Desert'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * thm4FireInfusedStoneFreq ' range=':= 0.969 * _default_ * thm4FireInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.685 * _default_ * thm4FireInfusedStoneFreq ' range=':= 0.685 * _default_ * thm4FireInfusedStoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * thm4FireInfusedStoneSize ' range=':= 0 * _default_ * thm4FireInfusedStoneSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.984 * _default_ ' range=':= 0.984 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.828 * _default_ ' range=':= 0.828 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * thm4FireInfusedStoneSize ' range=':= _default_ * thm4FireInfusedStoneSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.992 * _default_ * thm4FireInfusedStoneSize ' range=':= 0.992 * _default_ * thm4FireInfusedStoneSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.910 * _default_ * thm4FireInfusedStoneSize ' range=':= 0.910 * _default_ * thm4FireInfusedStoneSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -881,9 +881,9 @@
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:2")'> <OreBlock block='Thaumcraft:blockCustomOre:2' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.588 * _default_ * thm4FireInfusedStoneSize ' range=':= 0.588 * _default_ * thm4FireInfusedStoneSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.588 * _default_ * thm4FireInfusedStoneSize ' range=':= 0.588 * _default_ * thm4FireInfusedStoneSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.346 * _default_ * thm4FireInfusedStoneFreq ' range=':= 0.346 * _default_ * thm4FireInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.495 * _default_ * thm4FireInfusedStoneSize ' range=':= 0.495 * _default_ * thm4FireInfusedStoneSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.495 * _default_ * thm4FireInfusedStoneSize ' range=':= 0.495 * _default_ * thm4FireInfusedStoneSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.245 * _default_ * thm4FireInfusedStoneFreq ' range=':= 0.245 * _default_ * thm4FireInfusedStoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -927,9 +927,9 @@
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:2")'> <OreBlock block='Thaumcraft:blockCustomOre:2' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Desert'  />
-                            <Setting name='CloudRadius' avg=':= 0.588 * _default_ * thm4FireInfusedStoneSize ' range=':= 0.588 * _default_ * thm4FireInfusedStoneSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.588 * _default_ * thm4FireInfusedStoneSize ' range=':= 0.588 * _default_ * thm4FireInfusedStoneSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.346 * _default_ * thm4FireInfusedStoneFreq ' range=':= 0.346 * _default_ * thm4FireInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.495 * _default_ * thm4FireInfusedStoneSize ' range=':= 0.495 * _default_ * thm4FireInfusedStoneSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.495 * _default_ * thm4FireInfusedStoneSize ' range=':= 0.495 * _default_ * thm4FireInfusedStoneSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.245 * _default_ * thm4FireInfusedStoneFreq ' range=':= 0.245 * _default_ * thm4FireInfusedStoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -965,8 +965,8 @@
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:2")'> <OreBlock block='Thaumcraft:blockCustomOre:2' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 5.000 * thm4FireInfusedStoneSize ' range=':= _default_ * thm4FireInfusedStoneSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.000 * thm4FireInfusedStoneFreq ' range=':= _default_ * thm4FireInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.500 * thm4FireInfusedStoneSize ' range=':= 2.500 * thm4FireInfusedStoneSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 0.500 * thm4FireInfusedStoneFreq ' range=':= 0.500 * thm4FireInfusedStoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -999,19 +999,19 @@
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:3")'> <OreBlock block='Thaumcraft:blockCustomOre:3' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * thm4WaterInfusedStoneFreq ' range=':= 0.969 * _default_ * thm4WaterInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.685 * _default_ * thm4WaterInfusedStoneFreq ' range=':= 0.685 * _default_ * thm4WaterInfusedStoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * thm4WaterInfusedStoneSize ' range=':= 0 * _default_ * thm4WaterInfusedStoneSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.984 * _default_ ' range=':= 0.984 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.828 * _default_ ' range=':= 0.828 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * thm4WaterInfusedStoneSize ' range=':= _default_ * thm4WaterInfusedStoneSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.992 * _default_ * thm4WaterInfusedStoneSize ' range=':= 0.992 * _default_ * thm4WaterInfusedStoneSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.910 * _default_ * thm4WaterInfusedStoneSize ' range=':= 0.910 * _default_ * thm4WaterInfusedStoneSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1026,19 +1026,19 @@
                             <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Water'  />
                             <BiomeType name='Swamp'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * thm4WaterInfusedStoneFreq ' range=':= 0.969 * _default_ * thm4WaterInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.685 * _default_ * thm4WaterInfusedStoneFreq ' range=':= 0.685 * _default_ * thm4WaterInfusedStoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * thm4WaterInfusedStoneSize ' range=':= 0 * _default_ * thm4WaterInfusedStoneSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.984 * _default_ ' range=':= 0.984 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.828 * _default_ ' range=':= 0.828 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * thm4WaterInfusedStoneSize ' range=':= _default_ * thm4WaterInfusedStoneSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.992 * _default_ * thm4WaterInfusedStoneSize ' range=':= 0.992 * _default_ * thm4WaterInfusedStoneSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.910 * _default_ * thm4WaterInfusedStoneSize ' range=':= 0.910 * _default_ * thm4WaterInfusedStoneSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1071,9 +1071,9 @@
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:3")'> <OreBlock block='Thaumcraft:blockCustomOre:3' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.588 * _default_ * thm4WaterInfusedStoneSize ' range=':= 0.588 * _default_ * thm4WaterInfusedStoneSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.588 * _default_ * thm4WaterInfusedStoneSize ' range=':= 0.588 * _default_ * thm4WaterInfusedStoneSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.346 * _default_ * thm4WaterInfusedStoneFreq ' range=':= 0.346 * _default_ * thm4WaterInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.495 * _default_ * thm4WaterInfusedStoneSize ' range=':= 0.495 * _default_ * thm4WaterInfusedStoneSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.495 * _default_ * thm4WaterInfusedStoneSize ' range=':= 0.495 * _default_ * thm4WaterInfusedStoneSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.245 * _default_ * thm4WaterInfusedStoneFreq ' range=':= 0.245 * _default_ * thm4WaterInfusedStoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1118,9 +1118,9 @@
                             <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Water'  />
                             <BiomeType name='Swamp'  />
-                            <Setting name='CloudRadius' avg=':= 0.588 * _default_ * thm4WaterInfusedStoneSize ' range=':= 0.588 * _default_ * thm4WaterInfusedStoneSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.588 * _default_ * thm4WaterInfusedStoneSize ' range=':= 0.588 * _default_ * thm4WaterInfusedStoneSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.346 * _default_ * thm4WaterInfusedStoneFreq ' range=':= 0.346 * _default_ * thm4WaterInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.495 * _default_ * thm4WaterInfusedStoneSize ' range=':= 0.495 * _default_ * thm4WaterInfusedStoneSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.495 * _default_ * thm4WaterInfusedStoneSize ' range=':= 0.495 * _default_ * thm4WaterInfusedStoneSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.245 * _default_ * thm4WaterInfusedStoneFreq ' range=':= 0.245 * _default_ * thm4WaterInfusedStoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1156,8 +1156,8 @@
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:3")'> <OreBlock block='Thaumcraft:blockCustomOre:3' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 5.000 * thm4WaterInfusedStoneSize ' range=':= _default_ * thm4WaterInfusedStoneSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.000 * thm4WaterInfusedStoneFreq ' range=':= _default_ * thm4WaterInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.500 * thm4WaterInfusedStoneSize ' range=':= 2.500 * thm4WaterInfusedStoneSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 0.500 * thm4WaterInfusedStoneFreq ' range=':= 0.500 * thm4WaterInfusedStoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -1190,19 +1190,19 @@
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:4")'> <OreBlock block='Thaumcraft:blockCustomOre:4' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * thm4EarthInfusedStoneFreq ' range=':= 0.969 * _default_ * thm4EarthInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.685 * _default_ * thm4EarthInfusedStoneFreq ' range=':= 0.685 * _default_ * thm4EarthInfusedStoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * thm4EarthInfusedStoneSize ' range=':= 0 * _default_ * thm4EarthInfusedStoneSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.984 * _default_ ' range=':= 0.984 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.828 * _default_ ' range=':= 0.828 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * thm4EarthInfusedStoneSize ' range=':= _default_ * thm4EarthInfusedStoneSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.992 * _default_ * thm4EarthInfusedStoneSize ' range=':= 0.992 * _default_ * thm4EarthInfusedStoneSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.910 * _default_ * thm4EarthInfusedStoneSize ' range=':= 0.910 * _default_ * thm4EarthInfusedStoneSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1216,19 +1216,19 @@
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:4")'> <OreBlock block='Thaumcraft:blockCustomOre:4' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Forest'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * thm4EarthInfusedStoneFreq ' range=':= 0.969 * _default_ * thm4EarthInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.685 * _default_ * thm4EarthInfusedStoneFreq ' range=':= 0.685 * _default_ * thm4EarthInfusedStoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * thm4EarthInfusedStoneSize ' range=':= 0 * _default_ * thm4EarthInfusedStoneSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.984 * _default_ ' range=':= 0.984 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.828 * _default_ ' range=':= 0.828 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * thm4EarthInfusedStoneSize ' range=':= _default_ * thm4EarthInfusedStoneSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.992 * _default_ * thm4EarthInfusedStoneSize ' range=':= 0.992 * _default_ * thm4EarthInfusedStoneSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.910 * _default_ * thm4EarthInfusedStoneSize ' range=':= 0.910 * _default_ * thm4EarthInfusedStoneSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1261,9 +1261,9 @@
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:4")'> <OreBlock block='Thaumcraft:blockCustomOre:4' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.588 * _default_ * thm4EarthInfusedStoneSize ' range=':= 0.588 * _default_ * thm4EarthInfusedStoneSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.588 * _default_ * thm4EarthInfusedStoneSize ' range=':= 0.588 * _default_ * thm4EarthInfusedStoneSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.346 * _default_ * thm4EarthInfusedStoneFreq ' range=':= 0.346 * _default_ * thm4EarthInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.495 * _default_ * thm4EarthInfusedStoneSize ' range=':= 0.495 * _default_ * thm4EarthInfusedStoneSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.495 * _default_ * thm4EarthInfusedStoneSize ' range=':= 0.495 * _default_ * thm4EarthInfusedStoneSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.245 * _default_ * thm4EarthInfusedStoneFreq ' range=':= 0.245 * _default_ * thm4EarthInfusedStoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1307,9 +1307,9 @@
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:4")'> <OreBlock block='Thaumcraft:blockCustomOre:4' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Forest'  />
-                            <Setting name='CloudRadius' avg=':= 0.588 * _default_ * thm4EarthInfusedStoneSize ' range=':= 0.588 * _default_ * thm4EarthInfusedStoneSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.588 * _default_ * thm4EarthInfusedStoneSize ' range=':= 0.588 * _default_ * thm4EarthInfusedStoneSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.346 * _default_ * thm4EarthInfusedStoneFreq ' range=':= 0.346 * _default_ * thm4EarthInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.495 * _default_ * thm4EarthInfusedStoneSize ' range=':= 0.495 * _default_ * thm4EarthInfusedStoneSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.495 * _default_ * thm4EarthInfusedStoneSize ' range=':= 0.495 * _default_ * thm4EarthInfusedStoneSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.245 * _default_ * thm4EarthInfusedStoneFreq ' range=':= 0.245 * _default_ * thm4EarthInfusedStoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1345,8 +1345,8 @@
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:4")'> <OreBlock block='Thaumcraft:blockCustomOre:4' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 5.000 * thm4EarthInfusedStoneSize ' range=':= _default_ * thm4EarthInfusedStoneSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.000 * thm4EarthInfusedStoneFreq ' range=':= _default_ * thm4EarthInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.500 * thm4EarthInfusedStoneSize ' range=':= 2.500 * thm4EarthInfusedStoneSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 0.500 * thm4EarthInfusedStoneFreq ' range=':= 0.500 * thm4EarthInfusedStoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -1379,19 +1379,19 @@
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:5")'> <OreBlock block='Thaumcraft:blockCustomOre:5' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * thm4OrderInfusedStoneFreq ' range=':= 0.969 * _default_ * thm4OrderInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.685 * _default_ * thm4OrderInfusedStoneFreq ' range=':= 0.685 * _default_ * thm4OrderInfusedStoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * thm4OrderInfusedStoneSize ' range=':= 0 * _default_ * thm4OrderInfusedStoneSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.984 * _default_ ' range=':= 0.984 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.828 * _default_ ' range=':= 0.828 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * thm4OrderInfusedStoneSize ' range=':= _default_ * thm4OrderInfusedStoneSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.992 * _default_ * thm4OrderInfusedStoneSize ' range=':= 0.992 * _default_ * thm4OrderInfusedStoneSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.910 * _default_ * thm4OrderInfusedStoneSize ' range=':= 0.910 * _default_ * thm4OrderInfusedStoneSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1407,19 +1407,19 @@
                             <BiomeType name='Mushroom'  />
                             <BiomeType name='Mountain'  />
                             <BiomeType name='Magical'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * thm4OrderInfusedStoneFreq ' range=':= 0.969 * _default_ * thm4OrderInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.685 * _default_ * thm4OrderInfusedStoneFreq ' range=':= 0.685 * _default_ * thm4OrderInfusedStoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * thm4OrderInfusedStoneSize ' range=':= 0 * _default_ * thm4OrderInfusedStoneSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.984 * _default_ ' range=':= 0.984 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.828 * _default_ ' range=':= 0.828 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * thm4OrderInfusedStoneSize ' range=':= _default_ * thm4OrderInfusedStoneSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.992 * _default_ * thm4OrderInfusedStoneSize ' range=':= 0.992 * _default_ * thm4OrderInfusedStoneSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.910 * _default_ * thm4OrderInfusedStoneSize ' range=':= 0.910 * _default_ * thm4OrderInfusedStoneSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1452,9 +1452,9 @@
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:5")'> <OreBlock block='Thaumcraft:blockCustomOre:5' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.588 * _default_ * thm4OrderInfusedStoneSize ' range=':= 0.588 * _default_ * thm4OrderInfusedStoneSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.588 * _default_ * thm4OrderInfusedStoneSize ' range=':= 0.588 * _default_ * thm4OrderInfusedStoneSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.346 * _default_ * thm4OrderInfusedStoneFreq ' range=':= 0.346 * _default_ * thm4OrderInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.495 * _default_ * thm4OrderInfusedStoneSize ' range=':= 0.495 * _default_ * thm4OrderInfusedStoneSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.495 * _default_ * thm4OrderInfusedStoneSize ' range=':= 0.495 * _default_ * thm4OrderInfusedStoneSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.245 * _default_ * thm4OrderInfusedStoneFreq ' range=':= 0.245 * _default_ * thm4OrderInfusedStoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1500,9 +1500,9 @@
                             <BiomeType name='Mushroom'  />
                             <BiomeType name='Mountain'  />
                             <BiomeType name='Magical'  />
-                            <Setting name='CloudRadius' avg=':= 0.588 * _default_ * thm4OrderInfusedStoneSize ' range=':= 0.588 * _default_ * thm4OrderInfusedStoneSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.588 * _default_ * thm4OrderInfusedStoneSize ' range=':= 0.588 * _default_ * thm4OrderInfusedStoneSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.346 * _default_ * thm4OrderInfusedStoneFreq ' range=':= 0.346 * _default_ * thm4OrderInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.495 * _default_ * thm4OrderInfusedStoneSize ' range=':= 0.495 * _default_ * thm4OrderInfusedStoneSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.495 * _default_ * thm4OrderInfusedStoneSize ' range=':= 0.495 * _default_ * thm4OrderInfusedStoneSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.245 * _default_ * thm4OrderInfusedStoneFreq ' range=':= 0.245 * _default_ * thm4OrderInfusedStoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1538,8 +1538,8 @@
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:5")'> <OreBlock block='Thaumcraft:blockCustomOre:5' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 5.000 * thm4OrderInfusedStoneSize ' range=':= _default_ * thm4OrderInfusedStoneSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.000 * thm4OrderInfusedStoneFreq ' range=':= _default_ * thm4OrderInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.500 * thm4OrderInfusedStoneSize ' range=':= 2.500 * thm4OrderInfusedStoneSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 0.500 * thm4OrderInfusedStoneFreq ' range=':= 0.500 * thm4OrderInfusedStoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -1572,19 +1572,19 @@
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:6")'> <OreBlock block='Thaumcraft:blockCustomOre:6' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * thm4EntropyInfusedStoneFreq ' range=':= 0.969 * _default_ * thm4EntropyInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.685 * _default_ * thm4EntropyInfusedStoneFreq ' range=':= 0.685 * _default_ * thm4EntropyInfusedStoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * thm4EntropyInfusedStoneSize ' range=':= 0 * _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.984 * _default_ ' range=':= 0.984 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.828 * _default_ ' range=':= 0.828 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * thm4EntropyInfusedStoneSize ' range=':= _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.992 * _default_ * thm4EntropyInfusedStoneSize ' range=':= 0.992 * _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.910 * _default_ * thm4EntropyInfusedStoneSize ' range=':= 0.910 * _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1599,19 +1599,19 @@
                             <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Swamp'  />
                             <BiomeType name='Wasteland'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * thm4EntropyInfusedStoneFreq ' range=':= 0.969 * _default_ * thm4EntropyInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.685 * _default_ * thm4EntropyInfusedStoneFreq ' range=':= 0.685 * _default_ * thm4EntropyInfusedStoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * thm4EntropyInfusedStoneSize ' range=':= 0 * _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.984 * _default_ ' range=':= 0.984 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.828 * _default_ ' range=':= 0.828 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * thm4EntropyInfusedStoneSize ' range=':= _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.992 * _default_ * thm4EntropyInfusedStoneSize ' range=':= 0.992 * _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.910 * _default_ * thm4EntropyInfusedStoneSize ' range=':= 0.910 * _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1644,9 +1644,9 @@
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:6")'> <OreBlock block='Thaumcraft:blockCustomOre:6' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.588 * _default_ * thm4EntropyInfusedStoneSize ' range=':= 0.588 * _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.588 * _default_ * thm4EntropyInfusedStoneSize ' range=':= 0.588 * _default_ * thm4EntropyInfusedStoneSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.346 * _default_ * thm4EntropyInfusedStoneFreq ' range=':= 0.346 * _default_ * thm4EntropyInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.495 * _default_ * thm4EntropyInfusedStoneSize ' range=':= 0.495 * _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.495 * _default_ * thm4EntropyInfusedStoneSize ' range=':= 0.495 * _default_ * thm4EntropyInfusedStoneSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.245 * _default_ * thm4EntropyInfusedStoneFreq ' range=':= 0.245 * _default_ * thm4EntropyInfusedStoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1691,9 +1691,9 @@
                             <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Swamp'  />
                             <BiomeType name='Wasteland'  />
-                            <Setting name='CloudRadius' avg=':= 0.588 * _default_ * thm4EntropyInfusedStoneSize ' range=':= 0.588 * _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.588 * _default_ * thm4EntropyInfusedStoneSize ' range=':= 0.588 * _default_ * thm4EntropyInfusedStoneSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.346 * _default_ * thm4EntropyInfusedStoneFreq ' range=':= 0.346 * _default_ * thm4EntropyInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.495 * _default_ * thm4EntropyInfusedStoneSize ' range=':= 0.495 * _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.495 * _default_ * thm4EntropyInfusedStoneSize ' range=':= 0.495 * _default_ * thm4EntropyInfusedStoneSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.245 * _default_ * thm4EntropyInfusedStoneFreq ' range=':= 0.245 * _default_ * thm4EntropyInfusedStoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1731,8 +1731,8 @@
                             <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:6")'> <OreBlock block='Thaumcraft:blockCustomOre:6' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 5.000 * thm4EntropyInfusedStoneSize ' range=':= _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.000 * thm4EntropyInfusedStoneFreq ' range=':= _default_ * thm4EntropyInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.500 * thm4EntropyInfusedStoneSize ' range=':= 2.500 * thm4EntropyInfusedStoneSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 0.500 * thm4EntropyInfusedStoneFreq ' range=':= 0.500 * thm4EntropyInfusedStoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>

--- a/src/main/resources/config/modules/ThermalFoundation.xml
+++ b/src/main/resources/config/modules/ThermalFoundation.xml
@@ -288,19 +288,19 @@
                             <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore")'> <OreBlock block='ThermalFoundation:Ore' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.583 * _default_ * thfoCopperFreq ' range=':= 1.583 * _default_ * thfoCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.080 * _default_ * thfoCopperSize ' range=':= 1.080 * _default_ * thfoCopperSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.119 * _default_ * thfoCopperFreq ' range=':= 1.119 * _default_ * thfoCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.019 * _default_ * thfoCopperSize ' range=':= 1.019 * _default_ * thfoCopperSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 68 ' range=':= 28 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.258 * _default_ ' range=':= 1.258 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.058 * _default_ ' range=':= 1.058 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * thfoCopperSize ' range=':= _default_ * thfoCopperSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.122 * _default_ * thfoCopperSize ' range=':= 1.122 * _default_ * thfoCopperSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.029 * _default_ * thfoCopperSize ' range=':= 1.029 * _default_ * thfoCopperSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -330,9 +330,9 @@
                             <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore")'> <OreBlock block='ThermalFoundation:Ore' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.177 * _default_ * thfoCopperSize ' range=':= 1.177 * _default_ * thfoCopperSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.177 * _default_ * thfoCopperSize ' range=':= 1.177 * _default_ * thfoCopperSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.385 * _default_ * thfoCopperFreq ' range=':= 1.385 * _default_ * thfoCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.990 * _default_ * thfoCopperSize ' range=':= 0.990 * _default_ * thfoCopperSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.990 * _default_ * thfoCopperSize ' range=':= 0.990 * _default_ * thfoCopperSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.979 * _default_ * thfoCopperFreq ' range=':= 0.979 * _default_ * thfoCopperFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 68 ' range=':= 28 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -382,8 +382,8 @@
                             <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore")'> <OreBlock block='ThermalFoundation:Ore' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 8.000 * thfoCopperSize ' range=':= _default_ * thfoCopperSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 10.000 * thfoCopperFreq ' range=':= _default_ * thfoCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.000 * thfoCopperSize ' range=':= 4.000 * thfoCopperSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 5.000 * thfoCopperFreq ' range=':= 5.000 * thfoCopperFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 68 ' range=':= 28 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -407,19 +407,19 @@
                             <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:1")'> <OreBlock block='ThermalFoundation:Ore:1' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.416 * _default_ * thfoTinFreq ' range=':= 1.416 * _default_ * thfoTinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.060 * _default_ * thfoTinSize ' range=':= 1.060 * _default_ * thfoTinSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.001 * _default_ * thfoTinFreq ' range=':= 1.001 * _default_ * thfoTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.000 * _default_ * thfoTinSize ' range=':= 1.000 * _default_ * thfoTinSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 38 ' range=':= 17 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.190 * _default_ ' range=':= 1.190 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.000 * _default_ ' range=':= 1.000 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * thfoTinSize ' range=':= _default_ * thfoTinSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.091 * _default_ * thfoTinSize ' range=':= 1.091 * _default_ * thfoTinSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.000 * _default_ * thfoTinSize ' range=':= 1.000 * _default_ * thfoTinSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -449,9 +449,9 @@
                             <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:1")'> <OreBlock block='ThermalFoundation:Ore:1' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.113 * _default_ * thfoTinSize ' range=':= 1.113 * _default_ * thfoTinSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.113 * _default_ * thfoTinSize ' range=':= 1.113 * _default_ * thfoTinSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.239 * _default_ * thfoTinFreq ' range=':= 1.239 * _default_ * thfoTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.936 * _default_ * thfoTinSize ' range=':= 0.936 * _default_ * thfoTinSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.936 * _default_ * thfoTinSize ' range=':= 0.936 * _default_ * thfoTinSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.876 * _default_ * thfoTinFreq ' range=':= 0.876 * _default_ * thfoTinFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 38 ' range=':= 17 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -501,8 +501,8 @@
                             <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:1")'> <OreBlock block='ThermalFoundation:Ore:1' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 8.000 * thfoTinSize ' range=':= _default_ * thfoTinSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 8.000 * thfoTinFreq ' range=':= _default_ * thfoTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.000 * thfoTinSize ' range=':= 4.000 * thfoTinSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4.000 * thfoTinFreq ' range=':= 4.000 * thfoTinFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 38 ' range=':= 17 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -526,19 +526,19 @@
                             <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:2")'> <OreBlock block='ThermalFoundation:Ore:2' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.821 * _default_ * thfoSilverFreq ' range=':= _default_ * thfoSilverFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.968 * _default_ * thfoSilverSize ' range=':= _default_ * thfoSilverSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.867 * _default_ * thfoSilverFreq ' range=':= 0.867 * _default_ * thfoSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.976 * _default_ * thfoSilverSize ' range=':= 0.976 * _default_ * thfoSilverSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 18 ' range=':= 12 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.906 * _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.931 * _default_ ' range=':= 0.931 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * thfoSilverSize ' range=':= _default_ * thfoSilverSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.952 * _default_ * thfoSilverSize ' range=':= _default_ * thfoSilverSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.965 * _default_ * thfoSilverSize ' range=':= 0.965 * _default_ * thfoSilverSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -568,9 +568,9 @@
                             <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:2")'> <OreBlock block='ThermalFoundation:Ore:2' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.280 * _default_ * thfoSilverSize ' range=':= _default_ * thfoSilverSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.280 * _default_ * thfoSilverSize ' range=':= _default_ * thfoSilverSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.638  * _default_ * thfoSilverFreq ' range=':= _default_ * thfoSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.871 * _default_ * thfoSilverSize ' range=':= 0.871 * _default_ * thfoSilverSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.871 * _default_ * thfoSilverSize ' range=':= 0.871 * _default_ * thfoSilverSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.758 * _default_ * thfoSilverFreq ' range=':= 0.758 * _default_ * thfoSilverFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 18 ' range=':= 12 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -620,8 +620,8 @@
                             <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:2")'> <OreBlock block='ThermalFoundation:Ore:2' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 8 * thfoSilverSize ' range=':= _default_ * thfoSilverSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 6 * thfoSilverFreq ' range=':= _default_ * thfoSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.000 * thfoSilverSize ' range=':= 4.000 * thfoSilverSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 3.000 * thfoSilverFreq ' range=':= 3.000 * thfoSilverFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 18 ' range=':= 12 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -645,19 +645,19 @@
                             <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:3")'> <OreBlock block='ThermalFoundation:Ore:3' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.416 * _default_ * thfoLeadFreq ' range=':= 1.416 * _default_ * thfoLeadFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.060 * _default_ * thfoLeadSize ' range=':= 1.060 * _default_ * thfoLeadSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.001 * _default_ * thfoLeadFreq ' range=':= 1.001 * _default_ * thfoLeadFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.000 * _default_ * thfoLeadSize ' range=':= 1.000 * _default_ * thfoLeadSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 23 ' range=':= 12 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.190 * _default_ ' range=':= 1.190 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.000 * _default_ ' range=':= 1.000 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * thfoLeadSize ' range=':= _default_ * thfoLeadSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.091 * _default_ * thfoLeadSize ' range=':= 1.091 * _default_ * thfoLeadSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.000 * _default_ * thfoLeadSize ' range=':= 1.000 * _default_ * thfoLeadSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -687,9 +687,9 @@
                             <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:3")'> <OreBlock block='ThermalFoundation:Ore:3' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.113 * _default_ * thfoLeadSize ' range=':= 1.113 * _default_ * thfoLeadSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.113 * _default_ * thfoLeadSize ' range=':= 1.113 * _default_ * thfoLeadSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.239 * _default_ * thfoLeadFreq ' range=':= 1.239 * _default_ * thfoLeadFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.936 * _default_ * thfoLeadSize ' range=':= 0.936 * _default_ * thfoLeadSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.936 * _default_ * thfoLeadSize ' range=':= 0.936 * _default_ * thfoLeadSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.876 * _default_ * thfoLeadFreq ' range=':= 0.876 * _default_ * thfoLeadFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 23 ' range=':= 12 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -739,8 +739,8 @@
                             <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:3")'> <OreBlock block='ThermalFoundation:Ore:3' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 8.000 * thfoLeadSize ' range=':= _default_ * thfoLeadSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 8.000 * thfoLeadFreq ' range=':= _default_ * thfoLeadFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.000 * thfoLeadSize ' range=':= 4.000 * thfoLeadSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4.000 * thfoLeadFreq ' range=':= 4.000 * thfoLeadFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 23 ' range=':= 12 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -764,19 +764,19 @@
                             <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:4")'> <OreBlock block='ThermalFoundation:Ore:4' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.613 * _default_ * thfoNickelFreq ' range=':= 0.613 * _default_ * thfoNickelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * thfoNickelSize ' range=':= 0.922 * _default_ * thfoNickelSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.433 * _default_ * thfoNickelFreq ' range=':= 0.433 * _default_ * thfoNickelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.870 * _default_ * thfoNickelSize ' range=':= 0.870 * _default_ * thfoNickelSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 13 ' range=':= 7 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.783 * _default_ ' range=':= 0.783 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.658 * _default_ ' range=':= 0.658 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * thfoNickelSize ' range=':= _default_ * thfoNickelSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.885 * _default_ * thfoNickelSize ' range=':= 0.885 * _default_ * thfoNickelSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.811 * _default_ * thfoNickelSize ' range=':= 0.811 * _default_ * thfoNickelSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -806,9 +806,9 @@
                             <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:4")'> <OreBlock block='ThermalFoundation:Ore:4' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.732 * _default_ * thfoNickelSize ' range=':= 0.732 * _default_ * thfoNickelSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.732 * _default_ * thfoNickelSize ' range=':= 0.732 * _default_ * thfoNickelSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.536 * _default_ * thfoNickelFreq ' range=':= 0.536 * _default_ * thfoNickelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.616 * _default_ * thfoNickelSize ' range=':= 0.616 * _default_ * thfoNickelSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.616 * _default_ * thfoNickelSize ' range=':= 0.616 * _default_ * thfoNickelSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.379 * _default_ * thfoNickelFreq ' range=':= 0.379 * _default_ * thfoNickelFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 13 ' range=':= 7 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -858,8 +858,8 @@
                             <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:4")'> <OreBlock block='ThermalFoundation:Ore:4' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.000 * thfoNickelSize ' range=':= _default_ * thfoNickelSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 3.000 * thfoNickelFreq ' range=':= _default_ * thfoNickelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.000 * thfoNickelSize ' range=':= 2.000 * thfoNickelSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.500 * thfoNickelFreq ' range=':= 1.500 * thfoNickelFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 13 ' range=':= 7 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -883,19 +883,19 @@
                             <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:5")'> <OreBlock block='ThermalFoundation:Ore:5' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.306 * _default_ * thfoPlatinumFreq ' range=':= 0.306 * _default_ * thfoPlatinumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.821 * _default_ * thfoPlatinumSize ' range=':= 0.821 * _default_ * thfoPlatinumSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.217 * _default_ * thfoPlatinumFreq ' range=':= 0.217 * _default_ * thfoPlatinumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.775 * _default_ * thfoPlatinumSize ' range=':= 0.775 * _default_ * thfoPlatinumSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 18 ' range=':= 12 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.554 * _default_ ' range=':= 0.554 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.466 * _default_ ' range=':= 0.466 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * thfoPlatinumSize ' range=':= _default_ * thfoPlatinumSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.744 * _default_ * thfoPlatinumSize ' range=':= 0.744 * _default_ * thfoPlatinumSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.682 * _default_ * thfoPlatinumSize ' range=':= 0.682 * _default_ * thfoPlatinumSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -925,9 +925,9 @@
                             <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:5")'> <OreBlock block='ThermalFoundation:Ore:5' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.518 * _default_ * thfoPlatinumSize ' range=':= 0.518 * _default_ * thfoPlatinumSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.518 * _default_ * thfoPlatinumSize ' range=':= 0.518 * _default_ * thfoPlatinumSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.268 * _default_ * thfoPlatinumFreq ' range=':= 0.268 * _default_ * thfoPlatinumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.435 * _default_ * thfoPlatinumSize ' range=':= 0.435 * _default_ * thfoPlatinumSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.435 * _default_ * thfoPlatinumSize ' range=':= 0.435 * _default_ * thfoPlatinumSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.190 * _default_ * thfoPlatinumFreq ' range=':= 0.190 * _default_ * thfoPlatinumFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 18 ' range=':= 12 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -977,8 +977,8 @@
                             <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:5")'> <OreBlock block='ThermalFoundation:Ore:5' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3.000 * thfoPlatinumSize ' range=':= _default_ * thfoPlatinumSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.000 * thfoPlatinumFreq ' range=':= _default_ * thfoPlatinumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 1.500 * thfoPlatinumSize ' range=':= 1.500 * thfoPlatinumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 0.500 * thfoPlatinumFreq ' range=':= 0.500 * thfoPlatinumFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 18 ' range=':= 12 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>

--- a/src/main/resources/config/modules/TinkersConstruct.xml
+++ b/src/main/resources/config/modules/TinkersConstruct.xml
@@ -475,19 +475,19 @@
                             <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:3")'> <OreBlock block='TConstruct:SearedBrick:3' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.708 * _default_ * ticoCopperFreq ' range=':= 0.708 * _default_ * ticoCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.944 * _default_ * ticoCopperSize ' range=':= 0.944 * _default_ * ticoCopperSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.500 * _default_ * ticoCopperFreq ' range=':= 0.500 * _default_ * ticoCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.891 * _default_ * ticoCopperSize ' range=':= 0.891 * _default_ * ticoCopperSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 40 ' range=':= 20 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.841 * _default_ ' range=':= 0.841 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.707 * _default_ ' range=':= 0.707 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * ticoCopperSize ' range=':= _default_ * ticoCopperSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.917 * _default_ * ticoCopperSize ' range=':= 0.917 * _default_ * ticoCopperSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.841 * _default_ * ticoCopperSize ' range=':= 0.841 * _default_ * ticoCopperSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -517,9 +517,9 @@
                             <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:3")'> <OreBlock block='TConstruct:SearedBrick:3' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.787 * _default_ * ticoCopperSize ' range=':= 0.787 * _default_ * ticoCopperSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.787 * _default_ * ticoCopperSize ' range=':= 0.787 * _default_ * ticoCopperSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.619 * _default_ * ticoCopperFreq ' range=':= 0.619 * _default_ * ticoCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.662 * _default_ * ticoCopperSize ' range=':= 0.662 * _default_ * ticoCopperSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.662 * _default_ * ticoCopperSize ' range=':= 0.662 * _default_ * ticoCopperSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.438 * _default_ * ticoCopperFreq ' range=':= 0.438 * _default_ * ticoCopperFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 40 ' range=':= 20 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -569,8 +569,8 @@
                             <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:3")'> <OreBlock block='TConstruct:SearedBrick:3' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 8.000 * ticoCopperSize ' range=':= _default_ * ticoCopperSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2.000 * ticoCopperFreq ' range=':= _default_ * ticoCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.000 * ticoCopperSize ' range=':= 4.000 * ticoCopperSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.000 * ticoCopperFreq ' range=':= 1.000 * ticoCopperFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 40 ' range=':= 20 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -594,19 +594,19 @@
                             <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:4")'> <OreBlock block='TConstruct:SearedBrick:4' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.708 * _default_ * ticoTinFreq ' range=':= 0.708 * _default_ * ticoTinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.944 * _default_ * ticoTinSize ' range=':= 0.944 * _default_ * ticoTinSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.500 * _default_ * ticoTinFreq ' range=':= 0.500 * _default_ * ticoTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.891 * _default_ * ticoTinSize ' range=':= 0.891 * _default_ * ticoTinSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 23 ' range=':= 17 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.841 * _default_ ' range=':= 0.841 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.707 * _default_ ' range=':= 0.707 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * ticoTinSize ' range=':= _default_ * ticoTinSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.917 * _default_ * ticoTinSize ' range=':= 0.917 * _default_ * ticoTinSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.841 * _default_ * ticoTinSize ' range=':= 0.841 * _default_ * ticoTinSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -636,9 +636,9 @@
                             <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:4")'> <OreBlock block='TConstruct:SearedBrick:4' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.787 * _default_ * ticoTinSize ' range=':= 0.787 * _default_ * ticoTinSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.787 * _default_ * ticoTinSize ' range=':= 0.787 * _default_ * ticoTinSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.619 * _default_ * ticoTinFreq ' range=':= 0.619 * _default_ * ticoTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.662 * _default_ * ticoTinSize ' range=':= 0.662 * _default_ * ticoTinSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.662 * _default_ * ticoTinSize ' range=':= 0.662 * _default_ * ticoTinSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.438 * _default_ * ticoTinFreq ' range=':= 0.438 * _default_ * ticoTinFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 23 ' range=':= 17 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -688,8 +688,8 @@
                             <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:4")'> <OreBlock block='TConstruct:SearedBrick:4' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 8.000 * ticoTinSize ' range=':= _default_ * ticoTinSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2.000 * ticoTinFreq ' range=':= _default_ * ticoTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.000 * ticoTinSize ' range=':= 4.000 * ticoTinSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.000 * ticoTinFreq ' range=':= 1.000 * ticoTinFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 23 ' range=':= 17 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -713,19 +713,19 @@
                             <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:5")'> <OreBlock block='TConstruct:SearedBrick:5' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.751 * _default_ * ticoAluminumFreq ' range=':= 0.751 * _default_ * ticoAluminumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.953 * _default_ * ticoAluminumSize ' range=':= 0.953 * _default_ * ticoAluminumSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.531 * _default_ * ticoAluminumFreq ' range=':= 0.531 * _default_ * ticoAluminumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.900 * _default_ * ticoAluminumSize ' range=':= 0.900 * _default_ * ticoAluminumSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 35 ' range=':= 29 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.866 * _default_ ' range=':= 0.866 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.729 * _default_ ' range=':= 0.729 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * ticoAluminumSize ' range=':= _default_ * ticoAluminumSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.931 * _default_ * ticoAluminumSize ' range=':= 0.931 * _default_ * ticoAluminumSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.854 * _default_ * ticoAluminumSize ' range=':= 0.854 * _default_ * ticoAluminumSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -755,9 +755,9 @@
                             <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:5")'> <OreBlock block='TConstruct:SearedBrick:5' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.810 * _default_ * ticoAluminumSize ' range=':= 0.810 * _default_ * ticoAluminumSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.810 * _default_ * ticoAluminumSize ' range=':= 0.810 * _default_ * ticoAluminumSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.657 * _default_ * ticoAluminumFreq ' range=':= 0.657 * _default_ * ticoAluminumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.682 * _default_ * ticoAluminumSize ' range=':= 0.682 * _default_ * ticoAluminumSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.682 * _default_ * ticoAluminumSize ' range=':= 0.682 * _default_ * ticoAluminumSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.464 * _default_ * ticoAluminumFreq ' range=':= 0.464 * _default_ * ticoAluminumFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 35 ' range=':= 29 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -807,8 +807,8 @@
                             <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:5")'> <OreBlock block='TConstruct:SearedBrick:5' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 6.000 * ticoAluminumSize ' range=':= _default_ * ticoAluminumSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 3.000 * ticoAluminumFreq ' range=':= _default_ * ticoAluminumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 3.000 * ticoAluminumSize ' range=':= 3.000 * ticoAluminumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.500 * ticoAluminumFreq ' range=':= 1.500 * ticoAluminumFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 35 ' range=':= 29 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -832,19 +832,19 @@
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre")'> <OreBlock block='TConstruct:GravelOre' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='gravel' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 2.238 * _default_ * ticoIronGravelFreq ' range=':= 2.238 * _default_ * ticoIronGravelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.144 * _default_ * ticoIronGravelSize ' range=':= 1.144 * _default_ * ticoIronGravelSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.583 * _default_ * ticoIronGravelFreq ' range=':= 1.583 * _default_ * ticoIronGravelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.080 * _default_ * ticoIronGravelSize ' range=':= 1.080 * _default_ * ticoIronGravelSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 36 ' range=':= 31 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.496 * _default_ ' range=':= 1.496 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.258 * _default_ ' range=':= 1.258 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * ticoIronGravelSize ' range=':= _default_ * ticoIronGravelSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.223 * _default_ * ticoIronGravelSize ' range=':= 1.223 * _default_ * ticoIronGravelSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.122 * _default_ * ticoIronGravelSize ' range=':= 1.122 * _default_ * ticoIronGravelSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -874,9 +874,9 @@
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre")'> <OreBlock block='TConstruct:GravelOre' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='gravel' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.399 * _default_ * ticoIronGravelSize ' range=':= 1.399 * _default_ * ticoIronGravelSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.399 * _default_ * ticoIronGravelSize ' range=':= 1.399 * _default_ * ticoIronGravelSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.958 * _default_ * ticoIronGravelFreq ' range=':= 1.958 * _default_ * ticoIronGravelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 1.177 * _default_ * ticoIronGravelSize ' range=':= 1.177 * _default_ * ticoIronGravelSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 1.177 * _default_ * ticoIronGravelSize ' range=':= 1.177 * _default_ * ticoIronGravelSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 1.385 * _default_ * ticoIronGravelFreq ' range=':= 1.385 * _default_ * ticoIronGravelFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 36 ' range=':= 31 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -926,8 +926,8 @@
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre")'> <OreBlock block='TConstruct:GravelOre' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='gravel' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 8.000 * ticoIronGravelSize ' range=':= _default_ * ticoIronGravelSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 20.000 * ticoIronGravelFreq ' range=':= _default_ * ticoIronGravelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.000 * ticoIronGravelSize ' range=':= 4.000 * ticoIronGravelSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 10.000 * ticoIronGravelFreq ' range=':= 10.000 * ticoIronGravelFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 36 ' range=':= 31 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -951,19 +951,19 @@
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:1")'> <OreBlock block='TConstruct:GravelOre:1' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='gravel' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.708 * _default_ * ticoGoldGravelFreq ' range=':= 0.708 * _default_ * ticoGoldGravelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.944 * _default_ * ticoGoldGravelSize ' range=':= 0.944 * _default_ * ticoGoldGravelSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.500 * _default_ * ticoGoldGravelFreq ' range=':= 0.500 * _default_ * ticoGoldGravelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.891 * _default_ * ticoGoldGravelSize ' range=':= 0.891 * _default_ * ticoGoldGravelSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 19 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.841 * _default_ ' range=':= 0.841 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.707 * _default_ ' range=':= 0.707 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * ticoGoldGravelSize ' range=':= _default_ * ticoGoldGravelSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.917 * _default_ * ticoGoldGravelSize ' range=':= 0.917 * _default_ * ticoGoldGravelSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.841 * _default_ * ticoGoldGravelSize ' range=':= 0.841 * _default_ * ticoGoldGravelSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -993,9 +993,9 @@
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:1")'> <OreBlock block='TConstruct:GravelOre:1' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='gravel' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.787 * _default_ * ticoGoldGravelSize ' range=':= 0.787 * _default_ * ticoGoldGravelSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.787 * _default_ * ticoGoldGravelSize ' range=':= 0.787 * _default_ * ticoGoldGravelSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.619 * _default_ * ticoGoldGravelFreq ' range=':= 0.619 * _default_ * ticoGoldGravelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.662 * _default_ * ticoGoldGravelSize ' range=':= 0.662 * _default_ * ticoGoldGravelSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.662 * _default_ * ticoGoldGravelSize ' range=':= 0.662 * _default_ * ticoGoldGravelSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.438 * _default_ * ticoGoldGravelFreq ' range=':= 0.438 * _default_ * ticoGoldGravelFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 19 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1045,8 +1045,8 @@
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:1")'> <OreBlock block='TConstruct:GravelOre:1' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='gravel' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 8.000 * ticoGoldGravelSize ' range=':= _default_ * ticoGoldGravelSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2.000 * ticoGoldGravelFreq ' range=':= _default_ * ticoGoldGravelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.000 * ticoGoldGravelSize ' range=':= 4.000 * ticoGoldGravelSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.000 * ticoGoldGravelFreq ' range=':= 1.000 * ticoGoldGravelFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 19 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -1070,19 +1070,19 @@
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:2")'> <OreBlock block='TConstruct:GravelOre:2' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='gravel' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.583 * _default_ * ticoCopperGravelFreq ' range=':= 1.583 * _default_ * ticoCopperGravelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.080 * _default_ * ticoCopperGravelSize ' range=':= 1.080 * _default_ * ticoCopperGravelSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 40 ' range=':= 20 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.500 * _default_ * ticoCopperGravelFreq ' range=':= 0.500 * _default_ * ticoCopperGravelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.891 * _default_ * ticoCopperGravelSize ' range=':= 0.891 * _default_ * ticoCopperGravelSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 68 ' range=':= 28 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.258 * _default_ ' range=':= 1.258 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.707 * _default_ ' range=':= 0.707 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * ticoCopperGravelSize ' range=':= _default_ * ticoCopperGravelSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.122 * _default_ * ticoCopperGravelSize ' range=':= 1.122 * _default_ * ticoCopperGravelSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.841 * _default_ * ticoCopperGravelSize ' range=':= 0.841 * _default_ * ticoCopperGravelSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1113,10 +1113,10 @@
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:2")'> <OreBlock block='TConstruct:GravelOre:2' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='gravel' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.177 * _default_ * ticoCopperGravelSize ' range=':= 1.177 * _default_ * ticoCopperGravelSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.177 * _default_ * ticoCopperGravelSize ' range=':= 1.177 * _default_ * ticoCopperGravelSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.385 * _default_ * ticoCopperGravelFreq ' range=':= 1.385 * _default_ * ticoCopperGravelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 40 ' range=':= 20 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.662 * _default_ * ticoCopperGravelSize ' range=':= 0.662 * _default_ * ticoCopperGravelSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.662 * _default_ * ticoCopperGravelSize ' range=':= 0.662 * _default_ * ticoCopperGravelSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.438 * _default_ * ticoCopperGravelFreq ' range=':= 0.438 * _default_ * ticoCopperGravelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 68 ' range=':= 28 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1165,9 +1165,9 @@
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:2")'> <OreBlock block='TConstruct:GravelOre:2' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='gravel' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 8.000 * ticoCopperGravelSize ' range=':= _default_ * ticoCopperGravelSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 10.000 * ticoCopperGravelFreq ' range=':= _default_ * ticoCopperGravelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 40 ' range=':= 20 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.000 * ticoCopperGravelSize ' range=':= 4.000 * ticoCopperGravelSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.000 * ticoCopperGravelFreq ' range=':= 1.000 * ticoCopperGravelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 68 ' range=':= 28 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1190,19 +1190,19 @@
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:3")'> <OreBlock block='TConstruct:GravelOre:3' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='gravel' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.416 * _default_ * ticoTinGravelFreq ' range=':= 1.416 * _default_ * ticoTinGravelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.060 * _default_ * ticoTinGravelSize ' range=':= 1.060 * _default_ * ticoTinGravelSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.001 * _default_ * ticoTinGravelFreq ' range=':= 1.001 * _default_ * ticoTinGravelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.000 * _default_ * ticoTinGravelSize ' range=':= 1.000 * _default_ * ticoTinGravelSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 38 ' range=':= 17 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.190 * _default_ ' range=':= 1.190 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 1.000 * _default_ ' range=':= 1.000 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * ticoTinGravelSize ' range=':= _default_ * ticoTinGravelSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.091 * _default_ * ticoTinGravelSize ' range=':= 1.091 * _default_ * ticoTinGravelSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 1.000 * _default_ * ticoTinGravelSize ' range=':= 1.000 * _default_ * ticoTinGravelSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1232,9 +1232,9 @@
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:3")'> <OreBlock block='TConstruct:GravelOre:3' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='gravel' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.113 * _default_ * ticoTinGravelSize ' range=':= 1.113 * _default_ * ticoTinGravelSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.113 * _default_ * ticoTinGravelSize ' range=':= 1.113 * _default_ * ticoTinGravelSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.239 * _default_ * ticoTinGravelFreq ' range=':= 1.239 * _default_ * ticoTinGravelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.936 * _default_ * ticoTinGravelSize ' range=':= 0.936 * _default_ * ticoTinGravelSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.936 * _default_ * ticoTinGravelSize ' range=':= 0.936 * _default_ * ticoTinGravelSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.876 * _default_ * ticoTinGravelFreq ' range=':= 0.876 * _default_ * ticoTinGravelFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 38 ' range=':= 17 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1284,8 +1284,8 @@
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:3")'> <OreBlock block='TConstruct:GravelOre:3' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='gravel' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 8.000 * ticoTinGravelSize ' range=':= _default_ * ticoTinGravelSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 8.000 * ticoTinGravelFreq ' range=':= _default_ * ticoTinGravelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.000 * ticoTinGravelSize ' range=':= 4.000 * ticoTinGravelSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4.000 * ticoTinGravelFreq ' range=':= 4.000 * ticoTinGravelFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 38 ' range=':= 17 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -1309,19 +1309,19 @@
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:4")'> <OreBlock block='TConstruct:GravelOre:4' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='gravel' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.751 * _default_ * ticoAluminumGravelFreq ' range=':= 0.751 * _default_ * ticoAluminumGravelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.953 * _default_ * ticoAluminumGravelSize ' range=':= 0.953 * _default_ * ticoAluminumGravelSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.531 * _default_ * ticoAluminumGravelFreq ' range=':= 0.531 * _default_ * ticoAluminumGravelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.900 * _default_ * ticoAluminumGravelSize ' range=':= 0.900 * _default_ * ticoAluminumGravelSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 35 ' range=':= 29 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.866 * _default_ ' range=':= 0.866 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.729 * _default_ ' range=':= 0.729 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * ticoAluminumGravelSize ' range=':= _default_ * ticoAluminumGravelSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.931 * _default_ * ticoAluminumGravelSize ' range=':= 0.931 * _default_ * ticoAluminumGravelSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.854 * _default_ * ticoAluminumGravelSize ' range=':= 0.854 * _default_ * ticoAluminumGravelSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1352,9 +1352,9 @@
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:4")'> <OreBlock block='TConstruct:GravelOre:4' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='gravel' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.810 * _default_ * ticoAluminumGravelSize ' range=':= 0.810 * _default_ * ticoAluminumGravelSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.810 * _default_ * ticoAluminumGravelSize ' range=':= 0.810 * _default_ * ticoAluminumGravelSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.657 * _default_ * ticoAluminumGravelFreq ' range=':= 0.657 * _default_ * ticoAluminumGravelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.682 * _default_ * ticoAluminumGravelSize ' range=':= 0.682 * _default_ * ticoAluminumGravelSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.682 * _default_ * ticoAluminumGravelSize ' range=':= 0.682 * _default_ * ticoAluminumGravelSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.464 * _default_ * ticoAluminumGravelFreq ' range=':= 0.464 * _default_ * ticoAluminumGravelFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 35 ' range=':= 29 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1404,8 +1404,8 @@
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:4")'> <OreBlock block='TConstruct:GravelOre:4' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='gravel' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 6.000 * ticoAluminumGravelSize ' range=':= _default_ * ticoAluminumGravelSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 3.000 * ticoAluminumGravelFreq ' range=':= _default_ * ticoAluminumGravelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 3.000 * ticoAluminumGravelSize ' range=':= 3.000 * ticoAluminumGravelSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.500 * ticoAluminumGravelFreq ' range=':= 1.500 * ticoAluminumGravelFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 35 ' range=':= 29 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -1479,8 +1479,8 @@
                             <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:1")'> <OreBlock block='TConstruct:SearedBrick:1' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.084 * _default_ * ticoCobaltFreq ' range=':= 1.084 * _default_ * ticoCobaltFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.014 * _default_ * ticoCobaltSize ' range=':= 1.014 * _default_ * ticoCobaltSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.767 * _default_ * ticoCobaltFreq ' range=':= 0.767 * _default_ * ticoCobaltFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.957 * _default_ * ticoCobaltSize ' range=':= 0.957 * _default_ * ticoCobaltSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 64 ' range=':= 64 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1521,9 +1521,9 @@
                             <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:1")'> <OreBlock block='TConstruct:SearedBrick:1' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.871 * _default_ * ticoCobaltSize ' range=':= 0.871 * _default_ * ticoCobaltSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.871 * _default_ * ticoCobaltSize ' range=':= 0.871 * _default_ * ticoCobaltSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.758 * _default_ * ticoCobaltFreq ' range=':= 0.758 * _default_ * ticoCobaltFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.732 * _default_ * ticoCobaltSize ' range=':= 0.732 * _default_ * ticoCobaltSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.732 * _default_ * ticoCobaltSize ' range=':= 0.732 * _default_ * ticoCobaltSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.536 * _default_ * ticoCobaltFreq ' range=':= 0.536 * _default_ * ticoCobaltFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 64 ' range=':= 64 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1573,8 +1573,8 @@
                             <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:1")'> <OreBlock block='TConstruct:SearedBrick:1' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3.000 * ticoCobaltSize ' range=':= _default_ * ticoCobaltSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 8.000 * ticoCobaltFreq ' range=':= _default_ * ticoCobaltFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 1.500 * ticoCobaltSize ' range=':= 1.500 * ticoCobaltSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4.000 * ticoCobaltFreq ' range=':= 4.000 * ticoCobaltFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 64 ' range=':= 64 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -1600,8 +1600,8 @@
                             <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:2")'> <OreBlock block='TConstruct:SearedBrick:2' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.084 * _default_ * ticoArditeFreq ' range=':= 1.084 * _default_ * ticoArditeFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.014 * _default_ * ticoArditeSize ' range=':= 1.014 * _default_ * ticoArditeSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.767 * _default_ * ticoArditeFreq ' range=':= 0.767 * _default_ * ticoArditeFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.957 * _default_ * ticoArditeSize ' range=':= 0.957 * _default_ * ticoArditeSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 64 ' range=':= 64 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1642,9 +1642,9 @@
                             <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:2")'> <OreBlock block='TConstruct:SearedBrick:2' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.871 * _default_ * ticoArditeSize ' range=':= 0.871 * _default_ * ticoArditeSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.871 * _default_ * ticoArditeSize ' range=':= 0.871 * _default_ * ticoArditeSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.758 * _default_ * ticoArditeFreq ' range=':= 0.758 * _default_ * ticoArditeFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.732 * _default_ * ticoArditeSize ' range=':= 0.732 * _default_ * ticoArditeSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.732 * _default_ * ticoArditeSize ' range=':= 0.732 * _default_ * ticoArditeSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.536 * _default_ * ticoArditeFreq ' range=':= 0.536 * _default_ * ticoArditeFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 64 ' range=':= 64 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1694,8 +1694,8 @@
                             <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:2")'> <OreBlock block='TConstruct:SearedBrick:2' weight='1.0' /> </IfCondition>
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3.000 * ticoArditeSize ' range=':= _default_ * ticoArditeSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 8.000 * ticoArditeFreq ' range=':= _default_ * ticoArditeFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 1.500 * ticoArditeSize ' range=':= 1.500 * ticoArditeSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4.000 * ticoArditeFreq ' range=':= 4.000 * ticoArditeFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 64 ' range=':= 64 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -1720,19 +1720,19 @@
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:5")'> <OreBlock block='TConstruct:GravelOre:5' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='gravel' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.867 * _default_ * ticoNetherCobaltGravelFreq ' range=':= 0.867 * _default_ * ticoNetherCobaltGravelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.976 * _default_ * ticoNetherCobaltGravelSize ' range=':= 0.976 * _default_ * ticoNetherCobaltGravelSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.613 * _default_ * ticoNetherCobaltGravelFreq ' range=':= 0.613 * _default_ * ticoNetherCobaltGravelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * ticoNetherCobaltGravelSize ' range=':= 0.922 * _default_ * ticoNetherCobaltGravelSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 64 ' range=':= 64 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.931 * _default_ ' range=':= 0.931 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.783 * _default_ ' range=':= 0.783 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * ticoNetherCobaltGravelSize ' range=':= _default_ * ticoNetherCobaltGravelSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.965 * _default_ * ticoNetherCobaltGravelSize ' range=':= 0.965 * _default_ * ticoNetherCobaltGravelSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.885 * _default_ * ticoNetherCobaltGravelSize ' range=':= 0.885 * _default_ * ticoNetherCobaltGravelSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1763,9 +1763,9 @@
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:5")'> <OreBlock block='TConstruct:GravelOre:5' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='gravel' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.871 * _default_ * ticoNetherCobaltGravelSize ' range=':= 0.871 * _default_ * ticoNetherCobaltGravelSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.871 * _default_ * ticoNetherCobaltGravelSize ' range=':= 0.871 * _default_ * ticoNetherCobaltGravelSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.758 * _default_ * ticoNetherCobaltGravelFreq ' range=':= 0.758 * _default_ * ticoNetherCobaltGravelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.732 * _default_ * ticoNetherCobaltGravelSize ' range=':= 0.732 * _default_ * ticoNetherCobaltGravelSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.732 * _default_ * ticoNetherCobaltGravelSize ' range=':= 0.732 * _default_ * ticoNetherCobaltGravelSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.536 * _default_ * ticoNetherCobaltGravelFreq ' range=':= 0.536 * _default_ * ticoNetherCobaltGravelFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 64 ' range=':= 64 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1816,8 +1816,8 @@
                             <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:5")'> <OreBlock block='TConstruct:GravelOre:5' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='gravel' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3.000 * ticoNetherCobaltGravelSize ' range=':= _default_ * ticoNetherCobaltGravelSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 8.000 * ticoNetherCobaltGravelFreq ' range=':= _default_ * ticoNetherCobaltGravelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 1.500 * ticoNetherCobaltGravelSize ' range=':= 1.500 * ticoNetherCobaltGravelSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4.000 * ticoNetherCobaltGravelFreq ' range=':= 4.000 * ticoNetherCobaltGravelFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 64 ' range=':= 64 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>

--- a/src/main/resources/config/modules/TinkersSteelworks.xml
+++ b/src/main/resources/config/modules/TinkersSteelworks.xml
@@ -101,8 +101,8 @@
                             <IfCondition condition=':= ?blockExists("TSteelworks:Limestone")'> <OreBlock block='TSteelworks:Limestone' weight='1.0' /> </IfCondition>
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 32.000 * tiswLimestoneSize ' range=':= _default_ * tiswLimestoneSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2.000 * tiswLimestoneFreq ' range=':= _default_ * tiswLimestoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 16.000 * tiswLimestoneSize ' range=':= 16.000 * tiswLimestoneSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.000 * tiswLimestoneFreq ' range=':= 1.000 * tiswLimestoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 38 ' range=':= 26 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>

--- a/src/main/resources/config/modules/VanillaMinecraft.xml
+++ b/src/main/resources/config/modules/VanillaMinecraft.xml
@@ -561,8 +561,8 @@
                     <IfCondition condition=':= ?blockExists("minecraft:coal_ore")'> <OreBlock block='minecraft:coal_ore' weight='1.0' /> </IfCondition>
                     <ReplacesOre block='stone' weight='1.0' />
                     <Biome name='.*'  />
-                    <Setting name='Size' avg=':= 16.000 * vnlaCoalSize ' range=':= _default_ * vnlaCoalSize ' type='normal' />
-                    <Setting name='Frequency' avg=':= 20.000 * vnlaCoalFreq ' range=':= _default_ * vnlaCoalFreq ' type='normal' scaleTo='base' />
+                    <Setting name='Size' avg=':= 8.000 * vnlaCoalSize ' range=':= 8.000 * vnlaCoalSize ' type='normal' />
+                    <Setting name='Frequency' avg=':= 10.000 * vnlaCoalFreq ' range=':= 10.000 * vnlaCoalFreq ' type='normal' scaleTo='base' />
                     <Setting name='Height' avg=':= 64 ' range=':= 64 ' type='normal' scaleTo='base' />
                     <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                 </StandardGen>
@@ -675,8 +675,8 @@
                     <IfCondition condition=':= ?blockExists("minecraft:iron_ore")'> <OreBlock block='minecraft:iron_ore' weight='1.0' /> </IfCondition>
                     <ReplacesOre block='stone' weight='1.0' />
                     <Biome name='.*'  />
-                    <Setting name='Size' avg=':= 8.000 * vnlaIronSize ' range=':= _default_ * vnlaIronSize ' type='normal' />
-                    <Setting name='Frequency' avg=':= 20.000 * vnlaIronFreq ' range=':= _default_ * vnlaIronFreq ' type='normal' scaleTo='base' />
+                    <Setting name='Size' avg=':= 4.000 * vnlaIronSize ' range=':= 4.000 * vnlaIronSize ' type='normal' />
+                    <Setting name='Frequency' avg=':= 10.000 * vnlaIronFreq ' range=':= 10.000 * vnlaIronFreq ' type='normal' scaleTo='base' />
                     <Setting name='Height' avg=':= 32 ' range=':= 32 ' type='normal' scaleTo='base' />
                     <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                 </StandardGen>
@@ -789,8 +789,8 @@
                     <IfCondition condition=':= ?blockExists("minecraft:gold_ore")'> <OreBlock block='minecraft:gold_ore' weight='1.0' /> </IfCondition>
                     <ReplacesOre block='stone' weight='1.0' />
                     <Biome name='.*'  />
-                    <Setting name='Size' avg=':= 8.000 * vnlaGoldSize ' range=':= _default_ * vnlaGoldSize ' type='normal' />
-                    <Setting name='Frequency' avg=':= 2.000 * vnlaGoldFreq ' range=':= _default_ * vnlaGoldFreq ' type='normal' scaleTo='base' />
+                    <Setting name='Size' avg=':= 4.000 * vnlaGoldSize ' range=':= 4.000 * vnlaGoldSize ' type='normal' />
+                    <Setting name='Frequency' avg=':= 1.000 * vnlaGoldFreq ' range=':= 1.000 * vnlaGoldFreq ' type='normal' scaleTo='base' />
                     <Setting name='Height' avg=':= 16 ' range=':= 16 ' type='normal' scaleTo='base' />
                     <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                 </StandardGen>
@@ -931,8 +931,8 @@
                     <IfCondition condition=':= ?blockExists("minecraft:redstone_ore")'> <OreBlock block='minecraft:redstone_ore' weight='1.0' /> </IfCondition>
                     <ReplacesOre block='stone' weight='1.0' />
                     <Biome name='.*'  />
-                    <Setting name='Size' avg=':= 7.000 * vnlaRedstoneSize ' range=':= _default_ * vnlaRedstoneSize ' type='normal' />
-                    <Setting name='Frequency' avg=':= 8.000 * vnlaRedstoneFreq ' range=':= _default_ * vnlaRedstoneFreq ' type='normal' scaleTo='base' />
+                    <Setting name='Size' avg=':= 3.500 * vnlaRedstoneSize ' range=':= 3.500 * vnlaRedstoneSize ' type='normal' />
+                    <Setting name='Frequency' avg=':= 4.000 * vnlaRedstoneFreq ' range=':= 4.000 * vnlaRedstoneFreq ' type='normal' scaleTo='base' />
                     <Setting name='Height' avg=':= 8 ' range=':= 8 ' type='normal' scaleTo='base' />
                     <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                 </StandardGen>
@@ -1087,8 +1087,8 @@
                     <IfCondition condition=':= ?blockExists("minecraft:diamond_ore")'> <OreBlock block='minecraft:diamond_ore' weight='1.0' /> </IfCondition>
                     <ReplacesOre block='stone' weight='1.0' />
                     <Biome name='.*'  />
-                    <Setting name='Size' avg=':= 7.000 * vnlaDiamondSize ' range=':= _default_ * vnlaDiamondSize ' type='normal' />
-                    <Setting name='Frequency' avg=':= 1.000 * vnlaDiamondFreq ' range=':= _default_ * vnlaDiamondFreq ' type='normal' scaleTo='base' />
+                    <Setting name='Size' avg=':= 3.500 * vnlaDiamondSize ' range=':= 3.500 * vnlaDiamondSize ' type='normal' />
+                    <Setting name='Frequency' avg=':= 0.500 * vnlaDiamondFreq ' range=':= 0.500 * vnlaDiamondFreq ' type='normal' scaleTo='base' />
                     <Setting name='Height' avg=':= 8 ' range=':= 8 ' type='normal' scaleTo='base' />
                     <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                 </StandardGen>
@@ -1229,8 +1229,8 @@
                     <IfCondition condition=':= ?blockExists("minecraft:lapis_ore")'> <OreBlock block='minecraft:lapis_ore' weight='1.0' /> </IfCondition>
                     <ReplacesOre block='stone' weight='1.0' />
                     <Biome name='.*'  />
-                    <Setting name='Size' avg=':= 6.000 * vnlaLapisLazuliSize ' range=':= _default_ * vnlaLapisLazuliSize ' type='normal' />
-                    <Setting name='Frequency' avg=':= 1.000 * vnlaLapisLazuliFreq ' range=':= _default_ * vnlaLapisLazuliFreq ' type='normal' scaleTo='base' />
+                    <Setting name='Size' avg=':= 3.000 * vnlaLapisLazuliSize ' range=':= 3.000 * vnlaLapisLazuliSize ' type='normal' />
+                    <Setting name='Frequency' avg=':= 0.500 * vnlaLapisLazuliFreq ' range=':= 0.500 * vnlaLapisLazuliFreq ' type='normal' scaleTo='base' />
                     <Setting name='Height' avg=':= 16 ' range=':= 0 ' type='normal' scaleTo='base' />
                     <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                 </StandardGen>
@@ -1385,8 +1385,8 @@
                     <IfCondition condition=':= ?blockExists("minecraft:emerald_ore")'> <OreBlock block='minecraft:emerald_ore' weight='1.0' /> </IfCondition>
                     <ReplacesOre block='stone' weight='1.0' />
                     <BiomeType name='Mountain'  />
-                    <Setting name='Size' avg=':= 2.000 * vnlaEmeraldSize ' range=':= _default_ * vnlaEmeraldSize ' type='normal' />
-                    <Setting name='Frequency' avg=':= 9.000 * vnlaEmeraldFreq ' range=':= _default_ * vnlaEmeraldFreq ' type='normal' scaleTo='base' />
+                    <Setting name='Size' avg=':= 1.000 * vnlaEmeraldSize ' range=':= 1.000 * vnlaEmeraldSize ' type='normal' />
+                    <Setting name='Frequency' avg=':= 4.500 * vnlaEmeraldFreq ' range=':= 4.500 * vnlaEmeraldFreq ' type='normal' scaleTo='base' />
                     <Setting name='Height' avg=':= 16 ' range=':= 12 ' type='normal' scaleTo='base' />
                     <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                 </StandardGen>
@@ -1530,8 +1530,8 @@
                     <IfCondition condition=':= ?blockExists("minecraft:quartz_ore")'> <OreBlock block='minecraft:quartz_ore' weight='1.0' /> </IfCondition>
                     <Replaces block='minecraft:netherrack' weight='1.0' />
                     <Biome name='.*'  />
-                    <Setting name='Size' avg=':= 16.000 * vnlaNetherQuartzSize ' range=':= _default_ * vnlaNetherQuartzSize ' type='normal' />
-                    <Setting name='Frequency' avg=':= 13.000 * vnlaNetherQuartzFreq ' range=':= _default_ * vnlaNetherQuartzFreq ' type='normal' scaleTo='base' />
+                    <Setting name='Size' avg=':= 8.000 * vnlaNetherQuartzSize ' range=':= 8.000 * vnlaNetherQuartzSize ' type='uniform' />
+                    <Setting name='Frequency' avg=':= 6.500 * vnlaNetherQuartzFreq ' range=':= 6.500 * vnlaNetherQuartzFreq ' type='normal' scaleTo='base' />
                     <Setting name='Height' avg=':= 59 ' range=':= 49 ' type='normal' scaleTo='base' />
                     <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                 </StandardGen>


### PR DESCRIPTION
All standard distributions have been halved; this is because the values should be averages, rather than maximums; the deviations go in both directions.  Additionally, all standard distributions have deviations that match their averages; this means they can be anything from 0 to the original maximum values.


Other fixes:

* Some tweaks to other distributions had apparently been overlooked in placement until now.  Fixed.
* Biomes O'Plenty's oregen was missing height values.  Fixed.
* Chisel 2's oregens were missing height values.  Fixed.
* Geostrata's Standard Frequency values were missing.  Fixed.
* Metallurgy 4's height values were missing.  Fixed.
* Nether Ores' height values are missing.  Fixed.
* Netherrocks' height values are missing.  Fixed.