### PR TITLE
Overhauled block existence checks.

### DIFF
--- a/src/main/resources/config/modules/AppliedEnergistics.xml
+++ b/src/main/resources/config/modules/AppliedEnergistics.xml
@@ -40,7 +40,7 @@
                 <OptionChoice name='apenCertusQuartzDist'  displayState=':= if(?enableAppliedEnergistics, "shown", "hidden")' displayGroup='groupAppliedEnergistics'>
                     <Description> Controls how Certus Quartz is generated </Description>
                     <DisplayName>Applied Energistics Certus Quartz</DisplayName>
-                    <IfCondition condition=':= (?blockExists("appliedenergistics2:tile.OreQuartz") | ?blockExists("appliedenergistics2:tile.OreQuartzCharged")) '>
+                    <IfCondition condition=':= (?blockExists("appliedenergistics2:tile.OreQuartz")  &amp; ?blockExists("appliedenergistics2:tile.OreQuartzCharged")) '>
 
                     <Choice value='SparseVeins' displayValue='Sparse Veins'>
                         <Description>
@@ -49,7 +49,7 @@
                     </Choice>
                     </IfCondition>
 
-                    <IfCondition condition=':= (?blockExists("appliedenergistics2:tile.OreQuartz") | ?blockExists("appliedenergistics2:tile.OreQuartzCharged")) '>
+                    <IfCondition condition=':= (?blockExists("appliedenergistics2:tile.OreQuartz")  &amp; ?blockExists("appliedenergistics2:tile.OreQuartzCharged")) '>
 
                     <Choice value='StrategicClouds' displayValue='Strategic Clouds'>
                         <Description>
@@ -58,7 +58,7 @@
                     </Choice>
                     </IfCondition>
 
-                    <IfCondition condition=':= (?blockExists("appliedenergistics2:tile.OreQuartz") | ?blockExists("appliedenergistics2:tile.OreQuartzCharged")) '>
+                    <IfCondition condition=':= (?blockExists("appliedenergistics2:tile.OreQuartz")  &amp; ?blockExists("appliedenergistics2:tile.OreQuartzCharged")) '>
 
                     <Choice value='Vanilla' displayValue='Vanilla'>
                         <Description>
@@ -130,8 +130,8 @@
                                 since it is  harder to get an idea of
                                 their  direction while mining.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("appliedenergistics2:tile.OreQuartz")'> <OreBlock block='appliedenergistics2:tile.OreQuartz' weight='0.90' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("appliedenergistics2:tile.OreQuartzCharged")'> <OreBlock block='appliedenergistics2:tile.OreQuartzCharged' weight='0.10' /> </IfCondition>
+                            <OreBlock block='appliedenergistics2:tile.OreQuartz' weight='0.90' />
+                            <OreBlock block='appliedenergistics2:tile.OreQuartzCharged' weight='0.10' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 3.355 * _default_ * apenCertusQuartzFreq ' range=':= 3.355 * _default_ * apenCertusQuartzFreq ' type='normal' scaleTo='base' />
@@ -174,8 +174,8 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("appliedenergistics2:tile.OreQuartz")'> <OreBlock block='appliedenergistics2:tile.OreQuartz' weight='0.90' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("appliedenergistics2:tile.OreQuartzCharged")'> <OreBlock block='appliedenergistics2:tile.OreQuartzCharged' weight='0.10' /> </IfCondition>
+                            <OreBlock block='appliedenergistics2:tile.OreQuartz' weight='0.90' />
+                            <OreBlock block='appliedenergistics2:tile.OreQuartzCharged' weight='0.10' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.251 * _default_ * apenCertusQuartzSize ' range=':= 1.251 * _default_ * apenCertusQuartzSize ' type='normal' />
@@ -209,8 +209,8 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("appliedenergistics2:tile.OreQuartz")'> <OreBlock block='appliedenergistics2:tile.OreQuartz' weight='0.90' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("appliedenergistics2:tile.OreQuartzCharged")'> <OreBlock block='appliedenergistics2:tile.OreQuartzCharged' weight='0.10' /> </IfCondition>
+                                <OreBlock block='appliedenergistics2:tile.OreQuartz' weight='0.90' />
+                                <OreBlock block='appliedenergistics2:tile.OreQuartzCharged' weight='0.10' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -229,8 +229,8 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("appliedenergistics2:tile.OreQuartz")'> <OreBlock block='appliedenergistics2:tile.OreQuartz' weight='0.90' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("appliedenergistics2:tile.OreQuartzCharged")'> <OreBlock block='appliedenergistics2:tile.OreQuartzCharged' weight='0.10' /> </IfCondition>
+                            <OreBlock block='appliedenergistics2:tile.OreQuartz' weight='0.90' />
+                            <OreBlock block='appliedenergistics2:tile.OreQuartzCharged' weight='0.10' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 2.000 * apenCertusQuartzSize ' range=':= 2.000 * apenCertusQuartzSize ' type='normal' />

--- a/src/main/resources/config/modules/ArsMagica2.xml
+++ b/src/main/resources/config/modules/ArsMagica2.xml
@@ -221,7 +221,7 @@
                                 since it is  harder to get an idea of
                                 their  direction while mining.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("arsmagica2:vinteumOre")'> <OreBlock block='arsmagica2:vinteumOre' weight='1.0' /> </IfCondition>
+                            <OreBlock block='arsmagica2:vinteumOre' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.122 * _default_ * arsmVinteumFreq ' range=':= 2.122 * _default_ * arsmVinteumFreq ' type='normal' scaleTo='base' />
@@ -263,7 +263,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("arsmagica2:vinteumOre")'> <OreBlock block='arsmagica2:vinteumOre' weight='1.0' /> </IfCondition>
+                            <OreBlock block='arsmagica2:vinteumOre' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.995 * _default_ * arsmVinteumSize ' range=':= 0.995 * _default_ * arsmVinteumSize ' type='normal' />
@@ -297,7 +297,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("arsmagica2:vinteumOre")'> <OreBlock block='arsmagica2:vinteumOre' weight='1.0' /> </IfCondition>
+                                <OreBlock block='arsmagica2:vinteumOre' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -315,7 +315,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("arsmagica2:vinteumOre")'> <OreBlock block='arsmagica2:vinteumOre' weight='1.0' /> </IfCondition>
+                            <OreBlock block='arsmagica2:vinteumOre' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 2.000 * arsmVinteumSize ' range=':= 2.000 * arsmVinteumSize ' type='normal' />
@@ -347,7 +347,7 @@
                                 since it is  harder to get an idea of
                                 their  direction while mining.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("arsmagica2:vinteumOre:1")'> <OreBlock block='arsmagica2:vinteumOre:1' weight='1.0' /> </IfCondition>
+                            <OreBlock block='arsmagica2:vinteumOre:1' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 3.001 * _default_ * arsmChimeriteFreq ' range=':= 3.001 * _default_ * arsmChimeriteFreq ' type='normal' scaleTo='base' />
@@ -389,7 +389,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("arsmagica2:vinteumOre:1")'> <OreBlock block='arsmagica2:vinteumOre:1' weight='1.0' /> </IfCondition>
+                            <OreBlock block='arsmagica2:vinteumOre:1' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.183 * _default_ * arsmChimeriteSize ' range=':= 1.183 * _default_ * arsmChimeriteSize ' type='normal' />
@@ -423,7 +423,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("arsmagica2:vinteumOre:1")'> <OreBlock block='arsmagica2:vinteumOre:1' weight='1.0' /> </IfCondition>
+                                <OreBlock block='arsmagica2:vinteumOre:1' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -441,7 +441,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("arsmagica2:vinteumOre:1")'> <OreBlock block='arsmagica2:vinteumOre:1' weight='1.0' /> </IfCondition>
+                            <OreBlock block='arsmagica2:vinteumOre:1' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.000 * arsmChimeriteSize ' range=':= 3.000 * arsmChimeriteSize ' type='normal' />
@@ -473,7 +473,7 @@
                                 since it is  harder to get an idea of
                                 their  direction while mining.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("arsmagica2:vinteumOre:2")'> <OreBlock block='arsmagica2:vinteumOre:2' weight='1.0' /> </IfCondition>
+                            <OreBlock block='arsmagica2:vinteumOre:2' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 3.001 * _default_ * arsmBlueTopazFreq ' range=':= 3.001 * _default_ * arsmBlueTopazFreq ' type='normal' scaleTo='base' />
@@ -515,7 +515,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("arsmagica2:vinteumOre:2")'> <OreBlock block='arsmagica2:vinteumOre:2' weight='1.0' /> </IfCondition>
+                            <OreBlock block='arsmagica2:vinteumOre:2' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.183 * _default_ * arsmBlueTopazSize ' range=':= 1.183 * _default_ * arsmBlueTopazSize ' type='normal' />
@@ -549,7 +549,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("arsmagica2:vinteumOre:2")'> <OreBlock block='arsmagica2:vinteumOre:2' weight='1.0' /> </IfCondition>
+                                <OreBlock block='arsmagica2:vinteumOre:2' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -568,7 +568,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("arsmagica2:vinteumOre:2")'> <OreBlock block='arsmagica2:vinteumOre:2' weight='1.0' /> </IfCondition>
+                            <OreBlock block='arsmagica2:vinteumOre:2' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.000 * arsmBlueTopazSize ' range=':= 3.000 * arsmBlueTopazSize ' type='normal' />

--- a/src/main/resources/config/modules/BiomesOPlenty.xml
+++ b/src/main/resources/config/modules/BiomesOPlenty.xml
@@ -449,7 +449,7 @@
                                 Short sparsely filled veins  sloping
                                 up from near the bottom  of the map.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:2")'> <OreBlock block='BiomesOPlenty:gemOre:2' weight='1.0' /> </IfCondition>
+                            <OreBlock block='BiomesOPlenty:gemOre:2' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Desert'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.270 * _default_ * boplRubyFreq ' range=':= 0.270 * _default_ * boplRubyFreq ' type='normal' scaleTo='base' />
@@ -471,7 +471,7 @@
 
                         <!-- Configuring contained material. -->
                         <Veins name='boplRubyVeinsPipe'  inherits='boplRubyVeins' seed='0x706D' drawWireframe='true' wireframeColor='0x60C60031' drawBoundBox='false' boundBoxColor='0x60C60031'>
-                            <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
+                            <OreBlock block='minecraft:lava' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Replaces block='BiomesOPlenty:gemOre:2' weight='1.0' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * boplRubySize  * 0.5 ' range=':= 0 * _default_ * boplRubySize  * 0.5 ' type='normal' />
@@ -501,7 +501,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:2")'> <OreBlock block='BiomesOPlenty:gemOre:2' weight='1.0' /> </IfCondition>
+                            <OreBlock block='BiomesOPlenty:gemOre:2' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Desert'  />
                             <Setting name='CloudRadius' avg=':= 0.449 * _default_ * boplRubySize ' range=':= 0.449 * _default_ * boplRubySize ' type='normal' />
@@ -535,7 +535,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:2")'> <OreBlock block='BiomesOPlenty:gemOre:2' weight='1.0' /> </IfCondition>
+                                <OreBlock block='BiomesOPlenty:gemOre:2' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -553,7 +553,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:2")'> <OreBlock block='BiomesOPlenty:gemOre:2' weight='1.0' /> </IfCondition>
+                            <OreBlock block='BiomesOPlenty:gemOre:2' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Desert'  />
                             <Setting name='Size' avg=':= 0.500 * boplRubySize ' range=':= 0.500 * boplRubySize ' type='normal' />
@@ -578,7 +578,7 @@
                                 Short sparsely filled veins  sloping
                                 up from near the bottom  of the map.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:4")'> <OreBlock block='BiomesOPlenty:gemOre:4' weight='1.0' /> </IfCondition>
+                            <OreBlock block='BiomesOPlenty:gemOre:4' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Plains'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.270 * _default_ * boplPeridotFreq ' range=':= 0.270 * _default_ * boplPeridotFreq ' type='normal' scaleTo='base' />
@@ -600,7 +600,7 @@
 
                         <!-- Configuring contained material. -->
                         <Veins name='boplPeridotVeinsPipe'  inherits='boplPeridotVeins' seed='0xA6AC' drawWireframe='true' wireframeColor='0x60076855' drawBoundBox='false' boundBoxColor='0x60076855'>
-                            <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
+                            <OreBlock block='minecraft:lava' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Replaces block='BiomesOPlenty:gemOre:4' weight='1.0' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * boplPeridotSize  * 0.5 ' range=':= 0 * _default_ * boplPeridotSize  * 0.5 ' type='normal' />
@@ -630,7 +630,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:4")'> <OreBlock block='BiomesOPlenty:gemOre:4' weight='1.0' /> </IfCondition>
+                            <OreBlock block='BiomesOPlenty:gemOre:4' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Plains'  />
                             <Setting name='CloudRadius' avg=':= 0.449 * _default_ * boplPeridotSize ' range=':= 0.449 * _default_ * boplPeridotSize ' type='normal' />
@@ -664,7 +664,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:4")'> <OreBlock block='BiomesOPlenty:gemOre:4' weight='1.0' /> </IfCondition>
+                                <OreBlock block='BiomesOPlenty:gemOre:4' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -682,7 +682,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:4")'> <OreBlock block='BiomesOPlenty:gemOre:4' weight='1.0' /> </IfCondition>
+                            <OreBlock block='BiomesOPlenty:gemOre:4' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Plains'  />
                             <Setting name='Size' avg=':= 0.500 * boplPeridotSize ' range=':= 0.500 * boplPeridotSize ' type='normal' />
@@ -707,7 +707,7 @@
                                 Short sparsely filled veins  sloping
                                 up from near the bottom  of the map.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:6")'> <OreBlock block='BiomesOPlenty:gemOre:6' weight='1.0' /> </IfCondition>
+                            <OreBlock block='BiomesOPlenty:gemOre:6' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Jungle'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.270 * _default_ * boplTopazFreq ' range=':= 0.270 * _default_ * boplTopazFreq ' type='normal' scaleTo='base' />
@@ -729,7 +729,7 @@
 
                         <!-- Configuring contained material. -->
                         <Veins name='boplTopazVeinsPipe'  inherits='boplTopazVeins' seed='0xB7E1' drawWireframe='true' wireframeColor='0x60D95A03' drawBoundBox='false' boundBoxColor='0x60D95A03'>
-                            <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
+                            <OreBlock block='minecraft:lava' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Replaces block='BiomesOPlenty:gemOre:6' weight='1.0' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * boplTopazSize  * 0.5 ' range=':= 0 * _default_ * boplTopazSize  * 0.5 ' type='normal' />
@@ -759,7 +759,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:6")'> <OreBlock block='BiomesOPlenty:gemOre:6' weight='1.0' /> </IfCondition>
+                            <OreBlock block='BiomesOPlenty:gemOre:6' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Jungle'  />
                             <Setting name='CloudRadius' avg=':= 0.449 * _default_ * boplTopazSize ' range=':= 0.449 * _default_ * boplTopazSize ' type='normal' />
@@ -793,7 +793,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:6")'> <OreBlock block='BiomesOPlenty:gemOre:6' weight='1.0' /> </IfCondition>
+                                <OreBlock block='BiomesOPlenty:gemOre:6' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -811,7 +811,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:6")'> <OreBlock block='BiomesOPlenty:gemOre:6' weight='1.0' /> </IfCondition>
+                            <OreBlock block='BiomesOPlenty:gemOre:6' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Jungle'  />
                             <Setting name='Size' avg=':= 0.500 * boplTopazSize ' range=':= 0.500 * boplTopazSize ' type='normal' />
@@ -836,7 +836,7 @@
                                 Short sparsely filled veins  sloping
                                 up from near the bottom  of the map.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:8")'> <OreBlock block='BiomesOPlenty:gemOre:8' weight='1.0' /> </IfCondition>
+                            <OreBlock block='BiomesOPlenty:gemOre:8' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Frozen'  />
                             <Biome name='Alps'  weight='-1' />
@@ -860,7 +860,7 @@
 
                         <!-- Configuring contained material. -->
                         <Veins name='boplTanzaniteVeinsPipe'  inherits='boplTanzaniteVeins' seed='0xA51A' drawWireframe='true' wireframeColor='0x607701B9' drawBoundBox='false' boundBoxColor='0x607701B9'>
-                            <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
+                            <OreBlock block='minecraft:lava' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Replaces block='BiomesOPlenty:gemOre:8' weight='1.0' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * boplTanzaniteSize  * 0.5 ' range=':= 0 * _default_ * boplTanzaniteSize  * 0.5 ' type='normal' />
@@ -890,7 +890,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:8")'> <OreBlock block='BiomesOPlenty:gemOre:8' weight='1.0' /> </IfCondition>
+                            <OreBlock block='BiomesOPlenty:gemOre:8' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Frozen'  />
                             <Biome name='Alps'  weight='-1' />
@@ -926,7 +926,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:8")'> <OreBlock block='BiomesOPlenty:gemOre:8' weight='1.0' /> </IfCondition>
+                                <OreBlock block='BiomesOPlenty:gemOre:8' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -944,7 +944,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:8")'> <OreBlock block='BiomesOPlenty:gemOre:8' weight='1.0' /> </IfCondition>
+                            <OreBlock block='BiomesOPlenty:gemOre:8' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Frozen'  />
                             <Biome name='Alps'  weight='-1' />
@@ -971,7 +971,7 @@
                                 Short sparsely filled veins  sloping
                                 up from near the bottom  of the map.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:10")'> <OreBlock block='BiomesOPlenty:gemOre:10' weight='1.0' /> </IfCondition>
+                            <OreBlock block='BiomesOPlenty:gemOre:10' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Swamp'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.270 * _default_ * boplMalachiteFreq ' range=':= 0.270 * _default_ * boplMalachiteFreq ' type='normal' scaleTo='base' />
@@ -993,7 +993,7 @@
 
                         <!-- Configuring contained material. -->
                         <Veins name='boplMalachiteVeinsPipe'  inherits='boplMalachiteVeins' seed='0x5A38' drawWireframe='true' wireframeColor='0x60109D81' drawBoundBox='false' boundBoxColor='0x60109D81'>
-                            <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
+                            <OreBlock block='minecraft:lava' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Replaces block='BiomesOPlenty:gemOre:10' weight='1.0' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * boplMalachiteSize  * 0.5 ' range=':= 0 * _default_ * boplMalachiteSize  * 0.5 ' type='normal' />
@@ -1023,7 +1023,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:10")'> <OreBlock block='BiomesOPlenty:gemOre:10' weight='1.0' /> </IfCondition>
+                            <OreBlock block='BiomesOPlenty:gemOre:10' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Swamp'  />
                             <Setting name='CloudRadius' avg=':= 0.449 * _default_ * boplMalachiteSize ' range=':= 0.449 * _default_ * boplMalachiteSize ' type='normal' />
@@ -1057,7 +1057,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:10")'> <OreBlock block='BiomesOPlenty:gemOre:10' weight='1.0' /> </IfCondition>
+                                <OreBlock block='BiomesOPlenty:gemOre:10' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -1075,7 +1075,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:10")'> <OreBlock block='BiomesOPlenty:gemOre:10' weight='1.0' /> </IfCondition>
+                            <OreBlock block='BiomesOPlenty:gemOre:10' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Swamp'  />
                             <Setting name='Size' avg=':= 0.500 * boplMalachiteSize ' range=':= 0.500 * boplMalachiteSize ' type='normal' />
@@ -1100,7 +1100,7 @@
                                 Short sparsely filled veins  sloping
                                 up from near the bottom  of the map.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:12")'> <OreBlock block='BiomesOPlenty:gemOre:12' weight='1.0' /> </IfCondition>
+                            <OreBlock block='BiomesOPlenty:gemOre:12' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='Coral Reef'  />
                             <Biome name='Crag'  />
@@ -1128,7 +1128,7 @@
 
                         <!-- Configuring contained material. -->
                         <Veins name='boplSapphireVeinsPipe'  inherits='boplSapphireVeins' seed='0x7474' drawWireframe='true' wireframeColor='0x603494C3' drawBoundBox='false' boundBoxColor='0x603494C3'>
-                            <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
+                            <OreBlock block='minecraft:lava' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Replaces block='BiomesOPlenty:gemOre:12' weight='1.0' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * boplSapphireSize  * 0.5 ' range=':= 0 * _default_ * boplSapphireSize  * 0.5 ' type='normal' />
@@ -1158,7 +1158,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:12")'> <OreBlock block='BiomesOPlenty:gemOre:12' weight='1.0' /> </IfCondition>
+                            <OreBlock block='BiomesOPlenty:gemOre:12' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='Coral Reef'  />
                             <Biome name='Crag'  />
@@ -1198,7 +1198,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:12")'> <OreBlock block='BiomesOPlenty:gemOre:12' weight='1.0' /> </IfCondition>
+                                <OreBlock block='BiomesOPlenty:gemOre:12' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -1216,7 +1216,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:12")'> <OreBlock block='BiomesOPlenty:gemOre:12' weight='1.0' /> </IfCondition>
+                            <OreBlock block='BiomesOPlenty:gemOre:12' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='Coral Reef'  />
                             <Biome name='Crag'  />
@@ -1247,7 +1247,7 @@
                                 Short sparsely filled veins  sloping
                                 up from near the bottom  of the map.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:14")'> <OreBlock block='BiomesOPlenty:gemOre:14' weight='1.0' /> </IfCondition>
+                            <OreBlock block='BiomesOPlenty:gemOre:14' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='River'  />
                             <Biome name='Grove'  />
@@ -1272,7 +1272,7 @@
 
                         <!-- Configuring contained material. -->
                         <Veins name='boplAmberVeinsPipe'  inherits='boplAmberVeins' seed='0x1FEF' drawWireframe='true' wireframeColor='0x60FE9D1B' drawBoundBox='false' boundBoxColor='0x60FE9D1B'>
-                            <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
+                            <OreBlock block='minecraft:lava' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Replaces block='BiomesOPlenty:gemOre:14' weight='1.0' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * boplAmberSize  * 0.5 ' range=':= 0 * _default_ * boplAmberSize  * 0.5 ' type='normal' />
@@ -1302,7 +1302,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:14")'> <OreBlock block='BiomesOPlenty:gemOre:14' weight='1.0' /> </IfCondition>
+                            <OreBlock block='BiomesOPlenty:gemOre:14' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='River'  />
                             <Biome name='Grove'  />
@@ -1339,7 +1339,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:14")'> <OreBlock block='BiomesOPlenty:gemOre:14' weight='1.0' /> </IfCondition>
+                                <OreBlock block='BiomesOPlenty:gemOre:14' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -1357,7 +1357,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre:14")'> <OreBlock block='BiomesOPlenty:gemOre:14' weight='1.0' /> </IfCondition>
+                            <OreBlock block='BiomesOPlenty:gemOre:14' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='River'  />
                             <Biome name='Grove'  />
@@ -1418,7 +1418,7 @@
                                 Short sparsely filled veins  sloping
                                 up from near the bottom  of the map.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre")'> <OreBlock block='BiomesOPlenty:gemOre' weight='1.0' /> </IfCondition>
+                            <OreBlock block='BiomesOPlenty:gemOre' weight='1.0' />
                             <Replaces block='minecraft:end_stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.270 * _default_ * boplAmathystFreq ' range=':= 0.270 * _default_ * boplAmathystFreq ' type='normal' scaleTo='base' />
@@ -1440,7 +1440,7 @@
 
                         <!-- Configuring contained material. -->
                         <Veins name='boplAmathystVeinsPipe'  inherits='boplAmathystVeins' seed='0x58D8' drawWireframe='true' wireframeColor='0x60DD4EEA' drawBoundBox='false' boundBoxColor='0x60DD4EEA'>
-                            <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
+                            <OreBlock block='minecraft:lava' weight='1.0' />
                             <Replaces block='minecraft:end_stone' weight='1.0' />
                             <Replaces block='BiomesOPlenty:gemOre' weight='1.0' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * boplAmathystSize  * 0.5 ' range=':= 0 * _default_ * boplAmathystSize  * 0.5 ' type='normal' />
@@ -1470,7 +1470,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre")'> <OreBlock block='BiomesOPlenty:gemOre' weight='1.0' /> </IfCondition>
+                            <OreBlock block='BiomesOPlenty:gemOre' weight='1.0' />
                             <Replaces block='minecraft:end_stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.449 * _default_ * boplAmathystSize ' range=':= 0.449 * _default_ * boplAmathystSize ' type='normal' />
@@ -1504,7 +1504,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre")'> <OreBlock block='BiomesOPlenty:gemOre' weight='1.0' /> </IfCondition>
+                                <OreBlock block='BiomesOPlenty:gemOre' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -1522,7 +1522,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("BiomesOPlenty:gemOre")'> <OreBlock block='BiomesOPlenty:gemOre' weight='1.0' /> </IfCondition>
+                            <OreBlock block='BiomesOPlenty:gemOre' weight='1.0' />
                             <Replaces block='minecraft:end_stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 0.500 * boplAmathystSize ' range=':= 0.500 * boplAmathystSize ' type='normal' />

--- a/src/main/resources/config/modules/Chisel2.xml
+++ b/src/main/resources/config/modules/Chisel2.xml
@@ -311,7 +311,7 @@
                                 to provide  realistic distribution of
                                 stone  in a strata formation.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("chisel:andesite")'> <OreBlock block='chisel:andesite' weight='1.0' /> </IfCondition>
+                            <OreBlock block='chisel:andesite' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.156 * _default_ * chslAndesiteSize ' range=':= 1.156 * _default_ * chslAndesiteSize ' type='normal' />
@@ -338,7 +338,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("chisel:andesite")'> <OreBlock block='chisel:andesite' weight='1.0' /> </IfCondition>
+                            <OreBlock block='chisel:andesite' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.002 * _default_ * chslAndesiteFreq ' range=':= 2.002 * _default_ * chslAndesiteFreq ' type='normal' scaleTo='base' />
@@ -370,7 +370,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("chisel:andesite")'> <OreBlock block='chisel:andesite' weight='1.0' /> </IfCondition>
+                            <OreBlock block='chisel:andesite' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 8.000 * chslAndesiteSize ' range=':= 8.000 * chslAndesiteSize ' type='normal' />
@@ -397,7 +397,7 @@
                                 to provide  realistic distribution of
                                 stone  in a strata formation.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("chisel:diorite")'> <OreBlock block='chisel:diorite' weight='1.0' /> </IfCondition>
+                            <OreBlock block='chisel:diorite' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.156 * _default_ * chslDioriteSize ' range=':= 1.156 * _default_ * chslDioriteSize ' type='normal' />
@@ -424,7 +424,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("chisel:diorite")'> <OreBlock block='chisel:diorite' weight='1.0' /> </IfCondition>
+                            <OreBlock block='chisel:diorite' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.002 * _default_ * chslDioriteFreq ' range=':= 2.002 * _default_ * chslDioriteFreq ' type='normal' scaleTo='base' />
@@ -456,7 +456,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("chisel:diorite")'> <OreBlock block='chisel:diorite' weight='1.0' /> </IfCondition>
+                            <OreBlock block='chisel:diorite' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 8.000 * chslDioriteSize ' range=':= 8.000 * chslDioriteSize ' type='normal' />
@@ -483,7 +483,7 @@
                                 to provide  realistic distribution of
                                 stone  in a strata formation.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("chisel:granite")'> <OreBlock block='chisel:granite' weight='1.0' /> </IfCondition>
+                            <OreBlock block='chisel:granite' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.156 * _default_ * chslGraniteSize ' range=':= 1.156 * _default_ * chslGraniteSize ' type='normal' />
@@ -510,7 +510,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("chisel:granite")'> <OreBlock block='chisel:granite' weight='1.0' /> </IfCondition>
+                            <OreBlock block='chisel:granite' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.002 * _default_ * chslGraniteFreq ' range=':= 2.002 * _default_ * chslGraniteFreq ' type='normal' scaleTo='base' />
@@ -542,7 +542,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("chisel:granite")'> <OreBlock block='chisel:granite' weight='1.0' /> </IfCondition>
+                            <OreBlock block='chisel:granite' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 8.000 * chslGraniteSize ' range=':= 8.000 * chslGraniteSize ' type='normal' />
@@ -569,7 +569,7 @@
                                 to provide  realistic distribution of
                                 stone  in a strata formation.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("chisel:limestone")'> <OreBlock block='chisel:limestone' weight='1.0' /> </IfCondition>
+                            <OreBlock block='chisel:limestone' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.252 * _default_ * chslLimestoneSize ' range=':= 1.252 * _default_ * chslLimestoneSize ' type='normal' />
@@ -596,7 +596,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("chisel:limestone")'> <OreBlock block='chisel:limestone' weight='1.0' /> </IfCondition>
+                            <OreBlock block='chisel:limestone' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.348 * _default_ * chslLimestoneFreq ' range=':= 2.348 * _default_ * chslLimestoneFreq ' type='normal' scaleTo='base' />
@@ -628,7 +628,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("chisel:limestone")'> <OreBlock block='chisel:limestone' weight='1.0' /> </IfCondition>
+                            <OreBlock block='chisel:limestone' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 11.000 * chslLimestoneSize ' range=':= 11.000 * chslLimestoneSize ' type='normal' />
@@ -655,7 +655,7 @@
                                 to provide  realistic distribution of
                                 stone  in a strata formation.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("chisel:marble")'> <OreBlock block='chisel:marble' weight='1.0' /> </IfCondition>
+                            <OreBlock block='chisel:marble' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.211 * _default_ * chslMarbleSize ' range=':= 1.211 * _default_ * chslMarbleSize ' type='normal' />
@@ -682,7 +682,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("chisel:marble")'> <OreBlock block='chisel:marble' weight='1.0' /> </IfCondition>
+                            <OreBlock block='chisel:marble' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.196 * _default_ * chslMarbleFreq ' range=':= 2.196 * _default_ * chslMarbleFreq ' type='normal' scaleTo='base' />
@@ -714,7 +714,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("chisel:marble")'> <OreBlock block='chisel:marble' weight='1.0' /> </IfCondition>
+                            <OreBlock block='chisel:marble' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 11.000 * chslMarbleSize ' range=':= 11.000 * chslMarbleSize ' type='normal' />

--- a/src/main/resources/config/modules/DenseOres.xml
+++ b/src/main/resources/config/modules/DenseOres.xml
@@ -39,7 +39,7 @@
                 <OptionChoice name='dnsoCoalDist'  displayState=':= if(?enableDenseOres, "shown", "hidden")' displayGroup='groupDenseOres'>
                     <Description> Controls how Coal is generated </Description>
                     <DisplayName>Dense Ores Coal</DisplayName>
-                    <IfCondition condition=':= (?blockExists("minecraft:coal_ore") | ?blockExists("denseores:block0:6")) '>
+                    <IfCondition condition=':= (?blockExists("minecraft:coal_ore")  &amp; ?blockExists("denseores:block0:6")) '>
 
                     <Choice value='SparseVeins' displayValue='Sparse Veins'>
                         <Description>
@@ -48,7 +48,7 @@
                     </Choice>
                     </IfCondition>
 
-                    <IfCondition condition=':= (?blockExists("minecraft:coal_ore") | ?blockExists("denseores:block0:6")) '>
+                    <IfCondition condition=':= (?blockExists("minecraft:coal_ore")  &amp; ?blockExists("denseores:block0:6")) '>
 
                     <Choice value='StrategicClouds' displayValue='Strategic Clouds'>
                         <Description>
@@ -57,7 +57,7 @@
                     </Choice>
                     </IfCondition>
 
-                    <IfCondition condition=':= (?blockExists("minecraft:coal_ore") | ?blockExists("denseores:block0:6")) '>
+                    <IfCondition condition=':= (?blockExists("minecraft:coal_ore")  &amp; ?blockExists("denseores:block0:6")) '>
 
                     <Choice value='Vanilla' displayValue='Vanilla'>
                         <Description>
@@ -85,7 +85,7 @@
                 <OptionChoice name='dnsoIronDist'  displayState=':= if(?enableDenseOres, "shown", "hidden")' displayGroup='groupDenseOres'>
                     <Description> Controls how Iron is generated </Description>
                     <DisplayName>Dense Ores Iron</DisplayName>
-                    <IfCondition condition=':= (?blockExists("minecraft:iron_ore") | ?blockExists("denseores:block0")) '>
+                    <IfCondition condition=':= (?blockExists("minecraft:iron_ore")  &amp; ?blockExists("denseores:block0")) '>
 
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
                         <Description>
@@ -94,7 +94,7 @@
                     </Choice>
                     </IfCondition>
 
-                    <IfCondition condition=':= (?blockExists("minecraft:iron_ore") | ?blockExists("denseores:block0")) '>
+                    <IfCondition condition=':= (?blockExists("minecraft:iron_ore")  &amp; ?blockExists("denseores:block0")) '>
 
                     <Choice value='StrategicClouds' displayValue='Strategic Clouds'>
                         <Description>
@@ -103,7 +103,7 @@
                     </Choice>
                     </IfCondition>
 
-                    <IfCondition condition=':= (?blockExists("minecraft:iron_ore") | ?blockExists("denseores:block0")) '>
+                    <IfCondition condition=':= (?blockExists("minecraft:iron_ore")  &amp; ?blockExists("denseores:block0")) '>
 
                     <Choice value='Vanilla' displayValue='Vanilla'>
                         <Description>
@@ -131,7 +131,7 @@
                 <OptionChoice name='dnsoGoldDist'  displayState=':= if(?enableDenseOres, "shown", "hidden")' displayGroup='groupDenseOres'>
                     <Description> Controls how Gold is generated </Description>
                     <DisplayName>Dense Ores Gold</DisplayName>
-                    <IfCondition condition=':= (?blockExists("minecraft:gold_ore") | ?blockExists("denseores:block0:1")) '>
+                    <IfCondition condition=':= (?blockExists("minecraft:gold_ore")  &amp; ?blockExists("denseores:block0:1")) '>
 
                     <Choice value='LayeredVeins' displayValue='Layered Veins'>
                         <Description>
@@ -140,7 +140,7 @@
                     </Choice>
                     </IfCondition>
 
-                    <IfCondition condition=':= (?blockExists("minecraft:gold_ore") | ?blockExists("denseores:block0:1")) '>
+                    <IfCondition condition=':= (?blockExists("minecraft:gold_ore")  &amp; ?blockExists("denseores:block0:1")) '>
 
                     <Choice value='StrategicClouds' displayValue='Strategic Clouds'>
                         <Description>
@@ -149,7 +149,7 @@
                     </Choice>
                     </IfCondition>
 
-                    <IfCondition condition=':= (?blockExists("minecraft:gold_ore") | ?blockExists("denseores:block0:1")) '>
+                    <IfCondition condition=':= (?blockExists("minecraft:gold_ore")  &amp; ?blockExists("denseores:block0:1")) '>
 
                     <Choice value='Vanilla' displayValue='Vanilla'>
                         <Description>
@@ -177,7 +177,7 @@
                 <OptionChoice name='dnsoRedstoneDist'  displayState=':= if(?enableDenseOres, "shown", "hidden")' displayGroup='groupDenseOres'>
                     <Description> Controls how Redstone is generated </Description>
                     <DisplayName>Dense Ores Redstone</DisplayName>
-                    <IfCondition condition=':= (?blockExists("minecraft:redstone_ore") | ?blockExists("denseores:block0:5")) '>
+                    <IfCondition condition=':= (?blockExists("minecraft:redstone_ore")  &amp; ?blockExists("denseores:block0:5")) '>
 
                     <Choice value='VerticalVeins' displayValue='Vertical Veins'>
                         <Description>
@@ -186,7 +186,7 @@
                     </Choice>
                     </IfCondition>
 
-                    <IfCondition condition=':= (?blockExists("minecraft:redstone_ore") | ?blockExists("denseores:block0:5")) '>
+                    <IfCondition condition=':= (?blockExists("minecraft:redstone_ore")  &amp; ?blockExists("denseores:block0:5")) '>
 
                     <Choice value='StrategicClouds' displayValue='Strategic Clouds'>
                         <Description>
@@ -195,7 +195,7 @@
                     </Choice>
                     </IfCondition>
 
-                    <IfCondition condition=':= (?blockExists("minecraft:redstone_ore") | ?blockExists("denseores:block0:5")) '>
+                    <IfCondition condition=':= (?blockExists("minecraft:redstone_ore")  &amp; ?blockExists("denseores:block0:5")) '>
 
                     <Choice value='Vanilla' displayValue='Vanilla'>
                         <Description>
@@ -223,7 +223,7 @@
                 <OptionChoice name='dnsoDiamondDist'  displayState=':= if(?enableDenseOres, "shown", "hidden")' displayGroup='groupDenseOres'>
                     <Description> Controls how Diamond is generated </Description>
                     <DisplayName>Dense Ores Diamond</DisplayName>
-                    <IfCondition condition=':= (?blockExists("minecraft:diamond_ore") | ?blockExists("denseores:block0:3")) &amp; (?blockExists("minecraft:lava")) '>
+                    <IfCondition condition=':= (?blockExists("minecraft:diamond_ore")  &amp; ?blockExists("denseores:block0:3")) &amp; (?blockExists("minecraft:lava")) '>
 
                     <Choice value='PipeVeins' displayValue='Pipe Veins'>
                         <Description>
@@ -232,7 +232,7 @@
                     </Choice>
                     </IfCondition>
 
-                    <IfCondition condition=':= (?blockExists("minecraft:diamond_ore") | ?blockExists("denseores:block0:3")) &amp; (?blockExists("minecraft:lava")) '>
+                    <IfCondition condition=':= (?blockExists("minecraft:diamond_ore")  &amp; ?blockExists("denseores:block0:3")) &amp; (?blockExists("minecraft:lava")) '>
 
                     <Choice value='StrategicClouds' displayValue='Strategic Clouds'>
                         <Description>
@@ -241,7 +241,7 @@
                     </Choice>
                     </IfCondition>
 
-                    <IfCondition condition=':= (?blockExists("minecraft:diamond_ore") | ?blockExists("denseores:block0:3")) &amp; (?blockExists("minecraft:lava")) '>
+                    <IfCondition condition=':= (?blockExists("minecraft:diamond_ore")  &amp; ?blockExists("denseores:block0:3")) &amp; (?blockExists("minecraft:lava")) '>
 
                     <Choice value='Vanilla' displayValue='Vanilla'>
                         <Description>
@@ -269,7 +269,7 @@
                 <OptionChoice name='dnsoLapisLazuliDist'  displayState=':= if(?enableDenseOres, "shown", "hidden")' displayGroup='groupDenseOres'>
                     <Description> Controls how Lapis Lazuli is generated </Description>
                     <DisplayName>Dense Ores Lapis Lazuli</DisplayName>
-                    <IfCondition condition=':= (?blockExists("minecraft:lapis_ore") | ?blockExists("denseores:block0:2")) '>
+                    <IfCondition condition=':= (?blockExists("minecraft:lapis_ore")  &amp; ?blockExists("denseores:block0:2")) '>
 
                     <Choice value='VerticalVeins' displayValue='Vertical Veins'>
                         <Description>
@@ -278,7 +278,7 @@
                     </Choice>
                     </IfCondition>
 
-                    <IfCondition condition=':= (?blockExists("minecraft:lapis_ore") | ?blockExists("denseores:block0:2")) '>
+                    <IfCondition condition=':= (?blockExists("minecraft:lapis_ore")  &amp; ?blockExists("denseores:block0:2")) '>
 
                     <Choice value='StrategicClouds' displayValue='Strategic Clouds'>
                         <Description>
@@ -287,7 +287,7 @@
                     </Choice>
                     </IfCondition>
 
-                    <IfCondition condition=':= (?blockExists("minecraft:lapis_ore") | ?blockExists("denseores:block0:2")) '>
+                    <IfCondition condition=':= (?blockExists("minecraft:lapis_ore")  &amp; ?blockExists("denseores:block0:2")) '>
 
                     <Choice value='Vanilla' displayValue='Vanilla'>
                         <Description>
@@ -315,7 +315,7 @@
                 <OptionChoice name='dnsoEmeraldDist'  displayState=':= if(?enableDenseOres, "shown", "hidden")' displayGroup='groupDenseOres'>
                     <Description> Controls how Emerald is generated </Description>
                     <DisplayName>Dense Ores Emerald</DisplayName>
-                    <IfCondition condition=':= (?blockExists("minecraft:emerald_ore") | ?blockExists("denseores:block0:4")) &amp; (?blockExists("minecraft:monster_egg")) '>
+                    <IfCondition condition=':= (?blockExists("minecraft:emerald_ore")  &amp; ?blockExists("denseores:block0:4")) &amp; (?blockExists("minecraft:monster_egg")) '>
 
                     <Choice value='PipeVeins' displayValue='Pipe Veins'>
                         <Description>
@@ -324,7 +324,7 @@
                     </Choice>
                     </IfCondition>
 
-                    <IfCondition condition=':= (?blockExists("minecraft:emerald_ore") | ?blockExists("denseores:block0:4")) &amp; (?blockExists("minecraft:monster_egg")) '>
+                    <IfCondition condition=':= (?blockExists("minecraft:emerald_ore")  &amp; ?blockExists("denseores:block0:4")) &amp; (?blockExists("minecraft:monster_egg")) '>
 
                     <Choice value='StrategicClouds' displayValue='Strategic Clouds'>
                         <Description>
@@ -333,7 +333,7 @@
                     </Choice>
                     </IfCondition>
 
-                    <IfCondition condition=':= (?blockExists("minecraft:emerald_ore") | ?blockExists("denseores:block0:4")) &amp; (?blockExists("minecraft:monster_egg")) '>
+                    <IfCondition condition=':= (?blockExists("minecraft:emerald_ore")  &amp; ?blockExists("denseores:block0:4")) &amp; (?blockExists("minecraft:monster_egg")) '>
 
                     <Choice value='Vanilla' displayValue='Vanilla'>
                         <Description>
@@ -361,7 +361,7 @@
                 <OptionChoice name='dnsoNetherQuartzDist'  displayState=':= if(?enableDenseOres, "shown", "hidden")' displayGroup='groupDenseOres'>
                     <Description> Controls how Nether Quartz is generated </Description>
                     <DisplayName>Dense Ores Nether Quartz</DisplayName>
-                    <IfCondition condition=':= (?blockExists("minecraft:quartz_ore") | ?blockExists("denseores:block0:7")) '>
+                    <IfCondition condition=':= (?blockExists("minecraft:quartz_ore")  &amp; ?blockExists("denseores:block0:7")) '>
 
                     <Choice value='SparseVeins' displayValue='Sparse Veins'>
                         <Description>
@@ -370,7 +370,7 @@
                     </Choice>
                     </IfCondition>
 
-                    <IfCondition condition=':= (?blockExists("minecraft:quartz_ore") | ?blockExists("denseores:block0:7")) '>
+                    <IfCondition condition=':= (?blockExists("minecraft:quartz_ore")  &amp; ?blockExists("denseores:block0:7")) '>
 
                     <Choice value='StrategicClouds' displayValue='Strategic Clouds'>
                         <Description>
@@ -379,7 +379,7 @@
                     </Choice>
                     </IfCondition>
 
-                    <IfCondition condition=':= (?blockExists("minecraft:quartz_ore") | ?blockExists("denseores:block0:7")) '>
+                    <IfCondition condition=':= (?blockExists("minecraft:quartz_ore")  &amp; ?blockExists("denseores:block0:7")) '>
 
                     <Choice value='Vanilla' displayValue='Vanilla'>
                         <Description>
@@ -463,8 +463,8 @@
                                 since it is  harder to get an idea of
                                 their  direction while mining.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("minecraft:coal_ore")'> <OreBlock block='minecraft:coal_ore' weight='0.9' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("denseores:block0:6")'> <OreBlock block='denseores:block0:6' weight='0.1' /> </IfCondition>
+                            <OreBlock block='minecraft:coal_ore' weight='0.9' />
+                            <OreBlock block='denseores:block0:6' weight='0.1' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 7.748 * _default_ * dnsoCoalFreq ' range=':= 7.748 * _default_ * dnsoCoalFreq ' type='normal' scaleTo='base' />
@@ -506,8 +506,8 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("minecraft:coal_ore")'> <OreBlock block='minecraft:coal_ore' weight='0.9' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("denseores:block0:6")'> <OreBlock block='denseores:block0:6' weight='0.1' /> </IfCondition>
+                            <OreBlock block='minecraft:coal_ore' weight='0.9' />
+                            <OreBlock block='denseores:block0:6' weight='0.1' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.901 * _default_ * dnsoCoalSize ' range=':= 1.901 * _default_ * dnsoCoalSize ' type='normal' />
@@ -541,8 +541,8 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("minecraft:coal_ore")'> <OreBlock block='minecraft:coal_ore' weight='0.9' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("denseores:block0:6")'> <OreBlock block='denseores:block0:6' weight='0.1' /> </IfCondition>
+                                <OreBlock block='minecraft:coal_ore' weight='0.9' />
+                                <OreBlock block='denseores:block0:6' weight='0.1' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -560,8 +560,8 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("minecraft:coal_ore")'> <OreBlock block='minecraft:coal_ore' weight='0.9' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("denseores:block0:6")'> <OreBlock block='denseores:block0:6' weight='0.1' /> </IfCondition>
+                            <OreBlock block='minecraft:coal_ore' weight='0.9' />
+                            <OreBlock block='denseores:block0:6' weight='0.1' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 8.000 * dnsoCoalSize ' range=':= 8.000 * dnsoCoalSize ' type='normal' />
@@ -586,8 +586,8 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("minecraft:iron_ore")'> <OreBlock block='minecraft:iron_ore' weight='0.9' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("denseores:block0")'> <OreBlock block='denseores:block0' weight='0.1' /> </IfCondition>
+                            <OreBlock block='minecraft:iron_ore' weight='0.9' />
+                            <OreBlock block='denseores:block0' weight='0.1' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.238 * _default_ * dnsoIronFreq ' range=':= 2.238 * _default_ * dnsoIronFreq ' type='normal' scaleTo='base' />
@@ -629,8 +629,8 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("minecraft:iron_ore")'> <OreBlock block='minecraft:iron_ore' weight='0.9' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("denseores:block0")'> <OreBlock block='denseores:block0' weight='0.1' /> </IfCondition>
+                            <OreBlock block='minecraft:iron_ore' weight='0.9' />
+                            <OreBlock block='denseores:block0' weight='0.1' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.599 * _default_ * dnsoIronSize ' range=':= 1.599 * _default_ * dnsoIronSize ' type='normal' />
@@ -664,8 +664,8 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("minecraft:iron_ore")'> <OreBlock block='minecraft:iron_ore' weight='0.9' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("denseores:block0")'> <OreBlock block='denseores:block0' weight='0.1' /> </IfCondition>
+                                <OreBlock block='minecraft:iron_ore' weight='0.9' />
+                                <OreBlock block='denseores:block0' weight='0.1' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -683,8 +683,8 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("minecraft:iron_ore")'> <OreBlock block='minecraft:iron_ore' weight='0.9' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("denseores:block0")'> <OreBlock block='denseores:block0' weight='0.1' /> </IfCondition>
+                            <OreBlock block='minecraft:iron_ore' weight='0.9' />
+                            <OreBlock block='denseores:block0' weight='0.1' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * dnsoIronSize ' range=':= 4.000 * dnsoIronSize ' type='normal' />
@@ -709,8 +709,8 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("minecraft:gold_ore")'> <OreBlock block='minecraft:gold_ore' weight='0.9' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("denseores:block0:1")'> <OreBlock block='denseores:block0:1' weight='0.1' /> </IfCondition>
+                            <OreBlock block='minecraft:gold_ore' weight='0.9' />
+                            <OreBlock block='denseores:block0:1' weight='0.1' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.708 * _default_ * dnsoGoldFreq ' range=':= 0.708 * _default_ * dnsoGoldFreq ' type='normal' scaleTo='base' />
@@ -752,8 +752,8 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("minecraft:gold_ore")'> <OreBlock block='minecraft:gold_ore' weight='0.9' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("denseores:block0:1")'> <OreBlock block='denseores:block0:1' weight='0.1' /> </IfCondition>
+                            <OreBlock block='minecraft:gold_ore' weight='0.9' />
+                            <OreBlock block='denseores:block0:1' weight='0.1' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.899 * _default_ * dnsoGoldSize ' range=':= 0.899 * _default_ * dnsoGoldSize ' type='normal' />
@@ -787,8 +787,8 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("minecraft:gold_ore")'> <OreBlock block='minecraft:gold_ore' weight='0.9' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("denseores:block0:1")'> <OreBlock block='denseores:block0:1' weight='0.1' /> </IfCondition>
+                                <OreBlock block='minecraft:gold_ore' weight='0.9' />
+                                <OreBlock block='denseores:block0:1' weight='0.1' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -806,8 +806,8 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("minecraft:gold_ore")'> <OreBlock block='minecraft:gold_ore' weight='0.9' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("denseores:block0:1")'> <OreBlock block='denseores:block0:1' weight='0.1' /> </IfCondition>
+                            <OreBlock block='minecraft:gold_ore' weight='0.9' />
+                            <OreBlock block='denseores:block0:1' weight='0.1' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * dnsoGoldSize ' range=':= 4.000 * dnsoGoldSize ' type='normal' />
@@ -832,8 +832,8 @@
                                 Single vertical veins that occur  with
                                 no motherlodes.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("minecraft:redstone_ore")'> <OreBlock block='minecraft:redstone_ore' weight='0.9' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("denseores:block0:5")'> <OreBlock block='denseores:block0:5' weight='0.1' /> </IfCondition>
+                            <OreBlock block='minecraft:redstone_ore' weight='0.9' />
+                            <OreBlock block='denseores:block0:5' weight='0.1' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.406 * _default_ * dnsoRedstoneFreq ' range=':= 2.406 * _default_ * dnsoRedstoneFreq ' type='normal' scaleTo='base' />
@@ -875,8 +875,8 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("minecraft:redstone_ore")'> <OreBlock block='minecraft:redstone_ore' weight='0.9' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("denseores:block0:5")'> <OreBlock block='denseores:block0:5' weight='0.1' /> </IfCondition>
+                            <OreBlock block='minecraft:redstone_ore' weight='0.9' />
+                            <OreBlock block='denseores:block0:5' weight='0.1' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.230 * _default_ * dnsoRedstoneSize ' range=':= 1.230 * _default_ * dnsoRedstoneSize ' type='normal' />
@@ -910,8 +910,8 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("minecraft:redstone_ore")'> <OreBlock block='minecraft:redstone_ore' weight='0.9' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("denseores:block0:5")'> <OreBlock block='denseores:block0:5' weight='0.1' /> </IfCondition>
+                                <OreBlock block='minecraft:redstone_ore' weight='0.9' />
+                                <OreBlock block='denseores:block0:5' weight='0.1' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -929,8 +929,8 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("minecraft:redstone_ore")'> <OreBlock block='minecraft:redstone_ore' weight='0.9' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("denseores:block0:5")'> <OreBlock block='denseores:block0:5' weight='0.1' /> </IfCondition>
+                            <OreBlock block='minecraft:redstone_ore' weight='0.9' />
+                            <OreBlock block='denseores:block0:5' weight='0.1' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.500 * dnsoRedstoneSize ' range=':= 3.500 * dnsoRedstoneSize ' type='normal' />
@@ -955,8 +955,8 @@
                                 Short sparsely filled veins  sloping
                                 up from near the bottom  of the map.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("minecraft:diamond_ore")'> <OreBlock block='minecraft:diamond_ore' weight='0.9' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("denseores:block0:3")'> <OreBlock block='denseores:block0:3' weight='0.1' /> </IfCondition>
+                            <OreBlock block='minecraft:diamond_ore' weight='0.9' />
+                            <OreBlock block='denseores:block0:3' weight='0.1' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.714 * _default_ * dnsoDiamondFreq ' range=':= 0.714 * _default_ * dnsoDiamondFreq ' type='normal' scaleTo='base' />
@@ -978,7 +978,7 @@
 
                         <!-- Configuring contained material. -->
                         <Veins name='dnsoDiamondVeinsPipe'  inherits='dnsoDiamondVeins' seed='0x197B' drawWireframe='true' wireframeColor='0x608BF4E3' drawBoundBox='false' boundBoxColor='0x608BF4E3'>
-                            <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
+                            <OreBlock block='minecraft:lava' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Replaces block='minecraft:diamond_ore' weight='1.0' />
                             <Replaces block='denseores:block0:3' weight='1.0' />
@@ -1009,8 +1009,8 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("minecraft:diamond_ore")'> <OreBlock block='minecraft:diamond_ore' weight='0.9' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("denseores:block0:3")'> <OreBlock block='denseores:block0:3' weight='0.1' /> </IfCondition>
+                            <OreBlock block='minecraft:diamond_ore' weight='0.9' />
+                            <OreBlock block='denseores:block0:3' weight='0.1' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.731 * _default_ * dnsoDiamondSize ' range=':= 0.731 * _default_ * dnsoDiamondSize ' type='normal' />
@@ -1044,8 +1044,8 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("minecraft:diamond_ore")'> <OreBlock block='minecraft:diamond_ore' weight='0.9' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("denseores:block0:3")'> <OreBlock block='denseores:block0:3' weight='0.1' /> </IfCondition>
+                                <OreBlock block='minecraft:diamond_ore' weight='0.9' />
+                                <OreBlock block='denseores:block0:3' weight='0.1' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -1063,8 +1063,8 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("minecraft:diamond_ore")'> <OreBlock block='minecraft:diamond_ore' weight='0.9' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("denseores:block0:3")'> <OreBlock block='denseores:block0:3' weight='0.1' /> </IfCondition>
+                            <OreBlock block='minecraft:diamond_ore' weight='0.9' />
+                            <OreBlock block='denseores:block0:3' weight='0.1' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.500 * dnsoDiamondSize ' range=':= 3.500 * dnsoDiamondSize ' type='normal' />
@@ -1089,8 +1089,8 @@
                                 Single vertical veins that occur  with
                                 no motherlodes.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("minecraft:lapis_ore")'> <OreBlock block='minecraft:lapis_ore' weight='0.9' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("denseores:block0:2")'> <OreBlock block='denseores:block0:2' weight='0.1' /> </IfCondition>
+                            <OreBlock block='minecraft:lapis_ore' weight='0.9' />
+                            <OreBlock block='denseores:block0:2' weight='0.1' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.787 * _default_ * dnsoLapisLazuliFreq ' range=':= 0.787 * _default_ * dnsoLapisLazuliFreq ' type='normal' scaleTo='base' />
@@ -1133,8 +1133,8 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("minecraft:lapis_ore")'> <OreBlock block='minecraft:lapis_ore' weight='0.9' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("denseores:block0:2")'> <OreBlock block='denseores:block0:2' weight='0.1' /> </IfCondition>
+                            <OreBlock block='minecraft:lapis_ore' weight='0.9' />
+                            <OreBlock block='denseores:block0:2' weight='0.1' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.703 * _default_ * dnsoLapisLazuliSize ' range=':= 0.703 * _default_ * dnsoLapisLazuliSize ' type='normal' />
@@ -1168,8 +1168,8 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("minecraft:lapis_ore")'> <OreBlock block='minecraft:lapis_ore' weight='0.9' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("denseores:block0:2")'> <OreBlock block='denseores:block0:2' weight='0.1' /> </IfCondition>
+                                <OreBlock block='minecraft:lapis_ore' weight='0.9' />
+                                <OreBlock block='denseores:block0:2' weight='0.1' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -1188,8 +1188,8 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("minecraft:lapis_ore")'> <OreBlock block='minecraft:lapis_ore' weight='0.9' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("denseores:block0:2")'> <OreBlock block='denseores:block0:2' weight='0.1' /> </IfCondition>
+                            <OreBlock block='minecraft:lapis_ore' weight='0.9' />
+                            <OreBlock block='denseores:block0:2' weight='0.1' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.000 * dnsoLapisLazuliSize ' range=':= 3.000 * dnsoLapisLazuliSize ' type='normal' />
@@ -1214,8 +1214,8 @@
                                 Short sparsely filled veins  sloping
                                 up from near the bottom  of the map.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("minecraft:emerald_ore")'> <OreBlock block='minecraft:emerald_ore' weight='0.9' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("denseores:block0:4")'> <OreBlock block='denseores:block0:4' weight='0.1' /> </IfCondition>
+                            <OreBlock block='minecraft:emerald_ore' weight='0.9' />
+                            <OreBlock block='denseores:block0:4' weight='0.1' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Mountain'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.145 * _default_ * dnsoEmeraldFreq ' range=':= 1.145 * _default_ * dnsoEmeraldFreq ' type='normal' scaleTo='base' />
@@ -1237,7 +1237,7 @@
 
                         <!-- Configuring contained material. -->
                         <Veins name='dnsoEmeraldVeinsPipe'  inherits='dnsoEmeraldVeins' seed='0x54B3' drawWireframe='true' wireframeColor='0x606CE391' drawBoundBox='false' boundBoxColor='0x606CE391'>
-                            <IfCondition condition=':= ?blockExists("minecraft:monster_egg")'> <OreBlock block='minecraft:monster_egg' weight='1.0' /> </IfCondition>
+                            <OreBlock block='minecraft:monster_egg' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Replaces block='minecraft:emerald_ore' weight='1.0' />
                             <Replaces block='denseores:block0:4' weight='1.0' />
@@ -1268,8 +1268,8 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("minecraft:emerald_ore")'> <OreBlock block='minecraft:emerald_ore' weight='0.9' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("denseores:block0:4")'> <OreBlock block='denseores:block0:4' weight='0.1' /> </IfCondition>
+                            <OreBlock block='minecraft:emerald_ore' weight='0.9' />
+                            <OreBlock block='denseores:block0:4' weight='0.1' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Mountain'  />
                             <Setting name='CloudRadius' avg=':= 0.926 * _default_ * dnsoEmeraldSize ' range=':= 0.926 * _default_ * dnsoEmeraldSize ' type='normal' />
@@ -1303,8 +1303,8 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("minecraft:emerald_ore")'> <OreBlock block='minecraft:emerald_ore' weight='0.9' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("denseores:block0:4")'> <OreBlock block='denseores:block0:4' weight='0.1' /> </IfCondition>
+                                <OreBlock block='minecraft:emerald_ore' weight='0.9' />
+                                <OreBlock block='denseores:block0:4' weight='0.1' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -1322,8 +1322,8 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("minecraft:emerald_ore")'> <OreBlock block='minecraft:emerald_ore' weight='0.9' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("denseores:block0:4")'> <OreBlock block='denseores:block0:4' weight='0.1' /> </IfCondition>
+                            <OreBlock block='minecraft:emerald_ore' weight='0.9' />
+                            <OreBlock block='denseores:block0:4' weight='0.1' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Mountain'  />
                             <Setting name='Size' avg=':= 1.000 * dnsoEmeraldSize ' range=':= 1.000 * dnsoEmeraldSize ' type='normal' />
@@ -1388,8 +1388,8 @@
                                 since it is  harder to get an idea of
                                 their  direction while mining.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("minecraft:quartz_ore")'> <OreBlock block='minecraft:quartz_ore' weight='0.9' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("denseores:block0:7")'> <OreBlock block='denseores:block0:7' weight='0.1' /> </IfCondition>
+                            <OreBlock block='minecraft:quartz_ore' weight='0.9' />
+                            <OreBlock block='denseores:block0:7' weight='0.1' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 6.247 * _default_ * dnsoNetherQuartzFreq ' range=':= 6.247 * _default_ * dnsoNetherQuartzFreq ' type='normal' scaleTo='base' />
@@ -1432,8 +1432,8 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("minecraft:quartz_ore")'> <OreBlock block='minecraft:quartz_ore' weight='0.9' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("denseores:block0:7")'> <OreBlock block='denseores:block0:7' weight='0.1' /> </IfCondition>
+                            <OreBlock block='minecraft:quartz_ore' weight='0.9' />
+                            <OreBlock block='denseores:block0:7' weight='0.1' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.707 * _default_ * dnsoNetherQuartzSize ' range=':= 1.707 * _default_ * dnsoNetherQuartzSize ' type='normal' />
@@ -1467,8 +1467,8 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("minecraft:quartz_ore")'> <OreBlock block='minecraft:quartz_ore' weight='0.9' /> </IfCondition>
-                                <IfCondition condition=':= ?blockExists("denseores:block0:7")'> <OreBlock block='denseores:block0:7' weight='0.1' /> </IfCondition>
+                                <OreBlock block='minecraft:quartz_ore' weight='0.9' />
+                                <OreBlock block='denseores:block0:7' weight='0.1' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -1487,8 +1487,8 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("minecraft:quartz_ore")'> <OreBlock block='minecraft:quartz_ore' weight='0.9' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("denseores:block0:7")'> <OreBlock block='denseores:block0:7' weight='0.1' /> </IfCondition>
+                            <OreBlock block='minecraft:quartz_ore' weight='0.9' />
+                            <OreBlock block='denseores:block0:7' weight='0.1' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 8.000 * dnsoNetherQuartzSize ' range=':= 8.000 * dnsoNetherQuartzSize ' type='normal' />

--- a/src/main/resources/config/modules/ElectriCraft.xml
+++ b/src/main/resources/config/modules/ElectriCraft.xml
@@ -356,7 +356,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore")'> <OreBlock block='ElectriCraft:electricraft_block_ore' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ElectriCraft:electricraft_block_ore' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.226 * _default_ * elcrCopperFreq ' range=':= 1.226 * _default_ * elcrCopperFreq ' type='normal' scaleTo='base' />
@@ -398,7 +398,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore")'> <OreBlock block='ElectriCraft:electricraft_block_ore' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ElectriCraft:electricraft_block_ore' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.183 * _default_ * elcrCopperSize ' range=':= 1.183 * _default_ * elcrCopperSize ' type='normal' />
@@ -432,7 +432,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore")'> <OreBlock block='ElectriCraft:electricraft_block_ore' weight='1.0' /> </IfCondition>
+                                <OreBlock block='ElectriCraft:electricraft_block_ore' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -450,7 +450,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore")'> <OreBlock block='ElectriCraft:electricraft_block_ore' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ElectriCraft:electricraft_block_ore' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.000 * elcrCopperSize ' range=':= 3.000 * elcrCopperSize ' type='normal' />
@@ -475,7 +475,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:1")'> <OreBlock block='ElectriCraft:electricraft_block_ore:1' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ElectriCraft:electricraft_block_ore:1' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.416 * _default_ * elcrTinFreq ' range=':= 1.416 * _default_ * elcrTinFreq ' type='normal' scaleTo='base' />
@@ -517,7 +517,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:1")'> <OreBlock block='ElectriCraft:electricraft_block_ore:1' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ElectriCraft:electricraft_block_ore:1' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.271 * _default_ * elcrTinSize ' range=':= 1.271 * _default_ * elcrTinSize ' type='normal' />
@@ -551,7 +551,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:1")'> <OreBlock block='ElectriCraft:electricraft_block_ore:1' weight='1.0' /> </IfCondition>
+                                <OreBlock block='ElectriCraft:electricraft_block_ore:1' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -569,7 +569,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:1")'> <OreBlock block='ElectriCraft:electricraft_block_ore:1' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ElectriCraft:electricraft_block_ore:1' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * elcrTinSize ' range=':= 4.000 * elcrTinSize ' type='normal' />
@@ -594,7 +594,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:2")'> <OreBlock block='ElectriCraft:electricraft_block_ore:2' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ElectriCraft:electricraft_block_ore:2' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.867 * _default_ * elcrSilverFreq ' range=':= 0.867 * _default_ * elcrSilverFreq ' type='normal' scaleTo='base' />
@@ -636,7 +636,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:2")'> <OreBlock block='ElectriCraft:electricraft_block_ore:2' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ElectriCraft:electricraft_block_ore:2' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.995 * _default_ * elcrSilverSize ' range=':= 0.995 * _default_ * elcrSilverSize ' type='normal' />
@@ -670,7 +670,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:2")'> <OreBlock block='ElectriCraft:electricraft_block_ore:2' weight='1.0' /> </IfCondition>
+                                <OreBlock block='ElectriCraft:electricraft_block_ore:2' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -688,7 +688,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:2")'> <OreBlock block='ElectriCraft:electricraft_block_ore:2' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ElectriCraft:electricraft_block_ore:2' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.000 * elcrSilverSize ' range=':= 3.000 * elcrSilverSize ' type='normal' />
@@ -713,7 +713,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:3")'> <OreBlock block='ElectriCraft:electricraft_block_ore:3' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ElectriCraft:electricraft_block_ore:3' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.226 * _default_ * elcrNickelFreq ' range=':= 1.226 * _default_ * elcrNickelFreq ' type='normal' scaleTo='base' />
@@ -755,7 +755,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:3")'> <OreBlock block='ElectriCraft:electricraft_block_ore:3' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ElectriCraft:electricraft_block_ore:3' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.183 * _default_ * elcrNickelSize ' range=':= 1.183 * _default_ * elcrNickelSize ' type='normal' />
@@ -789,7 +789,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:3")'> <OreBlock block='ElectriCraft:electricraft_block_ore:3' weight='1.0' /> </IfCondition>
+                                <OreBlock block='ElectriCraft:electricraft_block_ore:3' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -807,7 +807,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:3")'> <OreBlock block='ElectriCraft:electricraft_block_ore:3' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ElectriCraft:electricraft_block_ore:3' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * elcrNickelSize ' range=':= 4.000 * elcrNickelSize ' type='normal' />
@@ -832,7 +832,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:4")'> <OreBlock block='ElectriCraft:electricraft_block_ore:4' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ElectriCraft:electricraft_block_ore:4' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.583 * _default_ * elcrAluminumFreq ' range=':= 1.583 * _default_ * elcrAluminumFreq ' type='normal' scaleTo='base' />
@@ -874,7 +874,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:4")'> <OreBlock block='ElectriCraft:electricraft_block_ore:4' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ElectriCraft:electricraft_block_ore:4' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.344 * _default_ * elcrAluminumSize ' range=':= 1.344 * _default_ * elcrAluminumSize ' type='normal' />
@@ -908,7 +908,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:4")'> <OreBlock block='ElectriCraft:electricraft_block_ore:4' weight='1.0' /> </IfCondition>
+                                <OreBlock block='ElectriCraft:electricraft_block_ore:4' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -926,7 +926,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:4")'> <OreBlock block='ElectriCraft:electricraft_block_ore:4' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ElectriCraft:electricraft_block_ore:4' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * elcrAluminumSize ' range=':= 4.000 * elcrAluminumSize ' type='normal' />
@@ -951,7 +951,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:5")'> <OreBlock block='ElectriCraft:electricraft_block_ore:5' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ElectriCraft:electricraft_block_ore:5' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.500 * _default_ * elcrPlatinumFreq ' range=':= 0.500 * _default_ * elcrPlatinumFreq ' type='normal' scaleTo='base' />
@@ -993,7 +993,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:5")'> <OreBlock block='ElectriCraft:electricraft_block_ore:5' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ElectriCraft:electricraft_block_ore:5' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.756 * _default_ * elcrPlatinumSize ' range=':= 0.756 * _default_ * elcrPlatinumSize ' type='normal' />
@@ -1027,7 +1027,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:5")'> <OreBlock block='ElectriCraft:electricraft_block_ore:5' weight='1.0' /> </IfCondition>
+                                <OreBlock block='ElectriCraft:electricraft_block_ore:5' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -1045,7 +1045,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ElectriCraft:electricraft_block_ore:5")'> <OreBlock block='ElectriCraft:electricraft_block_ore:5' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ElectriCraft:electricraft_block_ore:5' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 2.000 * elcrPlatinumSize ' range=':= 2.000 * elcrPlatinumSize ' type='normal' />

--- a/src/main/resources/config/modules/Factorization.xml
+++ b/src/main/resources/config/modules/Factorization.xml
@@ -167,7 +167,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("factorization:ResourceBlock")'> <OreBlock block='factorization:ResourceBlock' weight='1.0' /> </IfCondition>
+                            <OreBlock block='factorization:ResourceBlock' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.811 * _default_ * fctrSilverFreq ' range=':= 0.811 * _default_ * fctrSilverFreq ' type='normal' scaleTo='base' />
@@ -209,7 +209,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("factorization:ResourceBlock")'> <OreBlock block='factorization:ResourceBlock' weight='1.0' /> </IfCondition>
+                            <OreBlock block='factorization:ResourceBlock' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.962 * _default_ * fctrSilverSize ' range=':= 0.962 * _default_ * fctrSilverSize ' type='normal' />
@@ -243,7 +243,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("factorization:ResourceBlock")'> <OreBlock block='factorization:ResourceBlock' weight='1.0' /> </IfCondition>
+                                <OreBlock block='factorization:ResourceBlock' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -261,7 +261,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("factorization:ResourceBlock")'> <OreBlock block='factorization:ResourceBlock' weight='1.0' /> </IfCondition>
+                            <OreBlock block='factorization:ResourceBlock' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.500 * fctrSilverSize ' range=':= 3.500 * fctrSilverSize ' type='normal' />
@@ -293,7 +293,7 @@
                                 since it is  harder to get an idea of
                                 their  direction while mining.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("factorization:DarkIronOre")'> <OreBlock block='factorization:DarkIronOre' weight='1.0' /> </IfCondition>
+                            <OreBlock block='factorization:DarkIronOre' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <ReplacesOre block='dirt' weight='1.0' />
                             <ReplacesOre block='gravel' weight='1.0' />
@@ -337,7 +337,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("factorization:DarkIronOre")'> <OreBlock block='factorization:DarkIronOre' weight='1.0' /> </IfCondition>
+                            <OreBlock block='factorization:DarkIronOre' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <ReplacesOre block='dirt' weight='1.0' />
                             <ReplacesOre block='gravel' weight='1.0' />
@@ -373,7 +373,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("factorization:DarkIronOre")'> <OreBlock block='factorization:DarkIronOre' weight='1.0' /> </IfCondition>
+                                <OreBlock block='factorization:DarkIronOre' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -391,7 +391,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("factorization:DarkIronOre")'> <OreBlock block='factorization:DarkIronOre' weight='1.0' /> </IfCondition>
+                            <OreBlock block='factorization:DarkIronOre' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <ReplacesOre block='dirt' weight='1.0' />
                             <ReplacesOre block='gravel' weight='1.0' />

--- a/src/main/resources/config/modules/FlaxbeardsSteamcraft.xml
+++ b/src/main/resources/config/modules/FlaxbeardsSteamcraft.xml
@@ -167,7 +167,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Steamcraft:steamcraftOre")'> <OreBlock block='Steamcraft:steamcraftOre' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Steamcraft:steamcraftOre' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.251 * _default_ * flxbCopperFreq ' range=':= 1.251 * _default_ * flxbCopperFreq ' type='normal' scaleTo='base' />
@@ -209,7 +209,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Steamcraft:steamcraftOre")'> <OreBlock block='Steamcraft:steamcraftOre' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Steamcraft:steamcraftOre' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.195 * _default_ * flxbCopperSize ' range=':= 1.195 * _default_ * flxbCopperSize ' type='normal' />
@@ -243,7 +243,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("Steamcraft:steamcraftOre")'> <OreBlock block='Steamcraft:steamcraftOre' weight='1.0' /> </IfCondition>
+                                <OreBlock block='Steamcraft:steamcraftOre' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -261,7 +261,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Steamcraft:steamcraftOre")'> <OreBlock block='Steamcraft:steamcraftOre' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Steamcraft:steamcraftOre' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 2.500 * flxbCopperSize ' range=':= 2.500 * flxbCopperSize ' type='normal' />
@@ -286,7 +286,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Steamcraft:steamcraftOre:1")'> <OreBlock block='Steamcraft:steamcraftOre:1' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Steamcraft:steamcraftOre:1' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.936 * _default_ * flxbZincFreq ' range=':= 0.936 * _default_ * flxbZincFreq ' type='normal' scaleTo='base' />
@@ -328,7 +328,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Steamcraft:steamcraftOre:1")'> <OreBlock block='Steamcraft:steamcraftOre:1' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Steamcraft:steamcraftOre:1' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.034 * _default_ * flxbZincSize ' range=':= 1.034 * _default_ * flxbZincSize ' type='normal' />
@@ -362,7 +362,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("Steamcraft:steamcraftOre:1")'> <OreBlock block='Steamcraft:steamcraftOre:1' weight='1.0' /> </IfCondition>
+                                <OreBlock block='Steamcraft:steamcraftOre:1' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -380,7 +380,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Steamcraft:steamcraftOre:1")'> <OreBlock block='Steamcraft:steamcraftOre:1' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Steamcraft:steamcraftOre:1' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 2.000 * flxbZincSize ' range=':= 2.000 * flxbZincSize ' type='normal' />

--- a/src/main/resources/config/modules/Forestry.xml
+++ b/src/main/resources/config/modules/Forestry.xml
@@ -221,7 +221,7 @@
                                 since it is  harder to get an idea of
                                 their  direction while mining.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Forestry:resources")'> <OreBlock block='Forestry:resources' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Forestry:resources' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.599 * _default_ * frstApatiteFreq ' range=':= 2.599 * _default_ * frstApatiteFreq ' type='normal' scaleTo='base' />
@@ -263,7 +263,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Forestry:resources")'> <OreBlock block='Forestry:resources' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Forestry:resources' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.101 * _default_ * frstApatiteSize ' range=':= 1.101 * _default_ * frstApatiteSize ' type='normal' />
@@ -297,7 +297,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("Forestry:resources")'> <OreBlock block='Forestry:resources' weight='1.0' /> </IfCondition>
+                                <OreBlock block='Forestry:resources' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -315,7 +315,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Forestry:resources")'> <OreBlock block='Forestry:resources' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Forestry:resources' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 18.000 * frstApatiteSize ' range=':= 18.000 * frstApatiteSize ' type='normal' />
@@ -340,7 +340,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Forestry:resources:1")'> <OreBlock block='Forestry:resources:1' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Forestry:resources:1' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.938 * _default_ * frstCopperFreq ' range=':= 1.938 * _default_ * frstCopperFreq ' type='normal' scaleTo='base' />
@@ -382,7 +382,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Forestry:resources:1")'> <OreBlock block='Forestry:resources:1' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Forestry:resources:1' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.488 * _default_ * frstCopperSize ' range=':= 1.488 * _default_ * frstCopperSize ' type='normal' />
@@ -416,7 +416,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("Forestry:resources:1")'> <OreBlock block='Forestry:resources:1' weight='1.0' /> </IfCondition>
+                                <OreBlock block='Forestry:resources:1' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -434,7 +434,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Forestry:resources:1")'> <OreBlock block='Forestry:resources:1' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Forestry:resources:1' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.000 * frstCopperSize ' range=':= 3.000 * frstCopperSize ' type='normal' />
@@ -459,7 +459,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Forestry:resources:2")'> <OreBlock block='Forestry:resources:2' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Forestry:resources:2' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.839 * _default_ * frstTinFreq ' range=':= 1.839 * _default_ * frstTinFreq ' type='normal' scaleTo='base' />
@@ -501,7 +501,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Forestry:resources:2")'> <OreBlock block='Forestry:resources:2' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Forestry:resources:2' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.449 * _default_ * frstTinSize ' range=':= 1.449 * _default_ * frstTinSize ' type='normal' />
@@ -535,7 +535,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("Forestry:resources:2")'> <OreBlock block='Forestry:resources:2' weight='1.0' /> </IfCondition>
+                                <OreBlock block='Forestry:resources:2' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -553,7 +553,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Forestry:resources:2")'> <OreBlock block='Forestry:resources:2' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Forestry:resources:2' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.000 * frstTinSize ' range=':= 3.000 * frstTinSize ' type='normal' />

--- a/src/main/resources/config/modules/FossilsandArchaeology.xml
+++ b/src/main/resources/config/modules/FossilsandArchaeology.xml
@@ -175,7 +175,7 @@
                                 since it is  harder to get an idea of
                                 their  direction while mining.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("fossil:fossil")'> <OreBlock block='fossil:fossil' weight='1.0' /> </IfCondition>
+                            <OreBlock block='fossil:fossil' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 7.552 * _default_ * fsarFossilsFreq ' range=':= 7.552 * _default_ * fsarFossilsFreq ' type='normal' scaleTo='base' />
@@ -201,7 +201,7 @@
                                 Ore generation is doubled in
                                 preferred biomes.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("fossil:fossil")'> <OreBlock block='fossil:fossil' weight='1.0' /> </IfCondition>
+                            <OreBlock block='fossil:fossil' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Swamp'  />
                             <BiomeType name='desert'  />
@@ -246,7 +246,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("fossil:fossil")'> <OreBlock block='fossil:fossil' weight='1.0' /> </IfCondition>
+                            <OreBlock block='fossil:fossil' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.877 * _default_ * fsarFossilsSize ' range=':= 1.877 * _default_ * fsarFossilsSize ' type='normal' />
@@ -280,7 +280,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("fossil:fossil")'> <OreBlock block='fossil:fossil' weight='1.0' /> </IfCondition>
+                                <OreBlock block='fossil:fossil' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -292,7 +292,7 @@
                                 Ore generation is doubled in
                                 preferred biomes.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("fossil:fossil")'> <OreBlock block='fossil:fossil' weight='1.0' /> </IfCondition>
+                            <OreBlock block='fossil:fossil' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Swamp'  />
                             <BiomeType name='desert'  />
@@ -311,7 +311,7 @@
                                     Ore generation is doubled in
                                     preferred biomes.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("fossil:fossil")'> <OreBlock block='fossil:fossil' weight='1.0' /> </IfCondition>
+                                <OreBlock block='fossil:fossil' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -331,7 +331,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("fossil:fossil")'> <OreBlock block='fossil:fossil' weight='1.0' /> </IfCondition>
+                            <OreBlock block='fossil:fossil' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * fsarFossilsSize ' range=':= 4.000 * fsarFossilsSize ' type='normal' />
@@ -363,7 +363,7 @@
                                 since it is  harder to get an idea of
                                 their  direction while mining.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("fossil:permafrost")'> <OreBlock block='fossil:permafrost' weight='1.0' /> </IfCondition>
+                            <OreBlock block='fossil:permafrost' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <BiomeType name='Frozen'  />
@@ -406,7 +406,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("fossil:permafrost")'> <OreBlock block='fossil:permafrost' weight='1.0' /> </IfCondition>
+                            <OreBlock block='fossil:permafrost' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <BiomeType name='Frozen'  />
@@ -441,7 +441,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("fossil:permafrost")'> <OreBlock block='fossil:permafrost' weight='1.0' /> </IfCondition>
+                                <OreBlock block='fossil:permafrost' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -460,7 +460,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("fossil:permafrost")'> <OreBlock block='fossil:permafrost' weight='1.0' /> </IfCondition>
+                            <OreBlock block='fossil:permafrost' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <BiomeType name='Frozen'  />

--- a/src/main/resources/config/modules/Galacticraft.xml
+++ b/src/main/resources/config/modules/Galacticraft.xml
@@ -262,7 +262,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("GalacticraftCore:tile.gcBlockCore:5")'> <OreBlock block='GalacticraftCore:tile.gcBlockCore:5' weight='1.0' /> </IfCondition>
+                            <OreBlock block='GalacticraftCore:tile.gcBlockCore:5' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.294 * _default_ * glctCopperFreq ' range=':= 2.294 * _default_ * glctCopperFreq ' type='normal' scaleTo='base' />
@@ -304,7 +304,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("GalacticraftCore:tile.gcBlockCore:5")'> <OreBlock block='GalacticraftCore:tile.gcBlockCore:5' weight='1.0' /> </IfCondition>
+                            <OreBlock block='GalacticraftCore:tile.gcBlockCore:5' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.618 * _default_ * glctCopperSize ' range=':= 1.618 * _default_ * glctCopperSize ' type='normal' />
@@ -338,7 +338,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("GalacticraftCore:tile.gcBlockCore:5")'> <OreBlock block='GalacticraftCore:tile.gcBlockCore:5' weight='1.0' /> </IfCondition>
+                                <OreBlock block='GalacticraftCore:tile.gcBlockCore:5' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -356,7 +356,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("GalacticraftCore:tile.gcBlockCore:5")'> <OreBlock block='GalacticraftCore:tile.gcBlockCore:5' weight='1.0' /> </IfCondition>
+                            <OreBlock block='GalacticraftCore:tile.gcBlockCore:5' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.500 * glctCopperSize ' range=':= 3.500 * glctCopperSize ' type='normal' />
@@ -381,7 +381,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("GalacticraftCore:tile.gcBlockCore:6")'> <OreBlock block='GalacticraftCore:tile.gcBlockCore:6' weight='1.0' /> </IfCondition>
+                            <OreBlock block='GalacticraftCore:tile.gcBlockCore:6' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.196 * _default_ * glctTinFreq ' range=':= 2.196 * _default_ * glctTinFreq ' type='normal' scaleTo='base' />
@@ -423,7 +423,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("GalacticraftCore:tile.gcBlockCore:6")'> <OreBlock block='GalacticraftCore:tile.gcBlockCore:6' weight='1.0' /> </IfCondition>
+                            <OreBlock block='GalacticraftCore:tile.gcBlockCore:6' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.583 * _default_ * glctTinSize ' range=':= 1.583 * _default_ * glctTinSize ' type='normal' />
@@ -457,7 +457,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("GalacticraftCore:tile.gcBlockCore:6")'> <OreBlock block='GalacticraftCore:tile.gcBlockCore:6' weight='1.0' /> </IfCondition>
+                                <OreBlock block='GalacticraftCore:tile.gcBlockCore:6' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -475,7 +475,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("GalacticraftCore:tile.gcBlockCore:6")'> <OreBlock block='GalacticraftCore:tile.gcBlockCore:6' weight='1.0' /> </IfCondition>
+                            <OreBlock block='GalacticraftCore:tile.gcBlockCore:6' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.500 * glctTinSize ' range=':= 3.500 * glctTinSize ' type='normal' />
@@ -500,7 +500,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("GalacticraftCore:tile.gcBlockCore:7")'> <OreBlock block='GalacticraftCore:tile.gcBlockCore:7' weight='1.0' /> </IfCondition>
+                            <OreBlock block='GalacticraftCore:tile.gcBlockCore:7' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.986 * _default_ * glctAluminumFreq ' range=':= 1.986 * _default_ * glctAluminumFreq ' type='normal' scaleTo='base' />
@@ -542,7 +542,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("GalacticraftCore:tile.gcBlockCore:7")'> <OreBlock block='GalacticraftCore:tile.gcBlockCore:7' weight='1.0' /> </IfCondition>
+                            <OreBlock block='GalacticraftCore:tile.gcBlockCore:7' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.506 * _default_ * glctAluminumSize ' range=':= 1.506 * _default_ * glctAluminumSize ' type='normal' />
@@ -576,7 +576,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("GalacticraftCore:tile.gcBlockCore:7")'> <OreBlock block='GalacticraftCore:tile.gcBlockCore:7' weight='1.0' /> </IfCondition>
+                                <OreBlock block='GalacticraftCore:tile.gcBlockCore:7' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -594,7 +594,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("GalacticraftCore:tile.gcBlockCore:7")'> <OreBlock block='GalacticraftCore:tile.gcBlockCore:7' weight='1.0' /> </IfCondition>
+                            <OreBlock block='GalacticraftCore:tile.gcBlockCore:7' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.500 * glctAluminumSize ' range=':= 3.500 * glctAluminumSize ' type='normal' />
@@ -619,7 +619,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("GalacticraftCore:tile.gcBlockCore:8")'> <OreBlock block='GalacticraftCore:tile.gcBlockCore:8' weight='1.0' /> </IfCondition>
+                            <OreBlock block='GalacticraftCore:tile.gcBlockCore:8' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.811 * _default_ * glctSiliconFreq ' range=':= 0.811 * _default_ * glctSiliconFreq ' type='normal' scaleTo='base' />
@@ -661,7 +661,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("GalacticraftCore:tile.gcBlockCore:8")'> <OreBlock block='GalacticraftCore:tile.gcBlockCore:8' weight='1.0' /> </IfCondition>
+                            <OreBlock block='GalacticraftCore:tile.gcBlockCore:8' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.962 * _default_ * glctSiliconSize ' range=':= 0.962 * _default_ * glctSiliconSize ' type='normal' />
@@ -695,7 +695,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("GalacticraftCore:tile.gcBlockCore:8")'> <OreBlock block='GalacticraftCore:tile.gcBlockCore:8' weight='1.0' /> </IfCondition>
+                                <OreBlock block='GalacticraftCore:tile.gcBlockCore:8' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -713,7 +713,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("GalacticraftCore:tile.gcBlockCore:8")'> <OreBlock block='GalacticraftCore:tile.gcBlockCore:8' weight='1.0' /> </IfCondition>
+                            <OreBlock block='GalacticraftCore:tile.gcBlockCore:8' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.500 * glctSiliconSize ' range=':= 3.500 * glctSiliconSize ' type='normal' />

--- a/src/main/resources/config/modules/GeoStrata.xml
+++ b/src/main/resources/config/modules/GeoStrata.xml
@@ -876,7 +876,7 @@
                                 to provide  realistic distribution of
                                 stone  in a strata formation.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_shale_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_shale_smooth' weight='1.0' /> </IfCondition>
+                            <OreBlock block='GeoStrata:geostrata_rock_shale_smooth' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.809 * _default_ * gstaShaleSize ' range=':= 1.809 * _default_ * gstaShaleSize ' type='normal' />
@@ -903,7 +903,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_shale_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_shale_smooth' weight='1.0' /> </IfCondition>
+                            <OreBlock block='GeoStrata:geostrata_rock_shale_smooth' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 4.904 * _default_ * gstaShaleFreq ' range=':= 4.904 * _default_ * gstaShaleFreq ' type='normal' scaleTo='base' />
@@ -935,7 +935,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_shale_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_shale_smooth' weight='1.0' /> </IfCondition>
+                            <OreBlock block='GeoStrata:geostrata_rock_shale_smooth' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 16.000 * gstaShaleSize ' range=':= 16.000 * gstaShaleSize ' type='normal' />
@@ -962,7 +962,7 @@
                                 to provide  realistic distribution of
                                 stone  in a strata formation.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_sandstone_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_sandstone_smooth' weight='1.0' /> </IfCondition>
+                            <OreBlock block='GeoStrata:geostrata_rock_sandstone_smooth' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.809 * _default_ * gstaSandstoneSize ' range=':= 1.809 * _default_ * gstaSandstoneSize ' type='normal' />
@@ -989,7 +989,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_sandstone_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_sandstone_smooth' weight='1.0' /> </IfCondition>
+                            <OreBlock block='GeoStrata:geostrata_rock_sandstone_smooth' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 4.904 * _default_ * gstaSandstoneFreq ' range=':= 4.904 * _default_ * gstaSandstoneFreq ' type='normal' scaleTo='base' />
@@ -1021,7 +1021,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_sandstone_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_sandstone_smooth' weight='1.0' /> </IfCondition>
+                            <OreBlock block='GeoStrata:geostrata_rock_sandstone_smooth' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 16.000 * gstaSandstoneSize ' range=':= 16.000 * gstaSandstoneSize ' type='normal' />
@@ -1048,7 +1048,7 @@
                                 to provide  realistic distribution of
                                 stone  in a strata formation.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_limestone_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_limestone_smooth' weight='1.0' /> </IfCondition>
+                            <OreBlock block='GeoStrata:geostrata_rock_limestone_smooth' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.809 * _default_ * gstaLimestoneSize ' range=':= 1.809 * _default_ * gstaLimestoneSize ' type='normal' />
@@ -1075,7 +1075,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_limestone_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_limestone_smooth' weight='1.0' /> </IfCondition>
+                            <OreBlock block='GeoStrata:geostrata_rock_limestone_smooth' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 4.904 * _default_ * gstaLimestoneFreq ' range=':= 4.904 * _default_ * gstaLimestoneFreq ' type='normal' scaleTo='base' />
@@ -1107,7 +1107,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_limestone_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_limestone_smooth' weight='1.0' /> </IfCondition>
+                            <OreBlock block='GeoStrata:geostrata_rock_limestone_smooth' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 16.000 * gstaLimestoneSize ' range=':= 16.000 * gstaLimestoneSize ' type='normal' />
@@ -1134,7 +1134,7 @@
                                 to provide  realistic distribution of
                                 stone  in a strata formation.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_pumice_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_pumice_smooth' weight='1.0' /> </IfCondition>
+                            <OreBlock block='GeoStrata:geostrata_rock_pumice_smooth' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.592 * _default_ * gstaPumiceSize ' range=':= 1.592 * _default_ * gstaPumiceSize ' type='normal' />
@@ -1161,7 +1161,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_pumice_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_pumice_smooth' weight='1.0' /> </IfCondition>
+                            <OreBlock block='GeoStrata:geostrata_rock_pumice_smooth' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 3.798 * _default_ * gstaPumiceFreq ' range=':= 3.798 * _default_ * gstaPumiceFreq ' type='normal' scaleTo='base' />
@@ -1193,7 +1193,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_pumice_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_pumice_smooth' weight='1.0' /> </IfCondition>
+                            <OreBlock block='GeoStrata:geostrata_rock_pumice_smooth' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 16.000 * gstaPumiceSize ' range=':= 16.000 * gstaPumiceSize ' type='normal' />
@@ -1220,7 +1220,7 @@
                                 to provide  realistic distribution of
                                 stone  in a strata formation.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_opal_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_opal_smooth' weight='1.0' /> </IfCondition>
+                            <OreBlock block='GeoStrata:geostrata_rock_opal_smooth' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.076 * _default_ * gstaOpalSize ' range=':= 1.076 * _default_ * gstaOpalSize ' type='normal' />
@@ -1247,7 +1247,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_opal_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_opal_smooth' weight='1.0' /> </IfCondition>
+                            <OreBlock block='GeoStrata:geostrata_rock_opal_smooth' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.734 * _default_ * gstaOpalFreq ' range=':= 1.734 * _default_ * gstaOpalFreq ' type='normal' scaleTo='base' />
@@ -1279,7 +1279,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_opal_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_opal_smooth' weight='1.0' /> </IfCondition>
+                            <OreBlock block='GeoStrata:geostrata_rock_opal_smooth' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 16.000 * gstaOpalSize ' range=':= 16.000 * gstaOpalSize ' type='normal' />
@@ -1306,7 +1306,7 @@
                                 to provide  realistic distribution of
                                 stone  in a strata formation.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_slate_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_slate_smooth' weight='1.0' /> </IfCondition>
+                            <OreBlock block='GeoStrata:geostrata_rock_slate_smooth' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.809 * _default_ * gstaSlateSize ' range=':= 1.809 * _default_ * gstaSlateSize ' type='normal' />
@@ -1333,7 +1333,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_slate_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_slate_smooth' weight='1.0' /> </IfCondition>
+                            <OreBlock block='GeoStrata:geostrata_rock_slate_smooth' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 4.904 * _default_ * gstaSlateFreq ' range=':= 4.904 * _default_ * gstaSlateFreq ' type='normal' scaleTo='base' />
@@ -1365,7 +1365,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_slate_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_slate_smooth' weight='1.0' /> </IfCondition>
+                            <OreBlock block='GeoStrata:geostrata_rock_slate_smooth' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 16.000 * gstaSlateSize ' range=':= 16.000 * gstaSlateSize ' type='normal' />
@@ -1392,7 +1392,7 @@
                                 to provide  realistic distribution of
                                 stone  in a strata formation.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_gneiss_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_gneiss_smooth' weight='1.0' /> </IfCondition>
+                            <OreBlock block='GeoStrata:geostrata_rock_gneiss_smooth' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.711 * _default_ * gstaGneissSize ' range=':= 1.711 * _default_ * gstaGneissSize ' type='normal' />
@@ -1419,7 +1419,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_gneiss_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_gneiss_smooth' weight='1.0' /> </IfCondition>
+                            <OreBlock block='GeoStrata:geostrata_rock_gneiss_smooth' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 4.386 * _default_ * gstaGneissFreq ' range=':= 4.386 * _default_ * gstaGneissFreq ' type='normal' scaleTo='base' />
@@ -1451,7 +1451,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_gneiss_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_gneiss_smooth' weight='1.0' /> </IfCondition>
+                            <OreBlock block='GeoStrata:geostrata_rock_gneiss_smooth' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 16.000 * gstaGneissSize ' range=':= 16.000 * gstaGneissSize ' type='normal' />
@@ -1478,7 +1478,7 @@
                                 to provide  realistic distribution of
                                 stone  in a strata formation.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_peridotite_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_peridotite_smooth' weight='1.0' /> </IfCondition>
+                            <OreBlock block='GeoStrata:geostrata_rock_peridotite_smooth' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.592 * _default_ * gstaPeridotiteSize ' range=':= 1.592 * _default_ * gstaPeridotiteSize ' type='normal' />
@@ -1505,7 +1505,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_peridotite_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_peridotite_smooth' weight='1.0' /> </IfCondition>
+                            <OreBlock block='GeoStrata:geostrata_rock_peridotite_smooth' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 3.798 * _default_ * gstaPeridotiteFreq ' range=':= 3.798 * _default_ * gstaPeridotiteFreq ' type='normal' scaleTo='base' />
@@ -1537,7 +1537,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_peridotite_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_peridotite_smooth' weight='1.0' /> </IfCondition>
+                            <OreBlock block='GeoStrata:geostrata_rock_peridotite_smooth' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 16.000 * gstaPeridotiteSize ' range=':= 16.000 * gstaPeridotiteSize ' type='normal' />
@@ -1564,7 +1564,7 @@
                                 to provide  realistic distribution of
                                 stone  in a strata formation.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_granulite_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_granulite_smooth' weight='1.0' /> </IfCondition>
+                            <OreBlock block='GeoStrata:geostrata_rock_granulite_smooth' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.655 * _default_ * gstaGranuliteSize ' range=':= 1.655 * _default_ * gstaGranuliteSize ' type='normal' />
@@ -1591,7 +1591,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_granulite_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_granulite_smooth' weight='1.0' /> </IfCondition>
+                            <OreBlock block='GeoStrata:geostrata_rock_granulite_smooth' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 4.103 * _default_ * gstaGranuliteFreq ' range=':= 4.103 * _default_ * gstaGranuliteFreq ' type='normal' scaleTo='base' />
@@ -1623,7 +1623,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_granulite_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_granulite_smooth' weight='1.0' /> </IfCondition>
+                            <OreBlock block='GeoStrata:geostrata_rock_granulite_smooth' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 16.000 * gstaGranuliteSize ' range=':= 16.000 * gstaGranuliteSize ' type='normal' />
@@ -1650,7 +1650,7 @@
                                 to provide  realistic distribution of
                                 stone  in a strata formation.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_migmatite_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_migmatite_smooth' weight='1.0' /> </IfCondition>
+                            <OreBlock block='GeoStrata:geostrata_rock_migmatite_smooth' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.592 * _default_ * gstaMigmatiteSize ' range=':= 1.592 * _default_ * gstaMigmatiteSize ' type='normal' />
@@ -1677,7 +1677,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_migmatite_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_migmatite_smooth' weight='1.0' /> </IfCondition>
+                            <OreBlock block='GeoStrata:geostrata_rock_migmatite_smooth' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 3.798 * _default_ * gstaMigmatiteFreq ' range=':= 3.798 * _default_ * gstaMigmatiteFreq ' type='normal' scaleTo='base' />
@@ -1709,7 +1709,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_migmatite_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_migmatite_smooth' weight='1.0' /> </IfCondition>
+                            <OreBlock block='GeoStrata:geostrata_rock_migmatite_smooth' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 16.000 * gstaMigmatiteSize ' range=':= 16.000 * gstaMigmatiteSize ' type='normal' />
@@ -1736,7 +1736,7 @@
                                 to provide  realistic distribution of
                                 stone  in a strata formation.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_schist_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_schist_smooth' weight='1.0' /> </IfCondition>
+                            <OreBlock block='GeoStrata:geostrata_rock_schist_smooth' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.711 * _default_ * gstaSchistSize ' range=':= 1.711 * _default_ * gstaSchistSize ' type='normal' />
@@ -1763,7 +1763,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_schist_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_schist_smooth' weight='1.0' /> </IfCondition>
+                            <OreBlock block='GeoStrata:geostrata_rock_schist_smooth' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 4.386 * _default_ * gstaSchistFreq ' range=':= 4.386 * _default_ * gstaSchistFreq ' type='normal' scaleTo='base' />
@@ -1795,7 +1795,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_schist_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_schist_smooth' weight='1.0' /> </IfCondition>
+                            <OreBlock block='GeoStrata:geostrata_rock_schist_smooth' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 16.000 * gstaSchistSize ' range=':= 16.000 * gstaSchistSize ' type='normal' />
@@ -1822,7 +1822,7 @@
                                 to provide  realistic distribution of
                                 stone  in a strata formation.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_basalt_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_basalt_smooth' weight='1.0' /> </IfCondition>
+                            <OreBlock block='GeoStrata:geostrata_rock_basalt_smooth' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.809 * _default_ * gstaBasaltSize ' range=':= 1.809 * _default_ * gstaBasaltSize ' type='normal' />
@@ -1849,7 +1849,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_basalt_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_basalt_smooth' weight='1.0' /> </IfCondition>
+                            <OreBlock block='GeoStrata:geostrata_rock_basalt_smooth' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 4.904 * _default_ * gstaBasaltFreq ' range=':= 4.904 * _default_ * gstaBasaltFreq ' type='normal' scaleTo='base' />
@@ -1881,7 +1881,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_basalt_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_basalt_smooth' weight='1.0' /> </IfCondition>
+                            <OreBlock block='GeoStrata:geostrata_rock_basalt_smooth' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 16.000 * gstaBasaltSize ' range=':= 16.000 * gstaBasaltSize ' type='normal' />
@@ -1908,7 +1908,7 @@
                                 to provide  realistic distribution of
                                 stone  in a strata formation.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_onyx_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_onyx_smooth' weight='1.0' /> </IfCondition>
+                            <OreBlock block='GeoStrata:geostrata_rock_onyx_smooth' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.809 * _default_ * gstaOnyxSize ' range=':= 1.809 * _default_ * gstaOnyxSize ' type='normal' />
@@ -1935,7 +1935,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_onyx_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_onyx_smooth' weight='1.0' /> </IfCondition>
+                            <OreBlock block='GeoStrata:geostrata_rock_onyx_smooth' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 4.904 * _default_ * gstaOnyxFreq ' range=':= 4.904 * _default_ * gstaOnyxFreq ' type='normal' scaleTo='base' />
@@ -1967,7 +1967,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_onyx_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_onyx_smooth' weight='1.0' /> </IfCondition>
+                            <OreBlock block='GeoStrata:geostrata_rock_onyx_smooth' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 16.000 * gstaOnyxSize ' range=':= 16.000 * gstaOnyxSize ' type='normal' />
@@ -1994,7 +1994,7 @@
                                 to provide  realistic distribution of
                                 stone  in a strata formation.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_quartz_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_quartz_smooth' weight='1.0' /> </IfCondition>
+                            <OreBlock block='GeoStrata:geostrata_rock_quartz_smooth' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.521 * _default_ * gstaQuartzSize ' range=':= 1.521 * _default_ * gstaQuartzSize ' type='normal' />
@@ -2021,7 +2021,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_quartz_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_quartz_smooth' weight='1.0' /> </IfCondition>
+                            <OreBlock block='GeoStrata:geostrata_rock_quartz_smooth' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 3.467 * _default_ * gstaQuartzFreq ' range=':= 3.467 * _default_ * gstaQuartzFreq ' type='normal' scaleTo='base' />
@@ -2053,7 +2053,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_quartz_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_quartz_smooth' weight='1.0' /> </IfCondition>
+                            <OreBlock block='GeoStrata:geostrata_rock_quartz_smooth' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 16.000 * gstaQuartzSize ' range=':= 16.000 * gstaQuartzSize ' type='normal' />
@@ -2080,7 +2080,7 @@
                                 to provide  realistic distribution of
                                 stone  in a strata formation.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_marble_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_marble_smooth' weight='1.0' /> </IfCondition>
+                            <OreBlock block='GeoStrata:geostrata_rock_marble_smooth' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.809 * _default_ * gstaMarbleSize ' range=':= 1.809 * _default_ * gstaMarbleSize ' type='normal' />
@@ -2107,7 +2107,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_marble_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_marble_smooth' weight='1.0' /> </IfCondition>
+                            <OreBlock block='GeoStrata:geostrata_rock_marble_smooth' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 4.904 * _default_ * gstaMarbleFreq ' range=':= 4.904 * _default_ * gstaMarbleFreq ' type='normal' scaleTo='base' />
@@ -2139,7 +2139,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_marble_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_marble_smooth' weight='1.0' /> </IfCondition>
+                            <OreBlock block='GeoStrata:geostrata_rock_marble_smooth' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 16.000 * gstaMarbleSize ' range=':= 16.000 * gstaMarbleSize ' type='normal' />
@@ -2166,7 +2166,7 @@
                                 to provide  realistic distribution of
                                 stone  in a strata formation.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_granite_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_granite_smooth' weight='1.0' /> </IfCondition>
+                            <OreBlock block='GeoStrata:geostrata_rock_granite_smooth' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.809 * _default_ * gstaGraniteSize ' range=':= 1.809 * _default_ * gstaGraniteSize ' type='normal' />
@@ -2193,7 +2193,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_granite_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_granite_smooth' weight='1.0' /> </IfCondition>
+                            <OreBlock block='GeoStrata:geostrata_rock_granite_smooth' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 4.904 * _default_ * gstaGraniteFreq ' range=':= 4.904 * _default_ * gstaGraniteFreq ' type='normal' scaleTo='base' />
@@ -2225,7 +2225,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_granite_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_granite_smooth' weight='1.0' /> </IfCondition>
+                            <OreBlock block='GeoStrata:geostrata_rock_granite_smooth' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 16.000 * gstaGraniteSize ' range=':= 16.000 * gstaGraniteSize ' type='normal' />
@@ -2252,7 +2252,7 @@
                                 to provide  realistic distribution of
                                 stone  in a strata formation.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_hornfel_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_hornfel_smooth' weight='1.0' /> </IfCondition>
+                            <OreBlock block='GeoStrata:geostrata_rock_hornfel_smooth' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.711 * _default_ * gstaHornfelSize ' range=':= 1.711 * _default_ * gstaHornfelSize ' type='normal' />
@@ -2279,7 +2279,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_hornfel_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_hornfel_smooth' weight='1.0' /> </IfCondition>
+                            <OreBlock block='GeoStrata:geostrata_rock_hornfel_smooth' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 4.386 * _default_ * gstaHornfelFreq ' range=':= 4.386 * _default_ * gstaHornfelFreq ' type='normal' scaleTo='base' />
@@ -2311,7 +2311,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("GeoStrata:geostrata_rock_hornfel_smooth")'> <OreBlock block='GeoStrata:geostrata_rock_hornfel_smooth' weight='1.0' /> </IfCondition>
+                            <OreBlock block='GeoStrata:geostrata_rock_hornfel_smooth' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 16.000 * gstaHornfelSize ' range=':= 16.000 * gstaHornfelSize ' type='normal' />

--- a/src/main/resources/config/modules/ImmersiveEngineering.xml
+++ b/src/main/resources/config/modules/ImmersiveEngineering.xml
@@ -308,7 +308,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ImmersiveEngineering:ore:0")'> <OreBlock block='ImmersiveEngineering:ore:0' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ImmersiveEngineering:ore:0' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.416 * _default_ * iengCopperFreq ' range=':= 1.416 * _default_ * iengCopperFreq ' type='normal' scaleTo='base' />
@@ -350,7 +350,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ImmersiveEngineering:ore:0")'> <OreBlock block='ImmersiveEngineering:ore:0' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ImmersiveEngineering:ore:0' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.271 * _default_ * iengCopperSize ' range=':= 1.271 * _default_ * iengCopperSize ' type='normal' />
@@ -384,7 +384,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("ImmersiveEngineering:ore:0")'> <OreBlock block='ImmersiveEngineering:ore:0' weight='1.0' /> </IfCondition>
+                                <OreBlock block='ImmersiveEngineering:ore:0' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -402,7 +402,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ImmersiveEngineering:ore:0")'> <OreBlock block='ImmersiveEngineering:ore:0' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ImmersiveEngineering:ore:0' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * iengCopperSize ' range=':= 4.000 * iengCopperSize ' type='normal' />
@@ -427,7 +427,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ImmersiveEngineering:ore:1")'> <OreBlock block='ImmersiveEngineering:ore:1' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ImmersiveEngineering:ore:1' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.001 * _default_ * iengBauxiteFreq ' range=':= 1.001 * _default_ * iengBauxiteFreq ' type='normal' scaleTo='base' />
@@ -469,7 +469,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ImmersiveEngineering:ore:1")'> <OreBlock block='ImmersiveEngineering:ore:1' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ImmersiveEngineering:ore:1' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.069 * _default_ * iengBauxiteSize ' range=':= 1.069 * _default_ * iengBauxiteSize ' type='normal' />
@@ -503,7 +503,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("ImmersiveEngineering:ore:1")'> <OreBlock block='ImmersiveEngineering:ore:1' weight='1.0' /> </IfCondition>
+                                <OreBlock block='ImmersiveEngineering:ore:1' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -521,7 +521,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ImmersiveEngineering:ore:1")'> <OreBlock block='ImmersiveEngineering:ore:1' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ImmersiveEngineering:ore:1' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 2.000 * iengBauxiteSize ' range=':= 2.000 * iengBauxiteSize ' type='normal' />
@@ -546,7 +546,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ImmersiveEngineering:ore:2")'> <OreBlock block='ImmersiveEngineering:ore:2' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ImmersiveEngineering:ore:2' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.867 * _default_ * iengLeadFreq ' range=':= 0.867 * _default_ * iengLeadFreq ' type='normal' scaleTo='base' />
@@ -588,7 +588,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ImmersiveEngineering:ore:2")'> <OreBlock block='ImmersiveEngineering:ore:2' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ImmersiveEngineering:ore:2' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.995 * _default_ * iengLeadSize ' range=':= 0.995 * _default_ * iengLeadSize ' type='normal' />
@@ -622,7 +622,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("ImmersiveEngineering:ore:2")'> <OreBlock block='ImmersiveEngineering:ore:2' weight='1.0' /> </IfCondition>
+                                <OreBlock block='ImmersiveEngineering:ore:2' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -640,7 +640,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ImmersiveEngineering:ore:2")'> <OreBlock block='ImmersiveEngineering:ore:2' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ImmersiveEngineering:ore:2' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.000 * iengLeadSize ' range=':= 3.000 * iengLeadSize ' type='normal' />
@@ -665,7 +665,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ImmersiveEngineering:ore:3")'> <OreBlock block='ImmersiveEngineering:ore:3' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ImmersiveEngineering:ore:3' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.001 * _default_ * iengSilverFreq ' range=':= 1.001 * _default_ * iengSilverFreq ' type='normal' scaleTo='base' />
@@ -707,7 +707,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ImmersiveEngineering:ore:3")'> <OreBlock block='ImmersiveEngineering:ore:3' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ImmersiveEngineering:ore:3' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.069 * _default_ * iengSilverSize ' range=':= 1.069 * _default_ * iengSilverSize ' type='normal' />
@@ -741,7 +741,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("ImmersiveEngineering:ore:3")'> <OreBlock block='ImmersiveEngineering:ore:3' weight='1.0' /> </IfCondition>
+                                <OreBlock block='ImmersiveEngineering:ore:3' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -759,7 +759,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ImmersiveEngineering:ore:3")'> <OreBlock block='ImmersiveEngineering:ore:3' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ImmersiveEngineering:ore:3' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * iengSilverSize ' range=':= 4.000 * iengSilverSize ' type='normal' />
@@ -784,7 +784,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ImmersiveEngineering:ore:4")'> <OreBlock block='ImmersiveEngineering:ore:4' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ImmersiveEngineering:ore:4' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.613 * _default_ * iengNickelFreq ' range=':= 0.613 * _default_ * iengNickelFreq ' type='normal' scaleTo='base' />
@@ -826,7 +826,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ImmersiveEngineering:ore:4")'> <OreBlock block='ImmersiveEngineering:ore:4' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ImmersiveEngineering:ore:4' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.837 * _default_ * iengNickelSize ' range=':= 0.837 * _default_ * iengNickelSize ' type='normal' />
@@ -860,7 +860,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("ImmersiveEngineering:ore:4")'> <OreBlock block='ImmersiveEngineering:ore:4' weight='1.0' /> </IfCondition>
+                                <OreBlock block='ImmersiveEngineering:ore:4' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -878,7 +878,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ImmersiveEngineering:ore:4")'> <OreBlock block='ImmersiveEngineering:ore:4' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ImmersiveEngineering:ore:4' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.000 * iengNickelSize ' range=':= 3.000 * iengNickelSize ' type='normal' />

--- a/src/main/resources/config/modules/Mekanism.xml
+++ b/src/main/resources/config/modules/Mekanism.xml
@@ -213,7 +213,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Mekanism:OreBlock")'> <OreBlock block='Mekanism:OreBlock' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Mekanism:OreBlock' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.734 * _default_ * mknsOsmiumFreq ' range=':= 1.734 * _default_ * mknsOsmiumFreq ' type='normal' scaleTo='base' />
@@ -255,7 +255,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Mekanism:OreBlock")'> <OreBlock block='Mekanism:OreBlock' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Mekanism:OreBlock' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.407 * _default_ * mknsOsmiumSize ' range=':= 1.407 * _default_ * mknsOsmiumSize ' type='normal' />
@@ -289,7 +289,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("Mekanism:OreBlock")'> <OreBlock block='Mekanism:OreBlock' weight='1.0' /> </IfCondition>
+                                <OreBlock block='Mekanism:OreBlock' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -307,7 +307,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Mekanism:OreBlock")'> <OreBlock block='Mekanism:OreBlock' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Mekanism:OreBlock' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * mknsOsmiumSize ' range=':= 4.000 * mknsOsmiumSize ' type='normal' />
@@ -332,7 +332,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Mekanism:OreBlock:1")'> <OreBlock block='Mekanism:OreBlock:1' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Mekanism:OreBlock:1' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.002 * _default_ * mknsCopperFreq ' range=':= 2.002 * _default_ * mknsCopperFreq ' type='normal' scaleTo='base' />
@@ -374,7 +374,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Mekanism:OreBlock:1")'> <OreBlock block='Mekanism:OreBlock:1' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Mekanism:OreBlock:1' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.512 * _default_ * mknsCopperSize ' range=':= 1.512 * _default_ * mknsCopperSize ' type='normal' />
@@ -408,7 +408,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("Mekanism:OreBlock:1")'> <OreBlock block='Mekanism:OreBlock:1' weight='1.0' /> </IfCondition>
+                                <OreBlock block='Mekanism:OreBlock:1' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -426,7 +426,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Mekanism:OreBlock:1")'> <OreBlock block='Mekanism:OreBlock:1' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Mekanism:OreBlock:1' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * mknsCopperSize ' range=':= 4.000 * mknsCopperSize ' type='normal' />
@@ -451,7 +451,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Mekanism:OreBlock:2")'> <OreBlock block='Mekanism:OreBlock:2' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Mekanism:OreBlock:2' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.873 * _default_ * mknsTinFreq ' range=':= 1.873 * _default_ * mknsTinFreq ' type='normal' scaleTo='base' />
@@ -493,7 +493,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Mekanism:OreBlock:2")'> <OreBlock block='Mekanism:OreBlock:2' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Mekanism:OreBlock:2' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.462 * _default_ * mknsTinSize ' range=':= 1.462 * _default_ * mknsTinSize ' type='normal' />
@@ -527,7 +527,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("Mekanism:OreBlock:2")'> <OreBlock block='Mekanism:OreBlock:2' weight='1.0' /> </IfCondition>
+                                <OreBlock block='Mekanism:OreBlock:2' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -545,7 +545,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Mekanism:OreBlock:2")'> <OreBlock block='Mekanism:OreBlock:2' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Mekanism:OreBlock:2' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * mknsTinSize ' range=':= 4.000 * mknsTinSize ' type='normal' />

--- a/src/main/resources/config/modules/Metallurgy4.xml
+++ b/src/main/resources/config/modules/Metallurgy4.xml
@@ -1720,7 +1720,7 @@
                                 since it is  harder to get an idea of
                                 their  direction while mining.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore")'> <OreBlock block='Metallurgy:utility.ore' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:utility.ore' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.733 * _default_ * mtlgSulfurFreq ' range=':= 1.733 * _default_ * mtlgSulfurFreq ' type='normal' scaleTo='base' />
@@ -1762,7 +1762,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore")'> <OreBlock block='Metallurgy:utility.ore' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:utility.ore' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.899 * _default_ * mtlgSulfurSize ' range=':= 0.899 * _default_ * mtlgSulfurSize ' type='normal' />
@@ -1796,7 +1796,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore")'> <OreBlock block='Metallurgy:utility.ore' weight='1.0' /> </IfCondition>
+                                <OreBlock block='Metallurgy:utility.ore' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -1814,7 +1814,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore")'> <OreBlock block='Metallurgy:utility.ore' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:utility.ore' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 2.000 * mtlgSulfurSize ' range=':= 2.000 * mtlgSulfurSize ' type='normal' />
@@ -1846,7 +1846,7 @@
                                 since it is  harder to get an idea of
                                 their  direction while mining.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:1")'> <OreBlock block='Metallurgy:utility.ore:1' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:utility.ore:1' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.733 * _default_ * mtlgPhosphoriteFreq ' range=':= 1.733 * _default_ * mtlgPhosphoriteFreq ' type='normal' scaleTo='base' />
@@ -1888,7 +1888,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:1")'> <OreBlock block='Metallurgy:utility.ore:1' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:utility.ore:1' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.899 * _default_ * mtlgPhosphoriteSize ' range=':= 0.899 * _default_ * mtlgPhosphoriteSize ' type='normal' />
@@ -1922,7 +1922,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:1")'> <OreBlock block='Metallurgy:utility.ore:1' weight='1.0' /> </IfCondition>
+                                <OreBlock block='Metallurgy:utility.ore:1' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -1941,7 +1941,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:1")'> <OreBlock block='Metallurgy:utility.ore:1' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:utility.ore:1' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 2.000 * mtlgPhosphoriteSize ' range=':= 2.000 * mtlgPhosphoriteSize ' type='normal' />
@@ -1973,7 +1973,7 @@
                                 since it is  harder to get an idea of
                                 their  direction while mining.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:2")'> <OreBlock block='Metallurgy:utility.ore:2' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:utility.ore:2' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.733 * _default_ * mtlgSaltpeterFreq ' range=':= 1.733 * _default_ * mtlgSaltpeterFreq ' type='normal' scaleTo='base' />
@@ -2015,7 +2015,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:2")'> <OreBlock block='Metallurgy:utility.ore:2' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:utility.ore:2' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.899 * _default_ * mtlgSaltpeterSize ' range=':= 0.899 * _default_ * mtlgSaltpeterSize ' type='normal' />
@@ -2049,7 +2049,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:2")'> <OreBlock block='Metallurgy:utility.ore:2' weight='1.0' /> </IfCondition>
+                                <OreBlock block='Metallurgy:utility.ore:2' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -2067,7 +2067,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:2")'> <OreBlock block='Metallurgy:utility.ore:2' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:utility.ore:2' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 2.000 * mtlgSaltpeterSize ' range=':= 2.000 * mtlgSaltpeterSize ' type='normal' />
@@ -2099,7 +2099,7 @@
                                 since it is  harder to get an idea of
                                 their  direction while mining.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:3")'> <OreBlock block='Metallurgy:utility.ore:3' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:utility.ore:3' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.733 * _default_ * mtlgMagnesiumFreq ' range=':= 1.733 * _default_ * mtlgMagnesiumFreq ' type='normal' scaleTo='base' />
@@ -2141,7 +2141,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:3")'> <OreBlock block='Metallurgy:utility.ore:3' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:utility.ore:3' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.899 * _default_ * mtlgMagnesiumSize ' range=':= 0.899 * _default_ * mtlgMagnesiumSize ' type='normal' />
@@ -2175,7 +2175,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:3")'> <OreBlock block='Metallurgy:utility.ore:3' weight='1.0' /> </IfCondition>
+                                <OreBlock block='Metallurgy:utility.ore:3' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -2193,7 +2193,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:3")'> <OreBlock block='Metallurgy:utility.ore:3' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:utility.ore:3' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 2.000 * mtlgMagnesiumSize ' range=':= 2.000 * mtlgMagnesiumSize ' type='normal' />
@@ -2225,7 +2225,7 @@
                                 since it is  harder to get an idea of
                                 their  direction while mining.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:4")'> <OreBlock block='Metallurgy:utility.ore:4' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:utility.ore:4' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.733 * _default_ * mtlgBitumenFreq ' range=':= 1.733 * _default_ * mtlgBitumenFreq ' type='normal' scaleTo='base' />
@@ -2267,7 +2267,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:4")'> <OreBlock block='Metallurgy:utility.ore:4' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:utility.ore:4' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.899 * _default_ * mtlgBitumenSize ' range=':= 0.899 * _default_ * mtlgBitumenSize ' type='normal' />
@@ -2301,7 +2301,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:4")'> <OreBlock block='Metallurgy:utility.ore:4' weight='1.0' /> </IfCondition>
+                                <OreBlock block='Metallurgy:utility.ore:4' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -2319,7 +2319,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:4")'> <OreBlock block='Metallurgy:utility.ore:4' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:utility.ore:4' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 2.000 * mtlgBitumenSize ' range=':= 2.000 * mtlgBitumenSize ' type='normal' />
@@ -2351,7 +2351,7 @@
                                 since it is  harder to get an idea of
                                 their  direction while mining.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:5")'> <OreBlock block='Metallurgy:utility.ore:5' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:utility.ore:5' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.733 * _default_ * mtlgPotashFreq ' range=':= 1.733 * _default_ * mtlgPotashFreq ' type='normal' scaleTo='base' />
@@ -2393,7 +2393,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:5")'> <OreBlock block='Metallurgy:utility.ore:5' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:utility.ore:5' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.899 * _default_ * mtlgPotashSize ' range=':= 0.899 * _default_ * mtlgPotashSize ' type='normal' />
@@ -2427,7 +2427,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:5")'> <OreBlock block='Metallurgy:utility.ore:5' weight='1.0' /> </IfCondition>
+                                <OreBlock block='Metallurgy:utility.ore:5' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -2445,7 +2445,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:utility.ore:5")'> <OreBlock block='Metallurgy:utility.ore:5' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:utility.ore:5' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 2.000 * mtlgPotashSize ' range=':= 2.000 * mtlgPotashSize ' type='normal' />
@@ -2470,7 +2470,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:base.ore")'> <OreBlock block='Metallurgy:base.ore' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:base.ore' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.501 * _default_ * mtlgCopperFreq ' range=':= 1.501 * _default_ * mtlgCopperFreq ' type='normal' scaleTo='base' />
@@ -2512,7 +2512,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:base.ore")'> <OreBlock block='Metallurgy:base.ore' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:base.ore' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.309 * _default_ * mtlgCopperSize ' range=':= 1.309 * _default_ * mtlgCopperSize ' type='normal' />
@@ -2546,7 +2546,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("Metallurgy:base.ore")'> <OreBlock block='Metallurgy:base.ore' weight='1.0' /> </IfCondition>
+                                <OreBlock block='Metallurgy:base.ore' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -2564,7 +2564,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:base.ore")'> <OreBlock block='Metallurgy:base.ore' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:base.ore' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.000 * mtlgCopperSize ' range=':= 3.000 * mtlgCopperSize ' type='normal' />
@@ -2589,7 +2589,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:base.ore:1")'> <OreBlock block='Metallurgy:base.ore:1' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:base.ore:1' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.480 * _default_ * mtlgTinFreq ' range=':= 1.480 * _default_ * mtlgTinFreq ' type='normal' scaleTo='base' />
@@ -2631,7 +2631,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:base.ore:1")'> <OreBlock block='Metallurgy:base.ore:1' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:base.ore:1' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.300 * _default_ * mtlgTinSize ' range=':= 1.300 * _default_ * mtlgTinSize ' type='normal' />
@@ -2665,7 +2665,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("Metallurgy:base.ore:1")'> <OreBlock block='Metallurgy:base.ore:1' weight='1.0' /> </IfCondition>
+                                <OreBlock block='Metallurgy:base.ore:1' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -2683,7 +2683,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:base.ore:1")'> <OreBlock block='Metallurgy:base.ore:1' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:base.ore:1' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 5.000 * mtlgTinSize ' range=':= 5.000 * mtlgTinSize ' type='normal' />
@@ -2708,7 +2708,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:base.ore:2")'> <OreBlock block='Metallurgy:base.ore:2' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:base.ore:2' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.791 * _default_ * mtlgManganeseFreq ' range=':= 0.791 * _default_ * mtlgManganeseFreq ' type='normal' scaleTo='base' />
@@ -2750,7 +2750,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:base.ore:2")'> <OreBlock block='Metallurgy:base.ore:2' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:base.ore:2' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.951 * _default_ * mtlgManganeseSize ' range=':= 0.951 * _default_ * mtlgManganeseSize ' type='normal' />
@@ -2784,7 +2784,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("Metallurgy:base.ore:2")'> <OreBlock block='Metallurgy:base.ore:2' weight='1.0' /> </IfCondition>
+                                <OreBlock block='Metallurgy:base.ore:2' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -2802,7 +2802,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:base.ore:2")'> <OreBlock block='Metallurgy:base.ore:2' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:base.ore:2' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 2.000 * mtlgManganeseSize ' range=':= 2.000 * mtlgManganeseSize ' type='normal' />
@@ -2827,7 +2827,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:precious.ore")'> <OreBlock block='Metallurgy:precious.ore' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:precious.ore' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * mtlgZincFreq ' range=':= 0.969 * _default_ * mtlgZincFreq ' type='normal' scaleTo='base' />
@@ -2869,7 +2869,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:precious.ore")'> <OreBlock block='Metallurgy:precious.ore' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:precious.ore' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.052 * _default_ * mtlgZincSize ' range=':= 1.052 * _default_ * mtlgZincSize ' type='normal' />
@@ -2903,7 +2903,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("Metallurgy:precious.ore")'> <OreBlock block='Metallurgy:precious.ore' weight='1.0' /> </IfCondition>
+                                <OreBlock block='Metallurgy:precious.ore' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -2921,7 +2921,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:precious.ore")'> <OreBlock block='Metallurgy:precious.ore' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:precious.ore' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 2.500 * mtlgZincSize ' range=':= 2.500 * mtlgZincSize ' type='normal' />
@@ -2946,7 +2946,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:precious.ore:1")'> <OreBlock block='Metallurgy:precious.ore:1' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:precious.ore:1' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * mtlgSilverFreq ' range=':= 0.969 * _default_ * mtlgSilverFreq ' type='normal' scaleTo='base' />
@@ -2988,7 +2988,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:precious.ore:1")'> <OreBlock block='Metallurgy:precious.ore:1' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:precious.ore:1' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.052 * _default_ * mtlgSilverSize ' range=':= 1.052 * _default_ * mtlgSilverSize ' type='normal' />
@@ -3022,7 +3022,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("Metallurgy:precious.ore:1")'> <OreBlock block='Metallurgy:precious.ore:1' weight='1.0' /> </IfCondition>
+                                <OreBlock block='Metallurgy:precious.ore:1' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -3040,7 +3040,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:precious.ore:1")'> <OreBlock block='Metallurgy:precious.ore:1' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:precious.ore:1' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 2.500 * mtlgSilverSize ' range=':= 2.500 * mtlgSilverSize ' type='normal' />
@@ -3065,7 +3065,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:precious.ore:2")'> <OreBlock block='Metallurgy:precious.ore:2' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:precious.ore:2' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.531 * _default_ * mtlgPlatinumFreq ' range=':= 0.531 * _default_ * mtlgPlatinumFreq ' type='normal' scaleTo='base' />
@@ -3107,7 +3107,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:precious.ore:2")'> <OreBlock block='Metallurgy:precious.ore:2' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:precious.ore:2' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.779 * _default_ * mtlgPlatinumSize ' range=':= 0.779 * _default_ * mtlgPlatinumSize ' type='normal' />
@@ -3141,7 +3141,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("Metallurgy:precious.ore:2")'> <OreBlock block='Metallurgy:precious.ore:2' weight='1.0' /> </IfCondition>
+                                <OreBlock block='Metallurgy:precious.ore:2' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -3159,7 +3159,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:precious.ore:2")'> <OreBlock block='Metallurgy:precious.ore:2' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:precious.ore:2' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 1.500 * mtlgPlatinumSize ' range=':= 1.500 * mtlgPlatinumSize ' type='normal' />
@@ -3184,7 +3184,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore")'> <OreBlock block='Metallurgy:fantasy.ore' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:fantasy.ore' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * mtlgPromethiumFreq ' range=':= 0.969 * _default_ * mtlgPromethiumFreq ' type='normal' scaleTo='base' />
@@ -3226,7 +3226,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore")'> <OreBlock block='Metallurgy:fantasy.ore' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:fantasy.ore' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.052 * _default_ * mtlgPromethiumSize ' range=':= 1.052 * _default_ * mtlgPromethiumSize ' type='normal' />
@@ -3260,7 +3260,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore")'> <OreBlock block='Metallurgy:fantasy.ore' weight='1.0' /> </IfCondition>
+                                <OreBlock block='Metallurgy:fantasy.ore' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -3279,7 +3279,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore")'> <OreBlock block='Metallurgy:fantasy.ore' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:fantasy.ore' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.000 * mtlgPromethiumSize ' range=':= 3.000 * mtlgPromethiumSize ' type='normal' />
@@ -3304,7 +3304,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:1")'> <OreBlock block='Metallurgy:fantasy.ore:1' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:fantasy.ore:1' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.791 * _default_ * mtlgDeepIronFreq ' range=':= 0.791 * _default_ * mtlgDeepIronFreq ' type='normal' scaleTo='base' />
@@ -3346,7 +3346,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:1")'> <OreBlock block='Metallurgy:fantasy.ore:1' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:fantasy.ore:1' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.951 * _default_ * mtlgDeepIronSize ' range=':= 0.951 * _default_ * mtlgDeepIronSize ' type='normal' />
@@ -3380,7 +3380,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:1")'> <OreBlock block='Metallurgy:fantasy.ore:1' weight='1.0' /> </IfCondition>
+                                <OreBlock block='Metallurgy:fantasy.ore:1' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -3398,7 +3398,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:1")'> <OreBlock block='Metallurgy:fantasy.ore:1' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:fantasy.ore:1' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 2.000 * mtlgDeepIronSize ' range=':= 2.000 * mtlgDeepIronSize ' type='normal' />
@@ -3423,7 +3423,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:2")'> <OreBlock block='Metallurgy:fantasy.ore:2' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:fantasy.ore:2' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.791 * _default_ * mtlgInfuscoliumFreq ' range=':= 0.791 * _default_ * mtlgInfuscoliumFreq ' type='normal' scaleTo='base' />
@@ -3465,7 +3465,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:2")'> <OreBlock block='Metallurgy:fantasy.ore:2' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:fantasy.ore:2' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.951 * _default_ * mtlgInfuscoliumSize ' range=':= 0.951 * _default_ * mtlgInfuscoliumSize ' type='normal' />
@@ -3499,7 +3499,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:2")'> <OreBlock block='Metallurgy:fantasy.ore:2' weight='1.0' /> </IfCondition>
+                                <OreBlock block='Metallurgy:fantasy.ore:2' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -3518,7 +3518,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:2")'> <OreBlock block='Metallurgy:fantasy.ore:2' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:fantasy.ore:2' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 2.000 * mtlgInfuscoliumSize ' range=':= 2.000 * mtlgInfuscoliumSize ' type='normal' />
@@ -3543,7 +3543,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:4")'> <OreBlock block='Metallurgy:fantasy.ore:4' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:fantasy.ore:4' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.613 * _default_ * mtlgOureclaseFreq ' range=':= 0.613 * _default_ * mtlgOureclaseFreq ' type='normal' scaleTo='base' />
@@ -3585,7 +3585,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:4")'> <OreBlock block='Metallurgy:fantasy.ore:4' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:fantasy.ore:4' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.837 * _default_ * mtlgOureclaseSize ' range=':= 0.837 * _default_ * mtlgOureclaseSize ' type='normal' />
@@ -3619,7 +3619,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:4")'> <OreBlock block='Metallurgy:fantasy.ore:4' weight='1.0' /> </IfCondition>
+                                <OreBlock block='Metallurgy:fantasy.ore:4' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -3637,7 +3637,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:4")'> <OreBlock block='Metallurgy:fantasy.ore:4' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:fantasy.ore:4' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 1.500 * mtlgOureclaseSize ' range=':= 1.500 * mtlgOureclaseSize ' type='normal' />
@@ -3662,7 +3662,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:5")'> <OreBlock block='Metallurgy:fantasy.ore:5' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:fantasy.ore:5' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.613 * _default_ * mtlgAstralSilverFreq ' range=':= 0.613 * _default_ * mtlgAstralSilverFreq ' type='normal' scaleTo='base' />
@@ -3706,7 +3706,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:5")'> <OreBlock block='Metallurgy:fantasy.ore:5' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:fantasy.ore:5' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.837 * _default_ * mtlgAstralSilverSize ' range=':= 0.837 * _default_ * mtlgAstralSilverSize ' type='normal' />
@@ -3740,7 +3740,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:5")'> <OreBlock block='Metallurgy:fantasy.ore:5' weight='1.0' /> </IfCondition>
+                                <OreBlock block='Metallurgy:fantasy.ore:5' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -3759,7 +3759,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:5")'> <OreBlock block='Metallurgy:fantasy.ore:5' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:fantasy.ore:5' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 1.500 * mtlgAstralSilverSize ' range=':= 1.500 * mtlgAstralSilverSize ' type='normal' />
@@ -3784,7 +3784,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:6")'> <OreBlock block='Metallurgy:fantasy.ore:6' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:fantasy.ore:6' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.531 * _default_ * mtlgCarmotFreq ' range=':= 0.531 * _default_ * mtlgCarmotFreq ' type='normal' scaleTo='base' />
@@ -3826,7 +3826,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:6")'> <OreBlock block='Metallurgy:fantasy.ore:6' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:fantasy.ore:6' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.779 * _default_ * mtlgCarmotSize ' range=':= 0.779 * _default_ * mtlgCarmotSize ' type='normal' />
@@ -3860,7 +3860,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:6")'> <OreBlock block='Metallurgy:fantasy.ore:6' weight='1.0' /> </IfCondition>
+                                <OreBlock block='Metallurgy:fantasy.ore:6' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -3878,7 +3878,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:6")'> <OreBlock block='Metallurgy:fantasy.ore:6' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:fantasy.ore:6' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 1.500 * mtlgCarmotSize ' range=':= 1.500 * mtlgCarmotSize ' type='normal' />
@@ -3903,7 +3903,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:7")'> <OreBlock block='Metallurgy:fantasy.ore:7' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:fantasy.ore:7' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.531 * _default_ * mtlgMithrilFreq ' range=':= 0.531 * _default_ * mtlgMithrilFreq ' type='normal' scaleTo='base' />
@@ -3945,7 +3945,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:7")'> <OreBlock block='Metallurgy:fantasy.ore:7' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:fantasy.ore:7' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.779 * _default_ * mtlgMithrilSize ' range=':= 0.779 * _default_ * mtlgMithrilSize ' type='normal' />
@@ -3979,7 +3979,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:7")'> <OreBlock block='Metallurgy:fantasy.ore:7' weight='1.0' /> </IfCondition>
+                                <OreBlock block='Metallurgy:fantasy.ore:7' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -3997,7 +3997,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:7")'> <OreBlock block='Metallurgy:fantasy.ore:7' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:fantasy.ore:7' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 1.500 * mtlgMithrilSize ' range=':= 1.500 * mtlgMithrilSize ' type='normal' />
@@ -4022,7 +4022,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:8")'> <OreBlock block='Metallurgy:fantasy.ore:8' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:fantasy.ore:8' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.433 * _default_ * mtlgRubraciumFreq ' range=':= 0.433 * _default_ * mtlgRubraciumFreq ' type='normal' scaleTo='base' />
@@ -4064,7 +4064,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:8")'> <OreBlock block='Metallurgy:fantasy.ore:8' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:fantasy.ore:8' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.703 * _default_ * mtlgRubraciumSize ' range=':= 0.703 * _default_ * mtlgRubraciumSize ' type='normal' />
@@ -4098,7 +4098,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:8")'> <OreBlock block='Metallurgy:fantasy.ore:8' weight='1.0' /> </IfCondition>
+                                <OreBlock block='Metallurgy:fantasy.ore:8' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -4116,7 +4116,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:8")'> <OreBlock block='Metallurgy:fantasy.ore:8' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:fantasy.ore:8' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 1.500 * mtlgRubraciumSize ' range=':= 1.500 * mtlgRubraciumSize ' type='normal' />
@@ -4141,7 +4141,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:11")'> <OreBlock block='Metallurgy:fantasy.ore:11' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:fantasy.ore:11' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.500 * _default_ * mtlgOrichalcumFreq ' range=':= 0.500 * _default_ * mtlgOrichalcumFreq ' type='normal' scaleTo='base' />
@@ -4183,7 +4183,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:11")'> <OreBlock block='Metallurgy:fantasy.ore:11' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:fantasy.ore:11' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.756 * _default_ * mtlgOrichalcumSize ' range=':= 0.756 * _default_ * mtlgOrichalcumSize ' type='normal' />
@@ -4217,7 +4217,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:11")'> <OreBlock block='Metallurgy:fantasy.ore:11' weight='1.0' /> </IfCondition>
+                                <OreBlock block='Metallurgy:fantasy.ore:11' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -4236,7 +4236,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:11")'> <OreBlock block='Metallurgy:fantasy.ore:11' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:fantasy.ore:11' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 2.000 * mtlgOrichalcumSize ' range=':= 2.000 * mtlgOrichalcumSize ' type='normal' />
@@ -4261,7 +4261,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:13")'> <OreBlock block='Metallurgy:fantasy.ore:13' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:fantasy.ore:13' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.433 * _default_ * mtlgAdamantineFreq ' range=':= 0.433 * _default_ * mtlgAdamantineFreq ' type='normal' scaleTo='base' />
@@ -4303,7 +4303,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:13")'> <OreBlock block='Metallurgy:fantasy.ore:13' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:fantasy.ore:13' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.703 * _default_ * mtlgAdamantineSize ' range=':= 0.703 * _default_ * mtlgAdamantineSize ' type='normal' />
@@ -4337,7 +4337,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:13")'> <OreBlock block='Metallurgy:fantasy.ore:13' weight='1.0' /> </IfCondition>
+                                <OreBlock block='Metallurgy:fantasy.ore:13' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -4356,7 +4356,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:13")'> <OreBlock block='Metallurgy:fantasy.ore:13' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:fantasy.ore:13' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 1.500 * mtlgAdamantineSize ' range=':= 1.500 * mtlgAdamantineSize ' type='normal' />
@@ -4381,7 +4381,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:14")'> <OreBlock block='Metallurgy:fantasy.ore:14' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:fantasy.ore:14' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.433 * _default_ * mtlgAtlarusFreq ' range=':= 0.433 * _default_ * mtlgAtlarusFreq ' type='normal' scaleTo='base' />
@@ -4423,7 +4423,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:14")'> <OreBlock block='Metallurgy:fantasy.ore:14' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:fantasy.ore:14' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.703 * _default_ * mtlgAtlarusSize ' range=':= 0.703 * _default_ * mtlgAtlarusSize ' type='normal' />
@@ -4457,7 +4457,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:14")'> <OreBlock block='Metallurgy:fantasy.ore:14' weight='1.0' /> </IfCondition>
+                                <OreBlock block='Metallurgy:fantasy.ore:14' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -4475,7 +4475,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:fantasy.ore:14")'> <OreBlock block='Metallurgy:fantasy.ore:14' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:fantasy.ore:14' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 1.500 * mtlgAtlarusSize ' range=':= 1.500 * mtlgAtlarusSize ' type='normal' />
@@ -4541,7 +4541,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.300 * _default_ * mtlgIgnatiusFreq ' range=':= 1.300 * _default_ * mtlgIgnatiusFreq ' type='normal' scaleTo='base' />
@@ -4583,7 +4583,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.218 * _default_ * mtlgIgnatiusSize ' range=':= 1.218 * _default_ * mtlgIgnatiusSize ' type='normal' />
@@ -4617,7 +4617,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
+                                <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -4635,7 +4635,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore")'> <OreBlock block='Metallurgy:nether.ore' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.000 * mtlgIgnatiusSize ' range=':= 3.000 * mtlgIgnatiusSize ' type='normal' />
@@ -4660,7 +4660,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:1")'> <OreBlock block='Metallurgy:nether.ore:1' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:nether.ore:1' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.147 * _default_ * mtlgShadowIronFreq ' range=':= 1.147 * _default_ * mtlgShadowIronFreq ' type='normal' scaleTo='base' />
@@ -4702,7 +4702,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:1")'> <OreBlock block='Metallurgy:nether.ore:1' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:nether.ore:1' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.144 * _default_ * mtlgShadowIronSize ' range=':= 1.144 * _default_ * mtlgShadowIronSize ' type='normal' />
@@ -4736,7 +4736,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:1")'> <OreBlock block='Metallurgy:nether.ore:1' weight='1.0' /> </IfCondition>
+                                <OreBlock block='Metallurgy:nether.ore:1' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -4755,7 +4755,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:1")'> <OreBlock block='Metallurgy:nether.ore:1' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:nether.ore:1' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.000 * mtlgShadowIronSize ' range=':= 3.000 * mtlgShadowIronSize ' type='normal' />
@@ -4780,7 +4780,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:2")'> <OreBlock block='Metallurgy:nether.ore:2' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:nether.ore:2' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.062 * _default_ * mtlgLemuriteFreq ' range=':= 1.062 * _default_ * mtlgLemuriteFreq ' type='normal' scaleTo='base' />
@@ -4822,7 +4822,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:2")'> <OreBlock block='Metallurgy:nether.ore:2' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:nether.ore:2' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.101 * _default_ * mtlgLemuriteSize ' range=':= 1.101 * _default_ * mtlgLemuriteSize ' type='normal' />
@@ -4856,7 +4856,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:2")'> <OreBlock block='Metallurgy:nether.ore:2' weight='1.0' /> </IfCondition>
+                                <OreBlock block='Metallurgy:nether.ore:2' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -4874,7 +4874,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:2")'> <OreBlock block='Metallurgy:nether.ore:2' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:nether.ore:2' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.000 * mtlgLemuriteSize ' range=':= 3.000 * mtlgLemuriteSize ' type='normal' />
@@ -4899,7 +4899,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:3")'> <OreBlock block='Metallurgy:nether.ore:3' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:nether.ore:3' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * mtlgMidasiumFreq ' range=':= 0.969 * _default_ * mtlgMidasiumFreq ' type='normal' scaleTo='base' />
@@ -4941,7 +4941,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:3")'> <OreBlock block='Metallurgy:nether.ore:3' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:nether.ore:3' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.052 * _default_ * mtlgMidasiumSize ' range=':= 1.052 * _default_ * mtlgMidasiumSize ' type='normal' />
@@ -4975,7 +4975,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:3")'> <OreBlock block='Metallurgy:nether.ore:3' weight='1.0' /> </IfCondition>
+                                <OreBlock block='Metallurgy:nether.ore:3' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -4993,7 +4993,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:3")'> <OreBlock block='Metallurgy:nether.ore:3' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:nether.ore:3' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.000 * mtlgMidasiumSize ' range=':= 3.000 * mtlgMidasiumSize ' type='normal' />
@@ -5018,7 +5018,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:4")'> <OreBlock block='Metallurgy:nether.ore:4' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:nether.ore:4' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.936 * _default_ * mtlgVyroxeresFreq ' range=':= 0.936 * _default_ * mtlgVyroxeresFreq ' type='normal' scaleTo='base' />
@@ -5060,7 +5060,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:4")'> <OreBlock block='Metallurgy:nether.ore:4' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:nether.ore:4' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.034 * _default_ * mtlgVyroxeresSize ' range=':= 1.034 * _default_ * mtlgVyroxeresSize ' type='normal' />
@@ -5094,7 +5094,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:4")'> <OreBlock block='Metallurgy:nether.ore:4' weight='1.0' /> </IfCondition>
+                                <OreBlock block='Metallurgy:nether.ore:4' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -5112,7 +5112,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:4")'> <OreBlock block='Metallurgy:nether.ore:4' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:nether.ore:4' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.500 * mtlgVyroxeresSize ' range=':= 3.500 * mtlgVyroxeresSize ' type='normal' />
@@ -5137,7 +5137,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:5")'> <OreBlock block='Metallurgy:nether.ore:5' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:nether.ore:5' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.708 * _default_ * mtlgCeruclaseFreq ' range=':= 0.708 * _default_ * mtlgCeruclaseFreq ' type='normal' scaleTo='base' />
@@ -5179,7 +5179,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:5")'> <OreBlock block='Metallurgy:nether.ore:5' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:nether.ore:5' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.899 * _default_ * mtlgCeruclaseSize ' range=':= 0.899 * _default_ * mtlgCeruclaseSize ' type='normal' />
@@ -5213,7 +5213,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:5")'> <OreBlock block='Metallurgy:nether.ore:5' weight='1.0' /> </IfCondition>
+                                <OreBlock block='Metallurgy:nether.ore:5' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -5231,7 +5231,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:5")'> <OreBlock block='Metallurgy:nether.ore:5' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:nether.ore:5' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 2.000 * mtlgCeruclaseSize ' range=':= 2.000 * mtlgCeruclaseSize ' type='normal' />
@@ -5256,7 +5256,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:6")'> <OreBlock block='Metallurgy:nether.ore:6' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:nether.ore:6' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.613 * _default_ * mtlgAlduoriteFreq ' range=':= 0.613 * _default_ * mtlgAlduoriteFreq ' type='normal' scaleTo='base' />
@@ -5298,7 +5298,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:6")'> <OreBlock block='Metallurgy:nether.ore:6' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:nether.ore:6' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.837 * _default_ * mtlgAlduoriteSize ' range=':= 0.837 * _default_ * mtlgAlduoriteSize ' type='normal' />
@@ -5332,7 +5332,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:6")'> <OreBlock block='Metallurgy:nether.ore:6' weight='1.0' /> </IfCondition>
+                                <OreBlock block='Metallurgy:nether.ore:6' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -5350,7 +5350,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:6")'> <OreBlock block='Metallurgy:nether.ore:6' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:nether.ore:6' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 2.000 * mtlgAlduoriteSize ' range=':= 2.000 * mtlgAlduoriteSize ' type='normal' />
@@ -5375,7 +5375,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:7")'> <OreBlock block='Metallurgy:nether.ore:7' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:nether.ore:7' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.613 * _default_ * mtlgKalendriteFreq ' range=':= 0.613 * _default_ * mtlgKalendriteFreq ' type='normal' scaleTo='base' />
@@ -5417,7 +5417,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:7")'> <OreBlock block='Metallurgy:nether.ore:7' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:nether.ore:7' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.837 * _default_ * mtlgKalendriteSize ' range=':= 0.837 * _default_ * mtlgKalendriteSize ' type='normal' />
@@ -5451,7 +5451,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:7")'> <OreBlock block='Metallurgy:nether.ore:7' weight='1.0' /> </IfCondition>
+                                <OreBlock block='Metallurgy:nether.ore:7' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -5470,7 +5470,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:7")'> <OreBlock block='Metallurgy:nether.ore:7' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:nether.ore:7' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 2.000 * mtlgKalendriteSize ' range=':= 2.000 * mtlgKalendriteSize ' type='normal' />
@@ -5495,7 +5495,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:8")'> <OreBlock block='Metallurgy:nether.ore:8' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:nether.ore:8' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.433 * _default_ * mtlgVulcaniteFreq ' range=':= 0.433 * _default_ * mtlgVulcaniteFreq ' type='normal' scaleTo='base' />
@@ -5537,7 +5537,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:8")'> <OreBlock block='Metallurgy:nether.ore:8' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:nether.ore:8' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.703 * _default_ * mtlgVulcaniteSize ' range=':= 0.703 * _default_ * mtlgVulcaniteSize ' type='normal' />
@@ -5571,7 +5571,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:8")'> <OreBlock block='Metallurgy:nether.ore:8' weight='1.0' /> </IfCondition>
+                                <OreBlock block='Metallurgy:nether.ore:8' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -5589,7 +5589,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:8")'> <OreBlock block='Metallurgy:nether.ore:8' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:nether.ore:8' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 1.500 * mtlgVulcaniteSize ' range=':= 1.500 * mtlgVulcaniteSize ' type='normal' />
@@ -5614,7 +5614,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:9")'> <OreBlock block='Metallurgy:nether.ore:9' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:nether.ore:9' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.433 * _default_ * mtlgSanguiniteFreq ' range=':= 0.433 * _default_ * mtlgSanguiniteFreq ' type='normal' scaleTo='base' />
@@ -5656,7 +5656,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:9")'> <OreBlock block='Metallurgy:nether.ore:9' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:nether.ore:9' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.703 * _default_ * mtlgSanguiniteSize ' range=':= 0.703 * _default_ * mtlgSanguiniteSize ' type='normal' />
@@ -5690,7 +5690,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:9")'> <OreBlock block='Metallurgy:nether.ore:9' weight='1.0' /> </IfCondition>
+                                <OreBlock block='Metallurgy:nether.ore:9' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -5709,7 +5709,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:nether.ore:9")'> <OreBlock block='Metallurgy:nether.ore:9' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:nether.ore:9' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 1.500 * mtlgSanguiniteSize ' range=':= 1.500 * mtlgSanguiniteSize ' type='normal' />
@@ -5767,7 +5767,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:ender.ore")'> <OreBlock block='Metallurgy:ender.ore' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:ender.ore' weight='1.0' />
                             <Replaces block='minecraft:end_stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.867 * _default_ * mtlgEximiteFreq ' range=':= 0.867 * _default_ * mtlgEximiteFreq ' type='normal' scaleTo='base' />
@@ -5809,7 +5809,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:ender.ore")'> <OreBlock block='Metallurgy:ender.ore' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:ender.ore' weight='1.0' />
                             <Replaces block='minecraft:end_stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.995 * _default_ * mtlgEximiteSize ' range=':= 0.995 * _default_ * mtlgEximiteSize ' type='normal' />
@@ -5843,7 +5843,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("Metallurgy:ender.ore")'> <OreBlock block='Metallurgy:ender.ore' weight='1.0' /> </IfCondition>
+                                <OreBlock block='Metallurgy:ender.ore' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -5861,7 +5861,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:ender.ore")'> <OreBlock block='Metallurgy:ender.ore' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:ender.ore' weight='1.0' />
                             <Replaces block='minecraft:end_stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 2.000 * mtlgEximiteSize ' range=':= 2.000 * mtlgEximiteSize ' type='normal' />
@@ -5886,7 +5886,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:ender.ore:1")'> <OreBlock block='Metallurgy:ender.ore:1' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:ender.ore:1' weight='1.0' />
                             <Replaces block='minecraft:end_stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.531 * _default_ * mtlgMeutoiteFreq ' range=':= 0.531 * _default_ * mtlgMeutoiteFreq ' type='normal' scaleTo='base' />
@@ -5928,7 +5928,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:ender.ore:1")'> <OreBlock block='Metallurgy:ender.ore:1' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:ender.ore:1' weight='1.0' />
                             <Replaces block='minecraft:end_stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.779 * _default_ * mtlgMeutoiteSize ' range=':= 0.779 * _default_ * mtlgMeutoiteSize ' type='normal' />
@@ -5962,7 +5962,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("Metallurgy:ender.ore:1")'> <OreBlock block='Metallurgy:ender.ore:1' weight='1.0' /> </IfCondition>
+                                <OreBlock block='Metallurgy:ender.ore:1' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -5980,7 +5980,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Metallurgy:ender.ore:1")'> <OreBlock block='Metallurgy:ender.ore:1' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Metallurgy:ender.ore:1' weight='1.0' />
                             <Replaces block='minecraft:end_stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 1.500 * mtlgMeutoiteSize ' range=':= 1.500 * mtlgMeutoiteSize ' type='normal' />

--- a/src/main/resources/config/modules/MineChem.xml
+++ b/src/main/resources/config/modules/MineChem.xml
@@ -120,7 +120,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("minechem:tile.oreUranium")'> <OreBlock block='minechem:tile.oreUranium' weight='1.0' /> </IfCondition>
+                            <OreBlock block='minechem:tile.oreUranium' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.500 * _default_ * mchmUraniumFreq ' range=':= 0.500 * _default_ * mchmUraniumFreq ' type='normal' scaleTo='base' />
@@ -162,7 +162,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("minechem:tile.oreUranium")'> <OreBlock block='minechem:tile.oreUranium' weight='1.0' /> </IfCondition>
+                            <OreBlock block='minechem:tile.oreUranium' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.756 * _default_ * mchmUraniumSize ' range=':= 0.756 * _default_ * mchmUraniumSize ' type='normal' />
@@ -196,7 +196,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("minechem:tile.oreUranium")'> <OreBlock block='minechem:tile.oreUranium' weight='1.0' /> </IfCondition>
+                                <OreBlock block='minechem:tile.oreUranium' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -214,7 +214,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("minechem:tile.oreUranium")'> <OreBlock block='minechem:tile.oreUranium' weight='1.0' /> </IfCondition>
+                            <OreBlock block='minechem:tile.oreUranium' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 2.000 * mchmUraniumSize ' range=':= 2.000 * mchmUraniumSize ' type='normal' />

--- a/src/main/resources/config/modules/MinecraftComesAlive.xml
+++ b/src/main/resources/config/modules/MinecraftComesAlive.xml
@@ -122,7 +122,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("MCA:tile.roseGoldOre")'> <OreBlock block='MCA:tile.roseGoldOre' weight='1.0' /> </IfCondition>
+                            <OreBlock block='MCA:tile.roseGoldOre' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * mccaRoseGoldFreq ' range=':= 0.969 * _default_ * mccaRoseGoldFreq ' type='normal' scaleTo='base' />
@@ -164,7 +164,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("MCA:tile.roseGoldOre")'> <OreBlock block='MCA:tile.roseGoldOre' weight='1.0' /> </IfCondition>
+                            <OreBlock block='MCA:tile.roseGoldOre' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.052 * _default_ * mccaRoseGoldSize ' range=':= 1.052 * _default_ * mccaRoseGoldSize ' type='normal' />
@@ -198,7 +198,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("MCA:tile.roseGoldOre")'> <OreBlock block='MCA:tile.roseGoldOre' weight='1.0' /> </IfCondition>
+                                <OreBlock block='MCA:tile.roseGoldOre' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -216,7 +216,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("MCA:tile.roseGoldOre")'> <OreBlock block='MCA:tile.roseGoldOre' weight='1.0' /> </IfCondition>
+                            <OreBlock block='MCA:tile.roseGoldOre' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.000 * mccaRoseGoldSize ' range=':= 3.000 * mccaRoseGoldSize ' type='normal' />

--- a/src/main/resources/config/modules/NetherOres.xml
+++ b/src/main/resources/config/modules/NetherOres.xml
@@ -1589,7 +1589,7 @@
                                 since it is  harder to get an idea of
                                 their  direction while mining.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0")'> <OreBlock block='NetherOres:tile.netherores.ore.0' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.0' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 4.900 * _default_ * nthoCoalFreq ' range=':= 4.900 * _default_ * nthoCoalFreq ' type='normal' scaleTo='base' />
@@ -1631,7 +1631,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0")'> <OreBlock block='NetherOres:tile.netherores.ore.0' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.0' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.512 * _default_ * nthoCoalSize ' range=':= 1.512 * _default_ * nthoCoalSize ' type='normal' />
@@ -1665,7 +1665,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0")'> <OreBlock block='NetherOres:tile.netherores.ore.0' weight='1.0' /> </IfCondition>
+                                <OreBlock block='NetherOres:tile.netherores.ore.0' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -1683,7 +1683,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0")'> <OreBlock block='NetherOres:tile.netherores.ore.0' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.0' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 8.000 * nthoCoalSize ' range=':= 8.000 * nthoCoalSize ' type='normal' />
@@ -1708,7 +1708,7 @@
                                 Short sparsely filled veins  sloping
                                 up from near the bottom  of the map.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:1")'> <OreBlock block='NetherOres:tile.netherores.ore.0:1' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.0:1' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.935 * _default_ * nthoDiamondFreq ' range=':= 0.935 * _default_ * nthoDiamondFreq ' type='normal' scaleTo='base' />
@@ -1730,7 +1730,7 @@
 
                         <!-- Configuring contained material. -->
                         <Veins name='nthoDiamondVeinsPipe'  inherits='nthoDiamondVeins' seed='0xAA9C' drawWireframe='true' wireframeColor='0x608BF4E3' drawBoundBox='false' boundBoxColor='0x608BF4E3'>
-                            <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
+                            <OreBlock block='minecraft:lava' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Replaces block='NetherOres:tile.netherores.ore.0:1' weight='1.0' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoDiamondSize  * 0.5 ' range=':= 0 * _default_ * nthoDiamondSize  * 0.5 ' type='normal' />
@@ -1760,7 +1760,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:1")'> <OreBlock block='NetherOres:tile.netherores.ore.0:1' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.0:1' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.837 * _default_ * nthoDiamondSize ' range=':= 0.837 * _default_ * nthoDiamondSize ' type='normal' />
@@ -1794,7 +1794,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:1")'> <OreBlock block='NetherOres:tile.netherores.ore.0:1' weight='1.0' /> </IfCondition>
+                                <OreBlock block='NetherOres:tile.netherores.ore.0:1' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -1812,7 +1812,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:1")'> <OreBlock block='NetherOres:tile.netherores.ore.0:1' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.0:1' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 1.500 * nthoDiamondSize ' range=':= 1.500 * nthoDiamondSize ' type='normal' />
@@ -1837,7 +1837,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:2")'> <OreBlock block='NetherOres:tile.netherores.ore.0:2' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.0:2' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.226 * _default_ * nthoGoldFreq ' range=':= 1.226 * _default_ * nthoGoldFreq ' type='normal' scaleTo='base' />
@@ -1879,7 +1879,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:2")'> <OreBlock block='NetherOres:tile.netherores.ore.0:2' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.0:2' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.183 * _default_ * nthoGoldSize ' range=':= 1.183 * _default_ * nthoGoldSize ' type='normal' />
@@ -1913,7 +1913,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:2")'> <OreBlock block='NetherOres:tile.netherores.ore.0:2' weight='1.0' /> </IfCondition>
+                                <OreBlock block='NetherOres:tile.netherores.ore.0:2' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -1931,7 +1931,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:2")'> <OreBlock block='NetherOres:tile.netherores.ore.0:2' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.0:2' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.000 * nthoGoldSize ' range=':= 3.000 * nthoGoldSize ' type='normal' />
@@ -1956,7 +1956,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:3")'> <OreBlock block='NetherOres:tile.netherores.ore.0:3' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.0:3' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.416 * _default_ * nthoIronFreq ' range=':= 1.416 * _default_ * nthoIronFreq ' type='normal' scaleTo='base' />
@@ -1998,7 +1998,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:3")'> <OreBlock block='NetherOres:tile.netherores.ore.0:3' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.0:3' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.271 * _default_ * nthoIronSize ' range=':= 1.271 * _default_ * nthoIronSize ' type='normal' />
@@ -2032,7 +2032,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:3")'> <OreBlock block='NetherOres:tile.netherores.ore.0:3' weight='1.0' /> </IfCondition>
+                                <OreBlock block='NetherOres:tile.netherores.ore.0:3' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -2050,7 +2050,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:3")'> <OreBlock block='NetherOres:tile.netherores.ore.0:3' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.0:3' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * nthoIronSize ' range=':= 4.000 * nthoIronSize ' type='normal' />
@@ -2075,7 +2075,7 @@
                                 Single vertical veins that occur  with
                                 no motherlodes.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:4")'> <OreBlock block='NetherOres:tile.netherores.ore.0:4' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.0:4' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.929 * _default_ * nthoLapisLazuliFreq ' range=':= 1.929 * _default_ * nthoLapisLazuliFreq ' type='normal' scaleTo='base' />
@@ -2118,7 +2118,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:4")'> <OreBlock block='NetherOres:tile.netherores.ore.0:4' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.0:4' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.101 * _default_ * nthoLapisLazuliSize ' range=':= 1.101 * _default_ * nthoLapisLazuliSize ' type='normal' />
@@ -2152,7 +2152,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:4")'> <OreBlock block='NetherOres:tile.netherores.ore.0:4' weight='1.0' /> </IfCondition>
+                                <OreBlock block='NetherOres:tile.netherores.ore.0:4' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -2171,7 +2171,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:4")'> <OreBlock block='NetherOres:tile.netherores.ore.0:4' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.0:4' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.000 * nthoLapisLazuliSize ' range=':= 3.000 * nthoLapisLazuliSize ' type='normal' />
@@ -2196,7 +2196,7 @@
                                 Single vertical veins that occur  with
                                 no motherlodes.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:5")'> <OreBlock block='NetherOres:tile.netherores.ore.0:5' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.0:5' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.227 * _default_ * nthoRedstoneFreq ' range=':= 2.227 * _default_ * nthoRedstoneFreq ' type='normal' scaleTo='base' />
@@ -2238,7 +2238,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:5")'> <OreBlock block='NetherOres:tile.netherores.ore.0:5' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.0:5' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.183 * _default_ * nthoRedstoneSize ' range=':= 1.183 * _default_ * nthoRedstoneSize ' type='normal' />
@@ -2272,7 +2272,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:5")'> <OreBlock block='NetherOres:tile.netherores.ore.0:5' weight='1.0' /> </IfCondition>
+                                <OreBlock block='NetherOres:tile.netherores.ore.0:5' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -2290,7 +2290,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:5")'> <OreBlock block='NetherOres:tile.netherores.ore.0:5' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.0:5' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * nthoRedstoneSize ' range=':= 4.000 * nthoRedstoneSize ' type='normal' />
@@ -2315,7 +2315,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:6")'> <OreBlock block='NetherOres:tile.netherores.ore.0:6' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.0:6' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.416 * _default_ * nthoCopperFreq ' range=':= 1.416 * _default_ * nthoCopperFreq ' type='normal' scaleTo='base' />
@@ -2357,7 +2357,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:6")'> <OreBlock block='NetherOres:tile.netherores.ore.0:6' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.0:6' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.271 * _default_ * nthoCopperSize ' range=':= 1.271 * _default_ * nthoCopperSize ' type='normal' />
@@ -2391,7 +2391,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:6")'> <OreBlock block='NetherOres:tile.netherores.ore.0:6' weight='1.0' /> </IfCondition>
+                                <OreBlock block='NetherOres:tile.netherores.ore.0:6' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -2409,7 +2409,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:6")'> <OreBlock block='NetherOres:tile.netherores.ore.0:6' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.0:6' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * nthoCopperSize ' range=':= 4.000 * nthoCopperSize ' type='normal' />
@@ -2434,7 +2434,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:7")'> <OreBlock block='NetherOres:tile.netherores.ore.0:7' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.0:7' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.416 * _default_ * nthoTinFreq ' range=':= 1.416 * _default_ * nthoTinFreq ' type='normal' scaleTo='base' />
@@ -2476,7 +2476,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:7")'> <OreBlock block='NetherOres:tile.netherores.ore.0:7' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.0:7' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.271 * _default_ * nthoTinSize ' range=':= 1.271 * _default_ * nthoTinSize ' type='normal' />
@@ -2510,7 +2510,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:7")'> <OreBlock block='NetherOres:tile.netherores.ore.0:7' weight='1.0' /> </IfCondition>
+                                <OreBlock block='NetherOres:tile.netherores.ore.0:7' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -2528,7 +2528,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:7")'> <OreBlock block='NetherOres:tile.netherores.ore.0:7' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.0:7' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * nthoTinSize ' range=':= 4.000 * nthoTinSize ' type='normal' />
@@ -2553,7 +2553,7 @@
                                 Short sparsely filled veins  sloping
                                 up from near the bottom  of the map.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:8")'> <OreBlock block='NetherOres:tile.netherores.ore.0:8' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.0:8' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.661 * _default_ * nthoEmeraldFreq ' range=':= 0.661 * _default_ * nthoEmeraldFreq ' type='normal' scaleTo='base' />
@@ -2575,7 +2575,7 @@
 
                         <!-- Configuring contained material. -->
                         <Veins name='nthoEmeraldVeinsPipe'  inherits='nthoEmeraldVeins' seed='0x907F' drawWireframe='true' wireframeColor='0x606CE391' drawBoundBox='false' boundBoxColor='0x606CE391'>
-                            <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
+                            <OreBlock block='minecraft:lava' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Replaces block='NetherOres:tile.netherores.ore.0:8' weight='1.0' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoEmeraldSize  * 0.5 ' range=':= 0 * _default_ * nthoEmeraldSize  * 0.5 ' type='normal' />
@@ -2605,7 +2605,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:8")'> <OreBlock block='NetherOres:tile.netherores.ore.0:8' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.0:8' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.703 * _default_ * nthoEmeraldSize ' range=':= 0.703 * _default_ * nthoEmeraldSize ' type='normal' />
@@ -2639,7 +2639,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:8")'> <OreBlock block='NetherOres:tile.netherores.ore.0:8' weight='1.0' /> </IfCondition>
+                                <OreBlock block='NetherOres:tile.netherores.ore.0:8' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -2657,7 +2657,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:8")'> <OreBlock block='NetherOres:tile.netherores.ore.0:8' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.0:8' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 1.000 * nthoEmeraldSize ' range=':= 1.000 * nthoEmeraldSize ' type='normal' />
@@ -2682,7 +2682,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:9")'> <OreBlock block='NetherOres:tile.netherores.ore.0:9' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.0:9' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.867 * _default_ * nthoSilverFreq ' range=':= 0.867 * _default_ * nthoSilverFreq ' type='normal' scaleTo='base' />
@@ -2724,7 +2724,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:9")'> <OreBlock block='NetherOres:tile.netherores.ore.0:9' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.0:9' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.995 * _default_ * nthoSilverSize ' range=':= 0.995 * _default_ * nthoSilverSize ' type='normal' />
@@ -2758,7 +2758,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:9")'> <OreBlock block='NetherOres:tile.netherores.ore.0:9' weight='1.0' /> </IfCondition>
+                                <OreBlock block='NetherOres:tile.netherores.ore.0:9' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -2776,7 +2776,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:9")'> <OreBlock block='NetherOres:tile.netherores.ore.0:9' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.0:9' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 2.000 * nthoSilverSize ' range=':= 2.000 * nthoSilverSize ' type='normal' />
@@ -2801,7 +2801,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:10")'> <OreBlock block='NetherOres:tile.netherores.ore.0:10' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.0:10' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.062 * _default_ * nthoLeadFreq ' range=':= 1.062 * _default_ * nthoLeadFreq ' type='normal' scaleTo='base' />
@@ -2843,7 +2843,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:10")'> <OreBlock block='NetherOres:tile.netherores.ore.0:10' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.0:10' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.101 * _default_ * nthoLeadSize ' range=':= 1.101 * _default_ * nthoLeadSize ' type='normal' />
@@ -2877,7 +2877,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:10")'> <OreBlock block='NetherOres:tile.netherores.ore.0:10' weight='1.0' /> </IfCondition>
+                                <OreBlock block='NetherOres:tile.netherores.ore.0:10' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -2895,7 +2895,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:10")'> <OreBlock block='NetherOres:tile.netherores.ore.0:10' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.0:10' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.000 * nthoLeadSize ' range=':= 3.000 * nthoLeadSize ' type='normal' />
@@ -2927,7 +2927,7 @@
                                 since it is  harder to get an idea of
                                 their  direction while mining.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:11")'> <OreBlock block='NetherOres:tile.netherores.ore.0:11' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.0:11' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.061 * _default_ * nthoUraniumFreq ' range=':= 1.061 * _default_ * nthoUraniumFreq ' type='normal' scaleTo='base' />
@@ -2969,7 +2969,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:11")'> <OreBlock block='NetherOres:tile.netherores.ore.0:11' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.0:11' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.703 * _default_ * nthoUraniumSize ' range=':= 0.703 * _default_ * nthoUraniumSize ' type='normal' />
@@ -3003,7 +3003,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:11")'> <OreBlock block='NetherOres:tile.netherores.ore.0:11' weight='1.0' /> </IfCondition>
+                                <OreBlock block='NetherOres:tile.netherores.ore.0:11' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -3021,7 +3021,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:11")'> <OreBlock block='NetherOres:tile.netherores.ore.0:11' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.0:11' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 1.000 * nthoUraniumSize ' range=':= 1.000 * nthoUraniumSize ' type='normal' />
@@ -3046,7 +3046,7 @@
                                 Single vertical veins that occur  with
                                 no motherlodes.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:12")'> <OreBlock block='NetherOres:tile.netherores.ore.0:12' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.0:12' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.818 * _default_ * nthoNikoliteFreq ' range=':= 1.818 * _default_ * nthoNikoliteFreq ' type='normal' scaleTo='base' />
@@ -3088,7 +3088,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:12")'> <OreBlock block='NetherOres:tile.netherores.ore.0:12' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.0:12' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.069 * _default_ * nthoNikoliteSize ' range=':= 1.069 * _default_ * nthoNikoliteSize ' type='normal' />
@@ -3122,7 +3122,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:12")'> <OreBlock block='NetherOres:tile.netherores.ore.0:12' weight='1.0' /> </IfCondition>
+                                <OreBlock block='NetherOres:tile.netherores.ore.0:12' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -3140,7 +3140,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:12")'> <OreBlock block='NetherOres:tile.netherores.ore.0:12' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.0:12' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 2.000 * nthoNikoliteSize ' range=':= 2.000 * nthoNikoliteSize ' type='normal' />
@@ -3165,7 +3165,7 @@
                                 Short sparsely filled veins  sloping
                                 up from near the bottom  of the map.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:13")'> <OreBlock block='NetherOres:tile.netherores.ore.0:13' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.0:13' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.145 * _default_ * nthoRubyFreq ' range=':= 1.145 * _default_ * nthoRubyFreq ' type='normal' scaleTo='base' />
@@ -3187,7 +3187,7 @@
 
                         <!-- Configuring contained material. -->
                         <Veins name='nthoRubyVeinsPipe'  inherits='nthoRubyVeins' seed='0xD0DC' drawWireframe='true' wireframeColor='0x60D10415' drawBoundBox='false' boundBoxColor='0x60D10415'>
-                            <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
+                            <OreBlock block='minecraft:lava' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Replaces block='NetherOres:tile.netherores.ore.0:13' weight='1.0' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoRubySize  * 0.5 ' range=':= 0 * _default_ * nthoRubySize  * 0.5 ' type='normal' />
@@ -3217,7 +3217,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:13")'> <OreBlock block='NetherOres:tile.netherores.ore.0:13' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.0:13' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.926 * _default_ * nthoRubySize ' range=':= 0.926 * _default_ * nthoRubySize ' type='normal' />
@@ -3251,7 +3251,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:13")'> <OreBlock block='NetherOres:tile.netherores.ore.0:13' weight='1.0' /> </IfCondition>
+                                <OreBlock block='NetherOres:tile.netherores.ore.0:13' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -3269,7 +3269,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:13")'> <OreBlock block='NetherOres:tile.netherores.ore.0:13' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.0:13' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 1.500 * nthoRubySize ' range=':= 1.500 * nthoRubySize ' type='normal' />
@@ -3294,7 +3294,7 @@
                                 Short sparsely filled veins  sloping
                                 up from near the bottom  of the map.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:14")'> <OreBlock block='NetherOres:tile.netherores.ore.0:14' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.0:14' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.145 * _default_ * nthoPeridotFreq ' range=':= 1.145 * _default_ * nthoPeridotFreq ' type='normal' scaleTo='base' />
@@ -3316,7 +3316,7 @@
 
                         <!-- Configuring contained material. -->
                         <Veins name='nthoPeridotVeinsPipe'  inherits='nthoPeridotVeins' seed='0x6CA7' drawWireframe='true' wireframeColor='0x6054A228' drawBoundBox='false' boundBoxColor='0x6054A228'>
-                            <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
+                            <OreBlock block='minecraft:lava' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Replaces block='NetherOres:tile.netherores.ore.0:14' weight='1.0' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoPeridotSize  * 0.5 ' range=':= 0 * _default_ * nthoPeridotSize  * 0.5 ' type='normal' />
@@ -3346,7 +3346,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:14")'> <OreBlock block='NetherOres:tile.netherores.ore.0:14' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.0:14' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.926 * _default_ * nthoPeridotSize ' range=':= 0.926 * _default_ * nthoPeridotSize ' type='normal' />
@@ -3380,7 +3380,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:14")'> <OreBlock block='NetherOres:tile.netherores.ore.0:14' weight='1.0' /> </IfCondition>
+                                <OreBlock block='NetherOres:tile.netherores.ore.0:14' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -3398,7 +3398,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:14")'> <OreBlock block='NetherOres:tile.netherores.ore.0:14' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.0:14' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 1.500 * nthoPeridotSize ' range=':= 1.500 * nthoPeridotSize ' type='normal' />
@@ -3423,7 +3423,7 @@
                                 Short sparsely filled veins  sloping
                                 up from near the bottom  of the map.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:15")'> <OreBlock block='NetherOres:tile.netherores.ore.0:15' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.0:15' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.145 * _default_ * nthoSapphireFreq ' range=':= 1.145 * _default_ * nthoSapphireFreq ' type='normal' scaleTo='base' />
@@ -3445,7 +3445,7 @@
 
                         <!-- Configuring contained material. -->
                         <Veins name='nthoSapphireVeinsPipe'  inherits='nthoSapphireVeins' seed='0x83DD' drawWireframe='true' wireframeColor='0x60554DB4' drawBoundBox='false' boundBoxColor='0x60554DB4'>
-                            <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
+                            <OreBlock block='minecraft:lava' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Replaces block='NetherOres:tile.netherores.ore.0:15' weight='1.0' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoSapphireSize  * 0.5 ' range=':= 0 * _default_ * nthoSapphireSize  * 0.5 ' type='normal' />
@@ -3475,7 +3475,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:15")'> <OreBlock block='NetherOres:tile.netherores.ore.0:15' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.0:15' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.926 * _default_ * nthoSapphireSize ' range=':= 0.926 * _default_ * nthoSapphireSize ' type='normal' />
@@ -3509,7 +3509,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:15")'> <OreBlock block='NetherOres:tile.netherores.ore.0:15' weight='1.0' /> </IfCondition>
+                                <OreBlock block='NetherOres:tile.netherores.ore.0:15' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -3527,7 +3527,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.0:15")'> <OreBlock block='NetherOres:tile.netherores.ore.0:15' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.0:15' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 1.500 * nthoSapphireSize ' range=':= 1.500 * nthoSapphireSize ' type='normal' />
@@ -3552,7 +3552,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1")'> <OreBlock block='NetherOres:tile.netherores.ore.1' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.1' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.306 * _default_ * nthoPlatinumFreq ' range=':= 0.306 * _default_ * nthoPlatinumFreq ' type='normal' scaleTo='base' />
@@ -3594,7 +3594,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1")'> <OreBlock block='NetherOres:tile.netherores.ore.1' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.1' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.592 * _default_ * nthoPlatinumSize ' range=':= 0.592 * _default_ * nthoPlatinumSize ' type='normal' />
@@ -3628,7 +3628,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1")'> <OreBlock block='NetherOres:tile.netherores.ore.1' weight='1.0' /> </IfCondition>
+                                <OreBlock block='NetherOres:tile.netherores.ore.1' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -3646,7 +3646,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1")'> <OreBlock block='NetherOres:tile.netherores.ore.1' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.1' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 1.500 * nthoPlatinumSize ' range=':= 1.500 * nthoPlatinumSize ' type='normal' />
@@ -3671,7 +3671,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:1")'> <OreBlock block='NetherOres:tile.netherores.ore.1:1' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.1:1' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.867 * _default_ * nthoNickelFreq ' range=':= 0.867 * _default_ * nthoNickelFreq ' type='normal' scaleTo='base' />
@@ -3713,7 +3713,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:1")'> <OreBlock block='NetherOres:tile.netherores.ore.1:1' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.1:1' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.995 * _default_ * nthoNickelSize ' range=':= 0.995 * _default_ * nthoNickelSize ' type='normal' />
@@ -3747,7 +3747,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:1")'> <OreBlock block='NetherOres:tile.netherores.ore.1:1' weight='1.0' /> </IfCondition>
+                                <OreBlock block='NetherOres:tile.netherores.ore.1:1' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -3765,7 +3765,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:1")'> <OreBlock block='NetherOres:tile.netherores.ore.1:1' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.1:1' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.000 * nthoNickelSize ' range=':= 3.000 * nthoNickelSize ' type='normal' />
@@ -3790,7 +3790,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:2")'> <OreBlock block='NetherOres:tile.netherores.ore.1:2' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.1:2' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.613 * _default_ * nthoSteelFreq ' range=':= 0.613 * _default_ * nthoSteelFreq ' type='normal' scaleTo='base' />
@@ -3832,7 +3832,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:2")'> <OreBlock block='NetherOres:tile.netherores.ore.1:2' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.1:2' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.837 * _default_ * nthoSteelSize ' range=':= 0.837 * _default_ * nthoSteelSize ' type='normal' />
@@ -3866,7 +3866,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:2")'> <OreBlock block='NetherOres:tile.netherores.ore.1:2' weight='1.0' /> </IfCondition>
+                                <OreBlock block='NetherOres:tile.netherores.ore.1:2' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -3884,7 +3884,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:2")'> <OreBlock block='NetherOres:tile.netherores.ore.1:2' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.1:2' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 2.000 * nthoSteelSize ' range=':= 2.000 * nthoSteelSize ' type='normal' />
@@ -3911,7 +3911,7 @@
                                 produced by StandardGen
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:3")'> <OreBlock block='NetherOres:tile.netherores.ore.1:3' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.1:3' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.313 * _default_ * nthoIridiumFreq ' range=':= 0.313 * _default_ * nthoIridiumFreq ' type='normal' scaleTo='base' />
@@ -3953,7 +3953,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:3")'> <OreBlock block='NetherOres:tile.netherores.ore.1:3' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.1:3' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.535 * _default_ * nthoIridiumSize ' range=':= 0.535 * _default_ * nthoIridiumSize ' type='normal' />
@@ -3987,7 +3987,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:3")'> <OreBlock block='NetherOres:tile.netherores.ore.1:3' weight='1.0' /> </IfCondition>
+                                <OreBlock block='NetherOres:tile.netherores.ore.1:3' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -4005,7 +4005,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:3")'> <OreBlock block='NetherOres:tile.netherores.ore.1:3' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.1:3' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 1.000 * nthoIridiumSize ' range=':= 1.000 * nthoIridiumSize ' type='normal' />
@@ -4030,7 +4030,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:4")'> <OreBlock block='NetherOres:tile.netherores.ore.1:4' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.1:4' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.324 * _default_ * nthoOsmiumFreq ' range=':= 1.324 * _default_ * nthoOsmiumFreq ' type='normal' scaleTo='base' />
@@ -4072,7 +4072,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:4")'> <OreBlock block='NetherOres:tile.netherores.ore.1:4' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.1:4' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.230 * _default_ * nthoOsmiumSize ' range=':= 1.230 * _default_ * nthoOsmiumSize ' type='normal' />
@@ -4106,7 +4106,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:4")'> <OreBlock block='NetherOres:tile.netherores.ore.1:4' weight='1.0' /> </IfCondition>
+                                <OreBlock block='NetherOres:tile.netherores.ore.1:4' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -4124,7 +4124,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:4")'> <OreBlock block='NetherOres:tile.netherores.ore.1:4' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.1:4' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.500 * nthoOsmiumSize ' range=':= 3.500 * nthoOsmiumSize ' type='normal' />
@@ -4149,7 +4149,7 @@
                                 Short sparsely filled veins  sloping
                                 up from near the bottom  of the map.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:5")'> <OreBlock block='NetherOres:tile.netherores.ore.1:5' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.1:5' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 3.240 * _default_ * nthoSulfurFreq ' range=':= 3.240 * _default_ * nthoSulfurFreq ' type='normal' scaleTo='base' />
@@ -4171,7 +4171,7 @@
 
                         <!-- Configuring contained material. -->
                         <Veins name='nthoSulfurVeinsPipe'  inherits='nthoSulfurVeins' seed='0xCB5E' drawWireframe='true' wireframeColor='0x60FDFD11' drawBoundBox='false' boundBoxColor='0x60FDFD11'>
-                            <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
+                            <OreBlock block='minecraft:lava' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Replaces block='NetherOres:tile.netherores.ore.1:5' weight='1.0' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoSulfurSize  * 0.5 ' range=':= 0 * _default_ * nthoSulfurSize  * 0.5 ' type='normal' />
@@ -4201,7 +4201,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:5")'> <OreBlock block='NetherOres:tile.netherores.ore.1:5' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.1:5' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.557 * _default_ * nthoSulfurSize ' range=':= 1.557 * _default_ * nthoSulfurSize ' type='normal' />
@@ -4235,7 +4235,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:5")'> <OreBlock block='NetherOres:tile.netherores.ore.1:5' weight='1.0' /> </IfCondition>
+                                <OreBlock block='NetherOres:tile.netherores.ore.1:5' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -4253,7 +4253,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:5")'> <OreBlock block='NetherOres:tile.netherores.ore.1:5' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.1:5' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 6.000 * nthoSulfurSize ' range=':= 6.000 * nthoSulfurSize ' type='normal' />
@@ -4278,7 +4278,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:6")'> <OreBlock block='NetherOres:tile.netherores.ore.1:6' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.1:6' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.433 * _default_ * nthoTitaniumFreq ' range=':= 0.433 * _default_ * nthoTitaniumFreq ' type='normal' scaleTo='base' />
@@ -4320,7 +4320,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:6")'> <OreBlock block='NetherOres:tile.netherores.ore.1:6' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.1:6' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.703 * _default_ * nthoTitaniumSize ' range=':= 0.703 * _default_ * nthoTitaniumSize ' type='normal' />
@@ -4354,7 +4354,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:6")'> <OreBlock block='NetherOres:tile.netherores.ore.1:6' weight='1.0' /> </IfCondition>
+                                <OreBlock block='NetherOres:tile.netherores.ore.1:6' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -4372,7 +4372,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:6")'> <OreBlock block='NetherOres:tile.netherores.ore.1:6' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.1:6' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 1.000 * nthoTitaniumSize ' range=':= 1.000 * nthoTitaniumSize ' type='normal' />
@@ -4397,7 +4397,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:7")'> <OreBlock block='NetherOres:tile.netherores.ore.1:7' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.1:7' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.062 * _default_ * nthoMithrilFreq ' range=':= 1.062 * _default_ * nthoMithrilFreq ' type='normal' scaleTo='base' />
@@ -4439,7 +4439,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:7")'> <OreBlock block='NetherOres:tile.netherores.ore.1:7' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.1:7' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.101 * _default_ * nthoMithrilSize ' range=':= 1.101 * _default_ * nthoMithrilSize ' type='normal' />
@@ -4473,7 +4473,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:7")'> <OreBlock block='NetherOres:tile.netherores.ore.1:7' weight='1.0' /> </IfCondition>
+                                <OreBlock block='NetherOres:tile.netherores.ore.1:7' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -4491,7 +4491,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:7")'> <OreBlock block='NetherOres:tile.netherores.ore.1:7' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.1:7' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.000 * nthoMithrilSize ' range=':= 3.000 * nthoMithrilSize ' type='normal' />
@@ -4516,7 +4516,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:8")'> <OreBlock block='NetherOres:tile.netherores.ore.1:8' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.1:8' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.791 * _default_ * nthoAdamantiumFreq ' range=':= 0.791 * _default_ * nthoAdamantiumFreq ' type='normal' scaleTo='base' />
@@ -4558,7 +4558,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:8")'> <OreBlock block='NetherOres:tile.netherores.ore.1:8' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.1:8' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.951 * _default_ * nthoAdamantiumSize ' range=':= 0.951 * _default_ * nthoAdamantiumSize ' type='normal' />
@@ -4592,7 +4592,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:8")'> <OreBlock block='NetherOres:tile.netherores.ore.1:8' weight='1.0' /> </IfCondition>
+                                <OreBlock block='NetherOres:tile.netherores.ore.1:8' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -4611,7 +4611,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:8")'> <OreBlock block='NetherOres:tile.netherores.ore.1:8' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.1:8' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 2.000 * nthoAdamantiumSize ' range=':= 2.000 * nthoAdamantiumSize ' type='normal' />
@@ -4636,7 +4636,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:9")'> <OreBlock block='NetherOres:tile.netherores.ore.1:9' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.1:9' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.613 * _default_ * nthoRutileFreq ' range=':= 0.613 * _default_ * nthoRutileFreq ' type='normal' scaleTo='base' />
@@ -4678,7 +4678,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:9")'> <OreBlock block='NetherOres:tile.netherores.ore.1:9' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.1:9' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.837 * _default_ * nthoRutileSize ' range=':= 0.837 * _default_ * nthoRutileSize ' type='normal' />
@@ -4712,7 +4712,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:9")'> <OreBlock block='NetherOres:tile.netherores.ore.1:9' weight='1.0' /> </IfCondition>
+                                <OreBlock block='NetherOres:tile.netherores.ore.1:9' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -4730,7 +4730,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:9")'> <OreBlock block='NetherOres:tile.netherores.ore.1:9' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.1:9' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 2.000 * nthoRutileSize ' range=':= 2.000 * nthoRutileSize ' type='normal' />
@@ -4755,7 +4755,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:10")'> <OreBlock block='NetherOres:tile.netherores.ore.1:10' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.1:10' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.416 * _default_ * nthoTungstenFreq ' range=':= 1.416 * _default_ * nthoTungstenFreq ' type='normal' scaleTo='base' />
@@ -4797,7 +4797,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:10")'> <OreBlock block='NetherOres:tile.netherores.ore.1:10' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.1:10' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.271 * _default_ * nthoTungstenSize ' range=':= 1.271 * _default_ * nthoTungstenSize ' type='normal' />
@@ -4831,7 +4831,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:10")'> <OreBlock block='NetherOres:tile.netherores.ore.1:10' weight='1.0' /> </IfCondition>
+                                <OreBlock block='NetherOres:tile.netherores.ore.1:10' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -4849,7 +4849,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:10")'> <OreBlock block='NetherOres:tile.netherores.ore.1:10' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.1:10' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * nthoTungstenSize ' range=':= 4.000 * nthoTungstenSize ' type='normal' />
@@ -4881,7 +4881,7 @@
                                 since it is  harder to get an idea of
                                 their  direction while mining.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:11")'> <OreBlock block='NetherOres:tile.netherores.ore.1:11' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.1:11' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.372 * _default_ * nthoAmberFreq ' range=':= 2.372 * _default_ * nthoAmberFreq ' type='normal' scaleTo='base' />
@@ -4923,7 +4923,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:11")'> <OreBlock block='NetherOres:tile.netherores.ore.1:11' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.1:11' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.052 * _default_ * nthoAmberSize ' range=':= 1.052 * _default_ * nthoAmberSize ' type='normal' />
@@ -4957,7 +4957,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:11")'> <OreBlock block='NetherOres:tile.netherores.ore.1:11' weight='1.0' /> </IfCondition>
+                                <OreBlock block='NetherOres:tile.netherores.ore.1:11' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -4975,7 +4975,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:11")'> <OreBlock block='NetherOres:tile.netherores.ore.1:11' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.1:11' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.000 * nthoAmberSize ' range=':= 3.000 * nthoAmberSize ' type='normal' />
@@ -5000,7 +5000,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:12")'> <OreBlock block='NetherOres:tile.netherores.ore.1:12' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.1:12' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.416 * _default_ * nthoTennantiteFreq ' range=':= 1.416 * _default_ * nthoTennantiteFreq ' type='normal' scaleTo='base' />
@@ -5042,7 +5042,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:12")'> <OreBlock block='NetherOres:tile.netherores.ore.1:12' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.1:12' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.271 * _default_ * nthoTennantiteSize ' range=':= 1.271 * _default_ * nthoTennantiteSize ' type='normal' />
@@ -5076,7 +5076,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:12")'> <OreBlock block='NetherOres:tile.netherores.ore.1:12' weight='1.0' /> </IfCondition>
+                                <OreBlock block='NetherOres:tile.netherores.ore.1:12' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -5095,7 +5095,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:12")'> <OreBlock block='NetherOres:tile.netherores.ore.1:12' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.1:12' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * nthoTennantiteSize ' range=':= 4.000 * nthoTennantiteSize ' type='normal' />
@@ -5127,7 +5127,7 @@
                                 since it is  harder to get an idea of
                                 their  direction while mining.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:13")'> <OreBlock block='NetherOres:tile.netherores.ore.1:13' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.1:13' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.166 * _default_ * nthoSaltFreq ' range=':= 2.166 * _default_ * nthoSaltFreq ' type='normal' scaleTo='base' />
@@ -5169,7 +5169,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:13")'> <OreBlock block='NetherOres:tile.netherores.ore.1:13' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.1:13' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.005 * _default_ * nthoSaltSize ' range=':= 1.005 * _default_ * nthoSaltSize ' type='normal' />
@@ -5203,7 +5203,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:13")'> <OreBlock block='NetherOres:tile.netherores.ore.1:13' weight='1.0' /> </IfCondition>
+                                <OreBlock block='NetherOres:tile.netherores.ore.1:13' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -5221,7 +5221,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:13")'> <OreBlock block='NetherOres:tile.netherores.ore.1:13' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.1:13' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 2.500 * nthoSaltSize ' range=':= 2.500 * nthoSaltSize ' type='normal' />
@@ -5253,7 +5253,7 @@
                                 since it is  harder to get an idea of
                                 their  direction while mining.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:14")'> <OreBlock block='NetherOres:tile.netherores.ore.1:14' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.1:14' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.122 * _default_ * nthoSaltpeterFreq ' range=':= 2.122 * _default_ * nthoSaltpeterFreq ' type='normal' scaleTo='base' />
@@ -5295,7 +5295,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:14")'> <OreBlock block='NetherOres:tile.netherores.ore.1:14' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.1:14' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.995 * _default_ * nthoSaltpeterSize ' range=':= 0.995 * _default_ * nthoSaltpeterSize ' type='normal' />
@@ -5329,7 +5329,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:14")'> <OreBlock block='NetherOres:tile.netherores.ore.1:14' weight='1.0' /> </IfCondition>
+                                <OreBlock block='NetherOres:tile.netherores.ore.1:14' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -5347,7 +5347,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:14")'> <OreBlock block='NetherOres:tile.netherores.ore.1:14' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.1:14' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 2.000 * nthoSaltpeterSize ' range=':= 2.000 * nthoSaltpeterSize ' type='normal' />
@@ -5379,7 +5379,7 @@
                                 since it is  harder to get an idea of
                                 their  direction while mining.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:15")'> <OreBlock block='NetherOres:tile.netherores.ore.1:15' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.1:15' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.937 * _default_ * nthoMagnesiumFreq ' range=':= 1.937 * _default_ * nthoMagnesiumFreq ' type='normal' scaleTo='base' />
@@ -5421,7 +5421,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:15")'> <OreBlock block='NetherOres:tile.netherores.ore.1:15' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.1:15' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.951 * _default_ * nthoMagnesiumSize ' range=':= 0.951 * _default_ * nthoMagnesiumSize ' type='normal' />
@@ -5455,7 +5455,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:15")'> <OreBlock block='NetherOres:tile.netherores.ore.1:15' weight='1.0' /> </IfCondition>
+                                <OreBlock block='NetherOres:tile.netherores.ore.1:15' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -5473,7 +5473,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("NetherOres:tile.netherores.ore.1:15")'> <OreBlock block='NetherOres:tile.netherores.ore.1:15' weight='1.0' /> </IfCondition>
+                            <OreBlock block='NetherOres:tile.netherores.ore.1:15' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 2.500 * nthoMagnesiumSize ' range=':= 2.500 * nthoMagnesiumSize ' type='normal' />

--- a/src/main/resources/config/modules/Netherrocks.xml
+++ b/src/main/resources/config/modules/Netherrocks.xml
@@ -353,7 +353,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("netherrocks:fyrite_ore")'> <OreBlock block='netherrocks:fyrite_ore' weight='1.0' /> </IfCondition>
+                            <OreBlock block='netherrocks:fyrite_ore' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.371 * _default_ * nthrFyriteFreq ' range=':= 1.371 * _default_ * nthrFyriteFreq ' type='normal' scaleTo='base' />
@@ -395,7 +395,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("netherrocks:fyrite_ore")'> <OreBlock block='netherrocks:fyrite_ore' weight='1.0' /> </IfCondition>
+                            <OreBlock block='netherrocks:fyrite_ore' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.251 * _default_ * nthrFyriteSize ' range=':= 1.251 * _default_ * nthrFyriteSize ' type='normal' />
@@ -429,7 +429,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("netherrocks:fyrite_ore")'> <OreBlock block='netherrocks:fyrite_ore' weight='1.0' /> </IfCondition>
+                                <OreBlock block='netherrocks:fyrite_ore' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -447,7 +447,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("netherrocks:fyrite_ore")'> <OreBlock block='netherrocks:fyrite_ore' weight='1.0' /> </IfCondition>
+                            <OreBlock block='netherrocks:fyrite_ore' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.000 * nthrFyriteSize ' range=':= 3.000 * nthrFyriteSize ' type='normal' />
@@ -472,7 +472,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("netherrocks:malachite_ore")'> <OreBlock block='netherrocks:malachite_ore' weight='1.0' /> </IfCondition>
+                            <OreBlock block='netherrocks:malachite_ore' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.480 * _default_ * nthrMalachiteFreq ' range=':= 1.480 * _default_ * nthrMalachiteFreq ' type='normal' scaleTo='base' />
@@ -514,7 +514,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("netherrocks:malachite_ore")'> <OreBlock block='netherrocks:malachite_ore' weight='1.0' /> </IfCondition>
+                            <OreBlock block='netherrocks:malachite_ore' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.300 * _default_ * nthrMalachiteSize ' range=':= 1.300 * _default_ * nthrMalachiteSize ' type='normal' />
@@ -548,7 +548,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("netherrocks:malachite_ore")'> <OreBlock block='netherrocks:malachite_ore' weight='1.0' /> </IfCondition>
+                                <OreBlock block='netherrocks:malachite_ore' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -566,7 +566,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("netherrocks:malachite_ore")'> <OreBlock block='netherrocks:malachite_ore' weight='1.0' /> </IfCondition>
+                            <OreBlock block='netherrocks:malachite_ore' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.500 * nthrMalachiteSize ' range=':= 3.500 * nthrMalachiteSize ' type='normal' />
@@ -591,7 +591,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("netherrocks:ashstone_ore")'> <OreBlock block='netherrocks:ashstone_ore' weight='1.0' /> </IfCondition>
+                            <OreBlock block='netherrocks:ashstone_ore' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.251 * _default_ * nthrAshtoneFreq ' range=':= 1.251 * _default_ * nthrAshtoneFreq ' type='normal' scaleTo='base' />
@@ -633,7 +633,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("netherrocks:ashstone_ore")'> <OreBlock block='netherrocks:ashstone_ore' weight='1.0' /> </IfCondition>
+                            <OreBlock block='netherrocks:ashstone_ore' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.195 * _default_ * nthrAshtoneSize ' range=':= 1.195 * _default_ * nthrAshtoneSize ' type='normal' />
@@ -667,7 +667,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("netherrocks:ashstone_ore")'> <OreBlock block='netherrocks:ashstone_ore' weight='1.0' /> </IfCondition>
+                                <OreBlock block='netherrocks:ashstone_ore' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -685,7 +685,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("netherrocks:ashstone_ore")'> <OreBlock block='netherrocks:ashstone_ore' weight='1.0' /> </IfCondition>
+                            <OreBlock block='netherrocks:ashstone_ore' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 2.500 * nthrAshtoneSize ' range=':= 2.500 * nthrAshtoneSize ' type='normal' />
@@ -710,7 +710,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("netherrocks:illumenite_ore")'> <OreBlock block='netherrocks:illumenite_ore' weight='1.0' /> </IfCondition>
+                            <OreBlock block='netherrocks:illumenite_ore' weight='1.0' />
                             <Replaces block='minecraft:glowstone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 7.500 * nthrIllumeniteSize ' range=':= 7.500 * nthrIllumeniteSize ' type='normal' />
@@ -735,7 +735,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("netherrocks:dragonstone_ore")'> <OreBlock block='netherrocks:dragonstone_ore' weight='1.0' /> </IfCondition>
+                            <OreBlock block='netherrocks:dragonstone_ore' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * nthrDragonstoneFreq ' range=':= 0.969 * _default_ * nthrDragonstoneFreq ' type='normal' scaleTo='base' />
@@ -777,7 +777,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("netherrocks:dragonstone_ore")'> <OreBlock block='netherrocks:dragonstone_ore' weight='1.0' /> </IfCondition>
+                            <OreBlock block='netherrocks:dragonstone_ore' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.052 * _default_ * nthrDragonstoneSize ' range=':= 1.052 * _default_ * nthrDragonstoneSize ' type='normal' />
@@ -811,7 +811,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("netherrocks:dragonstone_ore")'> <OreBlock block='netherrocks:dragonstone_ore' weight='1.0' /> </IfCondition>
+                                <OreBlock block='netherrocks:dragonstone_ore' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -830,7 +830,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("netherrocks:dragonstone_ore")'> <OreBlock block='netherrocks:dragonstone_ore' weight='1.0' /> </IfCondition>
+                            <OreBlock block='netherrocks:dragonstone_ore' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 2.500 * nthrDragonstoneSize ' range=':= 2.500 * nthrDragonstoneSize ' type='normal' />
@@ -855,7 +855,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("netherrocks:argonite_ore")'> <OreBlock block='netherrocks:argonite_ore' weight='1.0' /> </IfCondition>
+                            <OreBlock block='netherrocks:argonite_ore' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.371 * _default_ * nthrArgoniteFreq ' range=':= 1.371 * _default_ * nthrArgoniteFreq ' type='normal' scaleTo='base' />
@@ -897,7 +897,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("netherrocks:argonite_ore")'> <OreBlock block='netherrocks:argonite_ore' weight='1.0' /> </IfCondition>
+                            <OreBlock block='netherrocks:argonite_ore' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.251 * _default_ * nthrArgoniteSize ' range=':= 1.251 * _default_ * nthrArgoniteSize ' type='normal' />
@@ -931,7 +931,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("netherrocks:argonite_ore")'> <OreBlock block='netherrocks:argonite_ore' weight='1.0' /> </IfCondition>
+                                <OreBlock block='netherrocks:argonite_ore' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -949,7 +949,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("netherrocks:argonite_ore")'> <OreBlock block='netherrocks:argonite_ore' weight='1.0' /> </IfCondition>
+                            <OreBlock block='netherrocks:argonite_ore' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.000 * nthrArgoniteSize ' range=':= 3.000 * nthrArgoniteSize ' type='normal' />

--- a/src/main/resources/config/modules/PamsHarvestCraft.xml
+++ b/src/main/resources/config/modules/PamsHarvestCraft.xml
@@ -128,7 +128,7 @@
                                 since it is  harder to get an idea of
                                 their  direction while mining.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("harvestcraft:salt")'> <OreBlock block='harvestcraft:salt' weight='1.0' /> </IfCondition>
+                            <OreBlock block='harvestcraft:salt' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 5.305 * _default_ * hvstSaltFreq ' range=':= 5.305 * _default_ * hvstSaltFreq ' type='normal' scaleTo='base' />
@@ -170,7 +170,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("harvestcraft:salt")'> <OreBlock block='harvestcraft:salt' weight='1.0' /> </IfCondition>
+                            <OreBlock block='harvestcraft:salt' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.573 * _default_ * hvstSaltSize ' range=':= 1.573 * _default_ * hvstSaltSize ' type='normal' />
@@ -204,7 +204,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("harvestcraft:salt")'> <OreBlock block='harvestcraft:salt' weight='1.0' /> </IfCondition>
+                                <OreBlock block='harvestcraft:salt' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -222,7 +222,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("harvestcraft:salt")'> <OreBlock block='harvestcraft:salt' weight='1.0' /> </IfCondition>
+                            <OreBlock block='harvestcraft:salt' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 2.500 * hvstSaltSize ' range=':= 2.500 * hvstSaltSize ' type='normal' />

--- a/src/main/resources/config/modules/ProjectRed.xml
+++ b/src/main/resources/config/modules/ProjectRed.xml
@@ -450,7 +450,7 @@
                                 Short sparsely filled veins  sloping
                                 up from near the bottom  of the map.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ProjRed|Exploration:projectred.exploration.ore' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.270 * _default_ * predRubyFreq ' range=':= 0.270 * _default_ * predRubyFreq ' type='normal' scaleTo='base' />
@@ -472,7 +472,7 @@
 
                         <!-- Configuring contained material. -->
                         <Veins name='predRubyVeinsPipe'  inherits='predRubyVeins' seed='0xE23A' drawWireframe='true' wireframeColor='0x60900113' drawBoundBox='false' boundBoxColor='0x60900113'>
-                            <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
+                            <OreBlock block='minecraft:lava' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Replaces block='ProjRed|Exploration:projectred.exploration.ore' weight='1.0' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * predRubySize  * 0.5 ' range=':= 0 * _default_ * predRubySize  * 0.5 ' type='normal' />
@@ -502,7 +502,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ProjRed|Exploration:projectred.exploration.ore' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.449 * _default_ * predRubySize ' range=':= 0.449 * _default_ * predRubySize ' type='normal' />
@@ -536,7 +536,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore' weight='1.0' /> </IfCondition>
+                                <OreBlock block='ProjRed|Exploration:projectred.exploration.ore' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -554,7 +554,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ProjRed|Exploration:projectred.exploration.ore' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 0.500 * predRubySize ' range=':= 0.500 * predRubySize ' type='normal' />
@@ -579,7 +579,7 @@
                                 Short sparsely filled veins  sloping
                                 up from near the bottom  of the map.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:1")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:1' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:1' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.270 * _default_ * predSapphireFreq ' range=':= 0.270 * _default_ * predSapphireFreq ' type='normal' scaleTo='base' />
@@ -601,7 +601,7 @@
 
                         <!-- Configuring contained material. -->
                         <Veins name='predSapphireVeinsPipe'  inherits='predSapphireVeins' seed='0x5196' drawWireframe='true' wireframeColor='0x600011C8' drawBoundBox='false' boundBoxColor='0x600011C8'>
-                            <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
+                            <OreBlock block='minecraft:lava' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Replaces block='ProjRed|Exploration:projectred.exploration.ore:1' weight='1.0' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * predSapphireSize  * 0.5 ' range=':= 0 * _default_ * predSapphireSize  * 0.5 ' type='normal' />
@@ -631,7 +631,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:1")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:1' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:1' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.449 * _default_ * predSapphireSize ' range=':= 0.449 * _default_ * predSapphireSize ' type='normal' />
@@ -665,7 +665,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:1")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:1' weight='1.0' /> </IfCondition>
+                                <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:1' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -683,7 +683,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:1")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:1' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:1' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 0.500 * predSapphireSize ' range=':= 0.500 * predSapphireSize ' type='normal' />
@@ -708,7 +708,7 @@
                                 Short sparsely filled veins  sloping
                                 up from near the bottom  of the map.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:2")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:2' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:2' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.270 * _default_ * predPeridotFreq ' range=':= 0.270 * _default_ * predPeridotFreq ' type='normal' scaleTo='base' />
@@ -730,7 +730,7 @@
 
                         <!-- Configuring contained material. -->
                         <Veins name='predPeridotVeinsPipe'  inherits='predPeridotVeins' seed='0x8759' drawWireframe='true' wireframeColor='0x60057529' drawBoundBox='false' boundBoxColor='0x60057529'>
-                            <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
+                            <OreBlock block='minecraft:lava' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Replaces block='ProjRed|Exploration:projectred.exploration.ore:2' weight='1.0' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * predPeridotSize  * 0.5 ' range=':= 0 * _default_ * predPeridotSize  * 0.5 ' type='normal' />
@@ -760,7 +760,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:2")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:2' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:2' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.449 * _default_ * predPeridotSize ' range=':= 0.449 * _default_ * predPeridotSize ' type='normal' />
@@ -794,7 +794,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:2")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:2' weight='1.0' /> </IfCondition>
+                                <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:2' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -812,7 +812,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:2")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:2' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:2' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 0.500 * predPeridotSize ' range=':= 0.500 * predPeridotSize ' type='normal' />
@@ -837,7 +837,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:3")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:3' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:3' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.416 * _default_ * predCopperFreq ' range=':= 1.416 * _default_ * predCopperFreq ' type='normal' scaleTo='base' />
@@ -879,7 +879,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:3")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:3' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:3' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.271 * _default_ * predCopperSize ' range=':= 1.271 * _default_ * predCopperSize ' type='normal' />
@@ -913,7 +913,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:3")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:3' weight='1.0' /> </IfCondition>
+                                <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:3' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -931,7 +931,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:3")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:3' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:3' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * predCopperSize ' range=':= 4.000 * predCopperSize ' type='normal' />
@@ -956,7 +956,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:4")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:4' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:4' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.119 * _default_ * predTinFreq ' range=':= 1.119 * _default_ * predTinFreq ' type='normal' scaleTo='base' />
@@ -998,7 +998,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:4")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:4' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:4' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.130 * _default_ * predTinSize ' range=':= 1.130 * _default_ * predTinSize ' type='normal' />
@@ -1032,7 +1032,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:4")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:4' weight='1.0' /> </IfCondition>
+                                <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:4' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -1050,7 +1050,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:4")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:4' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:4' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * predTinSize ' range=':= 4.000 * predTinSize ' type='normal' />
@@ -1075,7 +1075,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:5")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:5' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:5' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.354 * _default_ * predSilverFreq ' range=':= 0.354 * _default_ * predSilverFreq ' type='normal' scaleTo='base' />
@@ -1117,7 +1117,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:5")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:5' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:5' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.636 * _default_ * predSilverSize ' range=':= 0.636 * _default_ * predSilverSize ' type='normal' />
@@ -1151,7 +1151,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:5")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:5' weight='1.0' /> </IfCondition>
+                                <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:5' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -1169,7 +1169,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:5")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:5' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:5' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 2.000 * predSilverSize ' range=':= 2.000 * predSilverSize ' type='normal' />
@@ -1194,7 +1194,7 @@
                                 Single vertical veins that occur  with
                                 no motherlodes.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:6")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:6' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:6' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.286 * _default_ * predElectrotineFreq ' range=':= 1.286 * _default_ * predElectrotineFreq ' type='normal' scaleTo='base' />
@@ -1236,7 +1236,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:6")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:6' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:6' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.899 * _default_ * predElectrotineSize ' range=':= 0.899 * _default_ * predElectrotineSize ' type='normal' />
@@ -1270,7 +1270,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:6")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:6' weight='1.0' /> </IfCondition>
+                                <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:6' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -1289,7 +1289,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.ore:6")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:6' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:6' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * predElectrotineSize ' range=':= 4.000 * predElectrotineSize ' type='normal' />
@@ -1316,7 +1316,7 @@
                                 to provide  realistic distribution of
                                 stone  in a strata formation.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.stone")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.stone' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ProjRed|Exploration:projectred.exploration.stone' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.687 * _default_ * predMarbleSize ' range=':= 0.687 * _default_ * predMarbleSize ' type='normal' />
@@ -1343,7 +1343,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.stone")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.stone' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ProjRed|Exploration:projectred.exploration.stone' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.708 * _default_ * predMarbleFreq ' range=':= 0.708 * _default_ * predMarbleFreq ' type='normal' scaleTo='base' />
@@ -1375,7 +1375,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ProjRed|Exploration:projectred.exploration.stone")'> <OreBlock block='ProjRed|Exploration:projectred.exploration.stone' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ProjRed|Exploration:projectred.exploration.stone' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 8.000 * predMarbleSize ' range=':= 8.000 * predMarbleSize ' type='normal' />

--- a/src/main/resources/config/modules/RailCraft.xml
+++ b/src/main/resources/config/modules/RailCraft.xml
@@ -39,7 +39,7 @@
                 <OptionChoice name='rlcrAbyssalOresDist'  displayState=':= if(?enableRailCraft, "shown", "hidden")' displayGroup='groupRailCraft'>
                     <Description> Controls how Abyssal Ores is generated </Description>
                     <DisplayName>RailCraft Abyssal Ores</DisplayName>
-                    <IfCondition condition=':= (?blockExists("Railcraft:ore:2") | ?blockExists("Railcraft:ore:3") | ?blockExists("Railcraft:ore:4")) &amp; (?blockExists("Railcraft:cube:6")) '>
+                    <IfCondition condition=':= (?blockExists("Railcraft:ore:2")  &amp; ?blockExists("Railcraft:ore:3")  &amp; ?blockExists("Railcraft:ore:4")) &amp; (?blockExists("Railcraft:cube:6")) '>
 
                     <Choice value='Geode' displayValue='Geode'>
                         <Description>
@@ -499,7 +499,7 @@
                                 enterprising miner can  look for the
                                 contained ores.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Railcraft:cube:6")'> <OreBlock block='Railcraft:cube:6' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Railcraft:cube:6' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <ReplacesOre block='dirt' weight='1.0' />
                             <ReplacesOre block='gravel' weight='1.0' />
@@ -526,9 +526,9 @@
                                 enterprising miner can  look for the
                                 contained ores.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Railcraft:ore:2")'> <OreBlock block='Railcraft:ore:2' weight='0.0167' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("Railcraft:ore:3")'> <OreBlock block='Railcraft:ore:3' weight='0.0167' /> </IfCondition>
-                            <IfCondition condition=':= ?blockExists("Railcraft:ore:4")'> <OreBlock block='Railcraft:ore:4' weight='0.05' /> </IfCondition>
+                            <OreBlock block='Railcraft:ore:2' weight='0.0167' />
+                            <OreBlock block='Railcraft:ore:3' weight='0.0167' />
+                            <OreBlock block='Railcraft:ore:4' weight='0.05' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <ReplacesOre block='dirt' weight='1.0' />
                             <ReplacesOre block='gravel' weight='1.0' />
@@ -549,7 +549,7 @@
                                 enterprising miner can  look for the
                                 contained ores.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("minecraft:air")'> <OreBlock block='minecraft:air' weight='1.0' /> </IfCondition>
+                            <OreBlock block='minecraft:air' weight='1.0' />
                             <Replaces block='Railcraft:cube:6' weight='1.0' />
                             <Replaces block='Railcraft:ore:2' weight='1.0' />
                             <Replaces block='Railcraft:ore:3' weight='1.0' />
@@ -589,7 +589,7 @@
                                 since it is  harder to get an idea of
                                 their  direction while mining.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Railcraft:ore:7")'> <OreBlock block='Railcraft:ore:7' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Railcraft:ore:7' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 9.801 * _default_ * rlcrPoorIronFreq ' range=':= 9.801 * _default_ * rlcrPoorIronFreq ' type='normal' scaleTo='base' />
@@ -631,7 +631,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Railcraft:ore:7")'> <OreBlock block='Railcraft:ore:7' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Railcraft:ore:7' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 2.138 * _default_ * rlcrPoorIronSize ' range=':= 2.138 * _default_ * rlcrPoorIronSize ' type='normal' />
@@ -665,7 +665,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("Railcraft:ore:7")'> <OreBlock block='Railcraft:ore:7' weight='1.0' /> </IfCondition>
+                                <OreBlock block='Railcraft:ore:7' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -683,7 +683,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Railcraft:ore:7")'> <OreBlock block='Railcraft:ore:7' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Railcraft:ore:7' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 8.000 * rlcrPoorIronSize ' range=':= 8.000 * rlcrPoorIronSize ' type='normal' />
@@ -715,7 +715,7 @@
                                 since it is  harder to get an idea of
                                 their  direction while mining.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Railcraft:ore:8")'> <OreBlock block='Railcraft:ore:8' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Railcraft:ore:8' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.450 * _default_ * rlcrPoorGoldFreq ' range=':= 2.450 * _default_ * rlcrPoorGoldFreq ' type='normal' scaleTo='base' />
@@ -757,7 +757,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Railcraft:ore:8")'> <OreBlock block='Railcraft:ore:8' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Railcraft:ore:8' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.069 * _default_ * rlcrPoorGoldSize ' range=':= 1.069 * _default_ * rlcrPoorGoldSize ' type='normal' />
@@ -791,7 +791,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("Railcraft:ore:8")'> <OreBlock block='Railcraft:ore:8' weight='1.0' /> </IfCondition>
+                                <OreBlock block='Railcraft:ore:8' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -809,7 +809,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Railcraft:ore:8")'> <OreBlock block='Railcraft:ore:8' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Railcraft:ore:8' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 0.500 * rlcrPoorGoldSize ' range=':= 0.500 * rlcrPoorGoldSize ' type='normal' />
@@ -841,7 +841,7 @@
                                 since it is  harder to get an idea of
                                 their  direction while mining.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Railcraft:ore:9")'> <OreBlock block='Railcraft:ore:9' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Railcraft:ore:9' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 6.930 * _default_ * rlcrPoorCopperFreq ' range=':= 6.930 * _default_ * rlcrPoorCopperFreq ' type='normal' scaleTo='base' />
@@ -883,7 +883,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Railcraft:ore:9")'> <OreBlock block='Railcraft:ore:9' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Railcraft:ore:9' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.798 * _default_ * rlcrPoorCopperSize ' range=':= 1.798 * _default_ * rlcrPoorCopperSize ' type='normal' />
@@ -917,7 +917,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("Railcraft:ore:9")'> <OreBlock block='Railcraft:ore:9' weight='1.0' /> </IfCondition>
+                                <OreBlock block='Railcraft:ore:9' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -936,7 +936,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Railcraft:ore:9")'> <OreBlock block='Railcraft:ore:9' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Railcraft:ore:9' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * rlcrPoorCopperSize ' range=':= 4.000 * rlcrPoorCopperSize ' type='normal' />
@@ -968,7 +968,7 @@
                                 since it is  harder to get an idea of
                                 their  direction while mining.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Railcraft:ore:10")'> <OreBlock block='Railcraft:ore:10' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Railcraft:ore:10' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 3.465 * _default_ * rlcrPoorTinFreq ' range=':= 3.465 * _default_ * rlcrPoorTinFreq ' type='normal' scaleTo='base' />
@@ -1010,7 +1010,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Railcraft:ore:10")'> <OreBlock block='Railcraft:ore:10' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Railcraft:ore:10' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.271 * _default_ * rlcrPoorTinSize ' range=':= 1.271 * _default_ * rlcrPoorTinSize ' type='normal' />
@@ -1044,7 +1044,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("Railcraft:ore:10")'> <OreBlock block='Railcraft:ore:10' weight='1.0' /> </IfCondition>
+                                <OreBlock block='Railcraft:ore:10' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -1062,7 +1062,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Railcraft:ore:10")'> <OreBlock block='Railcraft:ore:10' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Railcraft:ore:10' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 1.000 * rlcrPoorTinSize ' range=':= 1.000 * rlcrPoorTinSize ' type='normal' />
@@ -1094,7 +1094,7 @@
                                 since it is  harder to get an idea of
                                 their  direction while mining.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Railcraft:ore:11")'> <OreBlock block='Railcraft:ore:11' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Railcraft:ore:11' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 6.002 * _default_ * rlcrPoorLeadFreq ' range=':= 6.002 * _default_ * rlcrPoorLeadFreq ' type='normal' scaleTo='base' />
@@ -1136,7 +1136,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Railcraft:ore:11")'> <OreBlock block='Railcraft:ore:11' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Railcraft:ore:11' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.673 * _default_ * rlcrPoorLeadSize ' range=':= 1.673 * _default_ * rlcrPoorLeadSize ' type='normal' />
@@ -1170,7 +1170,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("Railcraft:ore:11")'> <OreBlock block='Railcraft:ore:11' weight='1.0' /> </IfCondition>
+                                <OreBlock block='Railcraft:ore:11' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -1188,7 +1188,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Railcraft:ore:11")'> <OreBlock block='Railcraft:ore:11' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Railcraft:ore:11' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.000 * rlcrPoorLeadSize ' range=':= 3.000 * rlcrPoorLeadSize ' type='normal' />
@@ -1213,7 +1213,7 @@
                                 Short sparsely filled veins  sloping
                                 up from near the bottom  of the map.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Railcraft:ore")'> <OreBlock block='Railcraft:ore' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Railcraft:ore' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.707 * _default_ * rlcrSulfurFreq ' range=':= 1.707 * _default_ * rlcrSulfurFreq ' type='normal' scaleTo='base' />
@@ -1235,7 +1235,7 @@
 
                         <!-- Configuring contained material. -->
                         <Veins name='rlcrSulfurVeinsPipe'  inherits='rlcrSulfurVeins' seed='0xEE54' drawWireframe='true' wireframeColor='0x60FFE25C' drawBoundBox='false' boundBoxColor='0x60FFE25C'>
-                            <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
+                            <OreBlock block='minecraft:lava' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Replaces block='Railcraft:ore' weight='1.0' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * rlcrSulfurSize  * 0.5 ' range=':= 0 * _default_ * rlcrSulfurSize  * 0.5 ' type='normal' />
@@ -1265,7 +1265,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Railcraft:ore")'> <OreBlock block='Railcraft:ore' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Railcraft:ore' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.130 * _default_ * rlcrSulfurSize ' range=':= 1.130 * _default_ * rlcrSulfurSize ' type='normal' />
@@ -1299,7 +1299,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("Railcraft:ore")'> <OreBlock block='Railcraft:ore' weight='1.0' /> </IfCondition>
+                                <OreBlock block='Railcraft:ore' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -1317,7 +1317,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Railcraft:ore")'> <OreBlock block='Railcraft:ore' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Railcraft:ore' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 5.000 * rlcrSulfurSize ' range=':= 5.000 * rlcrSulfurSize ' type='normal' />
@@ -1349,7 +1349,7 @@
                                 since it is  harder to get an idea of
                                 their  direction while mining.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Railcraft:ore:1")'> <OreBlock block='Railcraft:ore:1' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Railcraft:ore:1' weight='1.0' />
                             <Replaces block='Replaces:minecraft:sand' weight='1.0' />
                             <Replaces block='minecraft:sandstone' weight='1.0' />
                             <BiomeType name='Desert'  minRainfall='0' maxRainfall='0.1' minTemperature='1.5' maxTemperature='2.0' />
@@ -1392,7 +1392,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Railcraft:ore:1")'> <OreBlock block='Railcraft:ore:1' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Railcraft:ore:1' weight='1.0' />
                             <Replaces block='Replaces:minecraft:sand' weight='1.0' />
                             <Replaces block='minecraft:sandstone' weight='1.0' />
                             <BiomeType name='Desert'  minRainfall='0' maxRainfall='0.1' minTemperature='1.5' maxTemperature='2.0' />
@@ -1427,7 +1427,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("Railcraft:ore:1")'> <OreBlock block='Railcraft:ore:1' weight='1.0' /> </IfCondition>
+                                <OreBlock block='Railcraft:ore:1' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -1445,7 +1445,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Railcraft:ore:1")'> <OreBlock block='Railcraft:ore:1' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Railcraft:ore:1' weight='1.0' />
                             <Replaces block='Replaces:minecraft:sand' weight='1.0' />
                             <Replaces block='minecraft:sandstone' weight='1.0' />
                             <BiomeType name='Desert'  minRainfall='0' maxRainfall='0.1' minTemperature='1.5' maxTemperature='2.0' />
@@ -1505,7 +1505,7 @@
                                 produced by StandardGen
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Railcraft:ore:5")'> <OreBlock block='Railcraft:ore:5' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Railcraft:ore:5' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.221 * _default_ * rlcrFirestoneFreq ' range=':= 0.221 * _default_ * rlcrFirestoneFreq ' type='normal' scaleTo='base' />
@@ -1547,7 +1547,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Railcraft:ore:5")'> <OreBlock block='Railcraft:ore:5' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Railcraft:ore:5' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.449 * _default_ * rlcrFirestoneSize ' range=':= 0.449 * _default_ * rlcrFirestoneSize ' type='normal' />
@@ -1581,7 +1581,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("Railcraft:ore:5")'> <OreBlock block='Railcraft:ore:5' weight='1.0' /> </IfCondition>
+                                <OreBlock block='Railcraft:ore:5' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -1599,7 +1599,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Railcraft:ore:5")'> <OreBlock block='Railcraft:ore:5' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Railcraft:ore:5' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 0.500 * rlcrFirestoneSize ' range=':= 0.500 * rlcrFirestoneSize ' type='normal' />

--- a/src/main/resources/config/modules/ReactorCraft.xml
+++ b/src/main/resources/config/modules/ReactorCraft.xml
@@ -880,7 +880,7 @@
                                 since it is  harder to get an idea of
                                 their  direction while mining.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:1")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:1' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ReactorCraft:reactorcraft_block_ore:1' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Mushroom'  />
                             <BiomeType name='Ocean'  />
@@ -924,7 +924,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:1")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:1' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ReactorCraft:reactorcraft_block_ore:1' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Mushroom'  />
                             <BiomeType name='Ocean'  />
@@ -960,7 +960,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:1")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:1' weight='1.0' /> </IfCondition>
+                                <OreBlock block='ReactorCraft:reactorcraft_block_ore:1' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -979,7 +979,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:1")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:1' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ReactorCraft:reactorcraft_block_ore:1' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Mushroom'  />
                             <BiomeType name='Ocean'  />
@@ -1006,7 +1006,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:2")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:2' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ReactorCraft:reactorcraft_block_ore:2' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.919 * _default_ * recrCadmiumFreq ' range=':= 0.919 * _default_ * recrCadmiumFreq ' type='normal' scaleTo='base' />
@@ -1048,7 +1048,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:2")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:2' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ReactorCraft:reactorcraft_block_ore:2' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.025 * _default_ * recrCadmiumSize ' range=':= 1.025 * _default_ * recrCadmiumSize ' type='normal' />
@@ -1082,7 +1082,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:2")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:2' weight='1.0' /> </IfCondition>
+                                <OreBlock block='ReactorCraft:reactorcraft_block_ore:2' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -1100,7 +1100,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:2")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:2' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ReactorCraft:reactorcraft_block_ore:2' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.500 * recrCadmiumSize ' range=':= 4.500 * recrCadmiumSize ' type='normal' />
@@ -1125,7 +1125,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:3")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:3' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ReactorCraft:reactorcraft_block_ore:3' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.662 * _default_ * recrIndiumFreq ' range=':= 0.662 * _default_ * recrIndiumFreq ' type='normal' scaleTo='base' />
@@ -1167,7 +1167,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:3")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:3' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ReactorCraft:reactorcraft_block_ore:3' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.869 * _default_ * recrIndiumSize ' range=':= 0.869 * _default_ * recrIndiumSize ' type='normal' />
@@ -1201,7 +1201,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:3")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:3' weight='1.0' /> </IfCondition>
+                                <OreBlock block='ReactorCraft:reactorcraft_block_ore:3' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -1219,7 +1219,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:3")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:3' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ReactorCraft:reactorcraft_block_ore:3' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.500 * recrIndiumSize ' range=':= 3.500 * recrIndiumSize ' type='normal' />
@@ -1244,7 +1244,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:4")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:4' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ReactorCraft:reactorcraft_block_ore:4' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.751 * _default_ * recrSilverFreq ' range=':= 0.751 * _default_ * recrSilverFreq ' type='normal' scaleTo='base' />
@@ -1286,7 +1286,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:4")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:4' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ReactorCraft:reactorcraft_block_ore:4' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.926 * _default_ * recrSilverSize ' range=':= 0.926 * _default_ * recrSilverSize ' type='normal' />
@@ -1320,7 +1320,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:4")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:4' weight='1.0' /> </IfCondition>
+                                <OreBlock block='ReactorCraft:reactorcraft_block_ore:4' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -1338,7 +1338,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:4")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:4' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ReactorCraft:reactorcraft_block_ore:4' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.500 * recrSilverSize ' range=':= 4.500 * recrSilverSize ' type='normal' />
@@ -1370,7 +1370,7 @@
                                 since it is  harder to get an idea of
                                 their  direction while mining.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:7")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:7' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ReactorCraft:reactorcraft_block_ore:7' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 3.001 * _default_ * recrCalciteFreq ' range=':= 3.001 * _default_ * recrCalciteFreq ' type='normal' scaleTo='base' />
@@ -1412,7 +1412,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:7")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:7' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ReactorCraft:reactorcraft_block_ore:7' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.183 * _default_ * recrCalciteSize ' range=':= 1.183 * _default_ * recrCalciteSize ' type='normal' />
@@ -1446,7 +1446,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:7")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:7' weight='1.0' /> </IfCondition>
+                                <OreBlock block='ReactorCraft:reactorcraft_block_ore:7' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -1464,7 +1464,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:7")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:7' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ReactorCraft:reactorcraft_block_ore:7' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 2.000 * recrCalciteSize ' range=':= 2.000 * recrCalciteSize ' type='normal' />
@@ -1496,7 +1496,7 @@
                                 since it is  harder to get an idea of
                                 their  direction while mining.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:8")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:8' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ReactorCraft:reactorcraft_block_ore:8' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 4.584 * _default_ * recrMagnetiteFreq ' range=':= 4.584 * _default_ * recrMagnetiteFreq ' type='normal' scaleTo='base' />
@@ -1538,7 +1538,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:8")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:8' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ReactorCraft:reactorcraft_block_ore:8' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.462 * _default_ * recrMagnetiteSize ' range=':= 1.462 * _default_ * recrMagnetiteSize ' type='normal' />
@@ -1572,7 +1572,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:8")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:8' weight='1.0' /> </IfCondition>
+                                <OreBlock block='ReactorCraft:reactorcraft_block_ore:8' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -1590,7 +1590,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:8")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:8' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ReactorCraft:reactorcraft_block_ore:8' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 8.000 * recrMagnetiteSize ' range=':= 8.000 * recrMagnetiteSize ' type='normal' />
@@ -1615,7 +1615,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.734 * _default_ * recrBlueFluoriteFreq ' range=':= 1.734 * _default_ * recrBlueFluoriteFreq ' type='normal' scaleTo='base' />
@@ -1659,7 +1659,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.407 * _default_ * recrBlueFluoriteSize ' range=':= 1.407 * _default_ * recrBlueFluoriteSize ' type='normal' />
@@ -1693,7 +1693,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore' weight='1.0' /> </IfCondition>
+                                <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -1712,7 +1712,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * recrBlueFluoriteSize ' range=':= 4.000 * recrBlueFluoriteSize ' type='normal' />
@@ -1737,7 +1737,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:1")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:1' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:1' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.734 * _default_ * recrPinkFluoriteFreq ' range=':= 1.734 * _default_ * recrPinkFluoriteFreq ' type='normal' scaleTo='base' />
@@ -1781,7 +1781,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:1")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:1' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:1' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.407 * _default_ * recrPinkFluoriteSize ' range=':= 1.407 * _default_ * recrPinkFluoriteSize ' type='normal' />
@@ -1815,7 +1815,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:1")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:1' weight='1.0' /> </IfCondition>
+                                <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:1' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -1834,7 +1834,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:1")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:1' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:1' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * recrPinkFluoriteSize ' range=':= 4.000 * recrPinkFluoriteSize ' type='normal' />
@@ -1859,7 +1859,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:2")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:2' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:2' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.734 * _default_ * recrOrangeFluoriteFreq ' range=':= 1.734 * _default_ * recrOrangeFluoriteFreq ' type='normal' scaleTo='base' />
@@ -1903,7 +1903,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:2")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:2' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:2' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.407 * _default_ * recrOrangeFluoriteSize ' range=':= 1.407 * _default_ * recrOrangeFluoriteSize ' type='normal' />
@@ -1937,7 +1937,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:2")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:2' weight='1.0' /> </IfCondition>
+                                <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:2' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -1956,7 +1956,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:2")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:2' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:2' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * recrOrangeFluoriteSize ' range=':= 4.000 * recrOrangeFluoriteSize ' type='normal' />
@@ -1982,7 +1982,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:3")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:3' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:3' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.734 * _default_ * recrMagentaFluoriteFreq ' range=':= 1.734 * _default_ * recrMagentaFluoriteFreq ' type='normal' scaleTo='base' />
@@ -2026,7 +2026,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:3")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:3' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:3' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.407 * _default_ * recrMagentaFluoriteSize ' range=':= 1.407 * _default_ * recrMagentaFluoriteSize ' type='normal' />
@@ -2060,7 +2060,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:3")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:3' weight='1.0' /> </IfCondition>
+                                <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:3' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -2079,7 +2079,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:3")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:3' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:3' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * recrMagentaFluoriteSize ' range=':= 4.000 * recrMagentaFluoriteSize ' type='normal' />
@@ -2104,7 +2104,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:4")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:4' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:4' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.734 * _default_ * recrGreenFluoriteFreq ' range=':= 1.734 * _default_ * recrGreenFluoriteFreq ' type='normal' scaleTo='base' />
@@ -2148,7 +2148,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:4")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:4' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:4' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.407 * _default_ * recrGreenFluoriteSize ' range=':= 1.407 * _default_ * recrGreenFluoriteSize ' type='normal' />
@@ -2182,7 +2182,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:4")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:4' weight='1.0' /> </IfCondition>
+                                <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:4' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -2201,7 +2201,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:4")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:4' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:4' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * recrGreenFluoriteSize ' range=':= 4.000 * recrGreenFluoriteSize ' type='normal' />
@@ -2226,7 +2226,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:5")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:5' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:5' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.734 * _default_ * recrRedFluoriteFreq ' range=':= 1.734 * _default_ * recrRedFluoriteFreq ' type='normal' scaleTo='base' />
@@ -2268,7 +2268,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:5")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:5' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:5' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.407 * _default_ * recrRedFluoriteSize ' range=':= 1.407 * _default_ * recrRedFluoriteSize ' type='normal' />
@@ -2302,7 +2302,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:5")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:5' weight='1.0' /> </IfCondition>
+                                <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:5' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -2321,7 +2321,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:5")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:5' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:5' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * recrRedFluoriteSize ' range=':= 4.000 * recrRedFluoriteSize ' type='normal' />
@@ -2346,7 +2346,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:6")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:6' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:6' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.734 * _default_ * recrWhiteFluoriteFreq ' range=':= 1.734 * _default_ * recrWhiteFluoriteFreq ' type='normal' scaleTo='base' />
@@ -2390,7 +2390,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:6")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:6' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:6' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.407 * _default_ * recrWhiteFluoriteSize ' range=':= 1.407 * _default_ * recrWhiteFluoriteSize ' type='normal' />
@@ -2424,7 +2424,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:6")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:6' weight='1.0' /> </IfCondition>
+                                <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:6' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -2443,7 +2443,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:6")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:6' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:6' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * recrWhiteFluoriteSize ' range=':= 4.000 * recrWhiteFluoriteSize ' type='normal' />
@@ -2468,7 +2468,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:7")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:7' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:7' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.734 * _default_ * recrYellowFluoriteFreq ' range=':= 1.734 * _default_ * recrYellowFluoriteFreq ' type='normal' scaleTo='base' />
@@ -2512,7 +2512,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:7")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:7' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:7' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.407 * _default_ * recrYellowFluoriteSize ' range=':= 1.407 * _default_ * recrYellowFluoriteSize ' type='normal' />
@@ -2546,7 +2546,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:7")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:7' weight='1.0' /> </IfCondition>
+                                <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:7' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -2565,7 +2565,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_fluoriteore:7")'> <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:7' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:7' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * recrYellowFluoriteSize ' range=':= 4.000 * recrYellowFluoriteSize ' type='normal' />
@@ -2631,7 +2631,7 @@
                                 since it is  harder to get an idea of
                                 their  direction while mining.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:6")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:6' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ReactorCraft:reactorcraft_block_ore:6' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 3.001 * _default_ * recrAmmoniumChlorideFreq ' range=':= 3.001 * _default_ * recrAmmoniumChlorideFreq ' type='normal' scaleTo='base' />
@@ -2675,7 +2675,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:6")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:6' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ReactorCraft:reactorcraft_block_ore:6' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.183 * _default_ * recrAmmoniumChlorideSize ' range=':= 1.183 * _default_ * recrAmmoniumChlorideSize ' type='normal' />
@@ -2709,7 +2709,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:6")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:6' weight='1.0' /> </IfCondition>
+                                <OreBlock block='ReactorCraft:reactorcraft_block_ore:6' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -2728,7 +2728,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:6")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:6' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ReactorCraft:reactorcraft_block_ore:6' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * recrAmmoniumChlorideSize ' range=':= 4.000 * recrAmmoniumChlorideSize ' type='normal' />
@@ -2760,7 +2760,7 @@
                                 since it is  harder to get an idea of
                                 their  direction while mining.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:9")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:9' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ReactorCraft:reactorcraft_block_ore:9' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.122 * _default_ * recrThoriteFreq ' range=':= 2.122 * _default_ * recrThoriteFreq ' type='normal' scaleTo='base' />
@@ -2802,7 +2802,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:9")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:9' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ReactorCraft:reactorcraft_block_ore:9' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.995 * _default_ * recrThoriteSize ' range=':= 0.995 * _default_ * recrThoriteSize ' type='normal' />
@@ -2836,7 +2836,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:9")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:9' weight='1.0' /> </IfCondition>
+                                <OreBlock block='ReactorCraft:reactorcraft_block_ore:9' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -2854,7 +2854,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:9")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:9' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ReactorCraft:reactorcraft_block_ore:9' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 12.000 * recrThoriteSize ' range=':= 12.000 * recrThoriteSize ' type='normal' />
@@ -2918,7 +2918,7 @@
                                 since it is  harder to get an idea of
                                 their  direction while mining.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:5")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:5' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ReactorCraft:reactorcraft_block_ore:5' weight='1.0' />
                             <Replaces block='minecraft:end_stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 4.244 * _default_ * recrEndPitchblendeFreq ' range=':= 4.244 * _default_ * recrEndPitchblendeFreq ' type='normal' scaleTo='base' />
@@ -2962,7 +2962,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:5")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:5' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ReactorCraft:reactorcraft_block_ore:5' weight='1.0' />
                             <Replaces block='minecraft:end_stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.407 * _default_ * recrEndPitchblendeSize ' range=':= 1.407 * _default_ * recrEndPitchblendeSize ' type='normal' />
@@ -2996,7 +2996,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:5")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:5' weight='1.0' /> </IfCondition>
+                                <OreBlock block='ReactorCraft:reactorcraft_block_ore:5' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -3015,7 +3015,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ReactorCraft:reactorcraft_block_ore:5")'> <OreBlock block='ReactorCraft:reactorcraft_block_ore:5' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ReactorCraft:reactorcraft_block_ore:5' weight='1.0' />
                             <Replaces block='minecraft:end_stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 8.000 * recrEndPitchblendeSize ' range=':= 8.000 * recrEndPitchblendeSize ' type='normal' />

--- a/src/main/resources/config/modules/SimpleOres.xml
+++ b/src/main/resources/config/modules/SimpleOres.xml
@@ -307,7 +307,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("simpleores:copper_ore")'> <OreBlock block='simpleores:copper_ore' weight='1.0' /> </IfCondition>
+                            <OreBlock block='simpleores:copper_ore' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.770 * _default_ * smpoCopperFreq ' range=':= 2.770 * _default_ * smpoCopperFreq ' type='normal' scaleTo='base' />
@@ -349,7 +349,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("simpleores:copper_ore")'> <OreBlock block='simpleores:copper_ore' weight='1.0' /> </IfCondition>
+                            <OreBlock block='simpleores:copper_ore' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.778 * _default_ * smpoCopperSize ' range=':= 1.778 * _default_ * smpoCopperSize ' type='normal' />
@@ -383,7 +383,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("simpleores:copper_ore")'> <OreBlock block='simpleores:copper_ore' weight='1.0' /> </IfCondition>
+                                <OreBlock block='simpleores:copper_ore' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -401,7 +401,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("simpleores:copper_ore")'> <OreBlock block='simpleores:copper_ore' weight='1.0' /> </IfCondition>
+                            <OreBlock block='simpleores:copper_ore' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.500 * smpoCopperSize ' range=':= 3.500 * smpoCopperSize ' type='normal' />
@@ -426,7 +426,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("simpleores:tin_ore")'> <OreBlock block='simpleores:tin_ore' weight='1.0' /> </IfCondition>
+                            <OreBlock block='simpleores:tin_ore' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.564 * _default_ * smpoTinFreq ' range=':= 2.564 * _default_ * smpoTinFreq ' type='normal' scaleTo='base' />
@@ -468,7 +468,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("simpleores:tin_ore")'> <OreBlock block='simpleores:tin_ore' weight='1.0' /> </IfCondition>
+                            <OreBlock block='simpleores:tin_ore' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.711 * _default_ * smpoTinSize ' range=':= 1.711 * _default_ * smpoTinSize ' type='normal' />
@@ -502,7 +502,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("simpleores:tin_ore")'> <OreBlock block='simpleores:tin_ore' weight='1.0' /> </IfCondition>
+                                <OreBlock block='simpleores:tin_ore' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -520,7 +520,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("simpleores:tin_ore")'> <OreBlock block='simpleores:tin_ore' weight='1.0' /> </IfCondition>
+                            <OreBlock block='simpleores:tin_ore' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.500 * smpoTinSize ' range=':= 3.500 * smpoTinSize ' type='normal' />
@@ -545,7 +545,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("simpleores:mythril_ore")'> <OreBlock block='simpleores:mythril_ore' weight='1.0' /> </IfCondition>
+                            <OreBlock block='simpleores:mythril_ore' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.001 * _default_ * smpoMythrilFreq ' range=':= 1.001 * _default_ * smpoMythrilFreq ' type='normal' scaleTo='base' />
@@ -587,7 +587,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("simpleores:mythril_ore")'> <OreBlock block='simpleores:mythril_ore' weight='1.0' /> </IfCondition>
+                            <OreBlock block='simpleores:mythril_ore' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.069 * _default_ * smpoMythrilSize ' range=':= 1.069 * _default_ * smpoMythrilSize ' type='normal' />
@@ -621,7 +621,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("simpleores:mythril_ore")'> <OreBlock block='simpleores:mythril_ore' weight='1.0' /> </IfCondition>
+                                <OreBlock block='simpleores:mythril_ore' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -639,7 +639,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("simpleores:mythril_ore")'> <OreBlock block='simpleores:mythril_ore' weight='1.0' /> </IfCondition>
+                            <OreBlock block='simpleores:mythril_ore' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 2.000 * smpoMythrilSize ' range=':= 2.000 * smpoMythrilSize ' type='normal' />
@@ -664,7 +664,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("simpleores:adamantium_ore")'> <OreBlock block='simpleores:adamantium_ore' weight='1.0' /> </IfCondition>
+                            <OreBlock block='simpleores:adamantium_ore' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.708 * _default_ * smpoAdamantiumFreq ' range=':= 0.708 * _default_ * smpoAdamantiumFreq ' type='normal' scaleTo='base' />
@@ -706,7 +706,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("simpleores:adamantium_ore")'> <OreBlock block='simpleores:adamantium_ore' weight='1.0' /> </IfCondition>
+                            <OreBlock block='simpleores:adamantium_ore' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.899 * _default_ * smpoAdamantiumSize ' range=':= 0.899 * _default_ * smpoAdamantiumSize ' type='normal' />
@@ -740,7 +740,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("simpleores:adamantium_ore")'> <OreBlock block='simpleores:adamantium_ore' weight='1.0' /> </IfCondition>
+                                <OreBlock block='simpleores:adamantium_ore' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -759,7 +759,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("simpleores:adamantium_ore")'> <OreBlock block='simpleores:adamantium_ore' weight='1.0' /> </IfCondition>
+                            <OreBlock block='simpleores:adamantium_ore' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 2.000 * smpoAdamantiumSize ' range=':= 2.000 * smpoAdamantiumSize ' type='normal' />
@@ -816,7 +816,7 @@
                                 Short sparsely filled veins  sloping
                                 up from near the bottom  of the map.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("simpleores:onyx_ore")'> <OreBlock block='simpleores:onyx_ore' weight='1.0' /> </IfCondition>
+                            <OreBlock block='simpleores:onyx_ore' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.597 * _default_ * smpoOnyxFreq ' range=':= 1.597 * _default_ * smpoOnyxFreq ' type='normal' scaleTo='base' />
@@ -838,7 +838,7 @@
 
                         <!-- Configuring contained material. -->
                         <Veins name='smpoOnyxVeinsPipe'  inherits='smpoOnyxVeins' seed='0x1523' drawWireframe='true' wireframeColor='0x60232323' drawBoundBox='false' boundBoxColor='0x60232323'>
-                            <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
+                            <OreBlock block='minecraft:lava' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Replaces block='simpleores:onyx_ore' weight='1.0' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * smpoOnyxSize  * 0.5 ' range=':= 0 * _default_ * smpoOnyxSize  * 0.5 ' type='normal' />
@@ -868,7 +868,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("simpleores:onyx_ore")'> <OreBlock block='simpleores:onyx_ore' weight='1.0' /> </IfCondition>
+                            <OreBlock block='simpleores:onyx_ore' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.093 * _default_ * smpoOnyxSize ' range=':= 1.093 * _default_ * smpoOnyxSize ' type='normal' />
@@ -902,7 +902,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("simpleores:onyx_ore")'> <OreBlock block='simpleores:onyx_ore' weight='1.0' /> </IfCondition>
+                                <OreBlock block='simpleores:onyx_ore' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -920,7 +920,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("simpleores:onyx_ore")'> <OreBlock block='simpleores:onyx_ore' weight='1.0' /> </IfCondition>
+                            <OreBlock block='simpleores:onyx_ore' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.500 * smpoOnyxSize ' range=':= 3.500 * smpoOnyxSize ' type='normal' />

--- a/src/main/resources/config/modules/Thaumcraft4.xml
+++ b/src/main/resources/config/modules/Thaumcraft4.xml
@@ -460,7 +460,7 @@
                                 since it is  harder to get an idea of
                                 their  direction while mining.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:7")'> <OreBlock block='Thaumcraft:blockCustomOre:7' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Thaumcraft:blockCustomOre:7' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.225 * _default_ * thm4Amber-BearingStoneFreq ' range=':= 1.225 * _default_ * thm4Amber-BearingStoneFreq ' type='normal' scaleTo='base' />
@@ -504,7 +504,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:7")'> <OreBlock block='Thaumcraft:blockCustomOre:7' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Thaumcraft:blockCustomOre:7' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.756 * _default_ * thm4Amber-BearingStoneSize ' range=':= 0.756 * _default_ * thm4Amber-BearingStoneSize ' type='normal' />
@@ -538,7 +538,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:7")'> <OreBlock block='Thaumcraft:blockCustomOre:7' weight='1.0' /> </IfCondition>
+                                <OreBlock block='Thaumcraft:blockCustomOre:7' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -557,7 +557,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:7")'> <OreBlock block='Thaumcraft:blockCustomOre:7' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Thaumcraft:blockCustomOre:7' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 0.500 * thm4Amber-BearingStoneSize ' range=':= 0.500 * thm4Amber-BearingStoneSize ' type='normal' />
@@ -590,7 +590,7 @@
                                 since it is  harder to get an idea of
                                 their  direction while mining.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre")'> <OreBlock block='Thaumcraft:blockCustomOre' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Thaumcraft:blockCustomOre' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.500 * _default_ * thm4CinnabarFreq ' range=':= 1.500 * _default_ * thm4CinnabarFreq ' type='normal' scaleTo='base' />
@@ -632,7 +632,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre")'> <OreBlock block='Thaumcraft:blockCustomOre' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Thaumcraft:blockCustomOre' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.837 * _default_ * thm4CinnabarSize ' range=':= 0.837 * _default_ * thm4CinnabarSize ' type='normal' />
@@ -666,7 +666,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre")'> <OreBlock block='Thaumcraft:blockCustomOre' weight='1.0' /> </IfCondition>
+                                <OreBlock block='Thaumcraft:blockCustomOre' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -684,7 +684,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre")'> <OreBlock block='Thaumcraft:blockCustomOre' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Thaumcraft:blockCustomOre' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 0.500 * thm4CinnabarSize ' range=':= 0.500 * thm4CinnabarSize ' type='normal' />
@@ -717,7 +717,7 @@
                                 since it is  harder to get an idea of
                                 their  direction while mining.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:1")'> <OreBlock block='Thaumcraft:blockCustomOre:1' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Thaumcraft:blockCustomOre:1' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * thm4AirInfusedStoneFreq ' range=':= 0.969 * _default_ * thm4AirInfusedStoneFreq ' type='normal' scaleTo='base' />
@@ -743,7 +743,7 @@
                                 Ore generation is doubled in
                                 preferred biomes.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:1")'> <OreBlock block='Thaumcraft:blockCustomOre:1' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Thaumcraft:blockCustomOre:1' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Plains'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * thm4AirInfusedStoneFreq ' range=':= 0.969 * _default_ * thm4AirInfusedStoneFreq ' type='normal' scaleTo='base' />
@@ -781,7 +781,7 @@
                                 to provide  realistic distribution of
                                 stone  in a strata formation.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:1")'> <OreBlock block='Thaumcraft:blockCustomOre:1' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Thaumcraft:blockCustomOre:1' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.514 * _default_ * thm4AirInfusedStoneSize ' range=':= 0.514 * _default_ * thm4AirInfusedStoneSize ' type='normal' />
@@ -802,7 +802,7 @@
                                 Ore generation is doubled in
                                 preferred biomes.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:1")'> <OreBlock block='Thaumcraft:blockCustomOre:1' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Thaumcraft:blockCustomOre:1' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Plains'  />
                             <Setting name='CloudRadius' avg=':= 0.514 * _default_ * thm4AirInfusedStoneSize ' range=':= 0.514 * _default_ * thm4AirInfusedStoneSize ' type='normal' />
@@ -832,7 +832,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:1")'> <OreBlock block='Thaumcraft:blockCustomOre:1' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Thaumcraft:blockCustomOre:1' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 2.500 * thm4AirInfusedStoneSize ' range=':= 2.500 * thm4AirInfusedStoneSize ' type='normal' />
@@ -865,7 +865,7 @@
                                 since it is  harder to get an idea of
                                 their  direction while mining.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:2")'> <OreBlock block='Thaumcraft:blockCustomOre:2' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Thaumcraft:blockCustomOre:2' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * thm4FireInfusedStoneFreq ' range=':= 0.969 * _default_ * thm4FireInfusedStoneFreq ' type='normal' scaleTo='base' />
@@ -891,7 +891,7 @@
                                 Ore generation is doubled in
                                 preferred biomes.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:2")'> <OreBlock block='Thaumcraft:blockCustomOre:2' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Thaumcraft:blockCustomOre:2' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Desert'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * thm4FireInfusedStoneFreq ' range=':= 0.969 * _default_ * thm4FireInfusedStoneFreq ' type='normal' scaleTo='base' />
@@ -929,7 +929,7 @@
                                 to provide  realistic distribution of
                                 stone  in a strata formation.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:2")'> <OreBlock block='Thaumcraft:blockCustomOre:2' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Thaumcraft:blockCustomOre:2' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.514 * _default_ * thm4FireInfusedStoneSize ' range=':= 0.514 * _default_ * thm4FireInfusedStoneSize ' type='normal' />
@@ -950,7 +950,7 @@
                                 Ore generation is doubled in
                                 preferred biomes.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:2")'> <OreBlock block='Thaumcraft:blockCustomOre:2' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Thaumcraft:blockCustomOre:2' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Desert'  />
                             <Setting name='CloudRadius' avg=':= 0.514 * _default_ * thm4FireInfusedStoneSize ' range=':= 0.514 * _default_ * thm4FireInfusedStoneSize ' type='normal' />
@@ -980,7 +980,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:2")'> <OreBlock block='Thaumcraft:blockCustomOre:2' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Thaumcraft:blockCustomOre:2' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 2.500 * thm4FireInfusedStoneSize ' range=':= 2.500 * thm4FireInfusedStoneSize ' type='normal' />
@@ -1014,7 +1014,7 @@
                                 since it is  harder to get an idea of
                                 their  direction while mining.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:3")'> <OreBlock block='Thaumcraft:blockCustomOre:3' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Thaumcraft:blockCustomOre:3' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * thm4WaterInfusedStoneFreq ' range=':= 0.969 * _default_ * thm4WaterInfusedStoneFreq ' type='normal' scaleTo='base' />
@@ -1040,7 +1040,7 @@
                                 Ore generation is doubled in
                                 preferred biomes.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:3")'> <OreBlock block='Thaumcraft:blockCustomOre:3' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Thaumcraft:blockCustomOre:3' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Water'  />
                             <BiomeType name='Swamp'  />
@@ -1079,7 +1079,7 @@
                                 to provide  realistic distribution of
                                 stone  in a strata formation.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:3")'> <OreBlock block='Thaumcraft:blockCustomOre:3' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Thaumcraft:blockCustomOre:3' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.514 * _default_ * thm4WaterInfusedStoneSize ' range=':= 0.514 * _default_ * thm4WaterInfusedStoneSize ' type='normal' />
@@ -1100,7 +1100,7 @@
                                 Ore generation is doubled in
                                 preferred biomes.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:3")'> <OreBlock block='Thaumcraft:blockCustomOre:3' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Thaumcraft:blockCustomOre:3' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Water'  />
                             <BiomeType name='Swamp'  />
@@ -1131,7 +1131,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:3")'> <OreBlock block='Thaumcraft:blockCustomOre:3' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Thaumcraft:blockCustomOre:3' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 2.500 * thm4WaterInfusedStoneSize ' range=':= 2.500 * thm4WaterInfusedStoneSize ' type='normal' />
@@ -1165,7 +1165,7 @@
                                 since it is  harder to get an idea of
                                 their  direction while mining.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:4")'> <OreBlock block='Thaumcraft:blockCustomOre:4' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Thaumcraft:blockCustomOre:4' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * thm4EarthInfusedStoneFreq ' range=':= 0.969 * _default_ * thm4EarthInfusedStoneFreq ' type='normal' scaleTo='base' />
@@ -1191,7 +1191,7 @@
                                 Ore generation is doubled in
                                 preferred biomes.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:4")'> <OreBlock block='Thaumcraft:blockCustomOre:4' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Thaumcraft:blockCustomOre:4' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Forest'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * thm4EarthInfusedStoneFreq ' range=':= 0.969 * _default_ * thm4EarthInfusedStoneFreq ' type='normal' scaleTo='base' />
@@ -1229,7 +1229,7 @@
                                 to provide  realistic distribution of
                                 stone  in a strata formation.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:4")'> <OreBlock block='Thaumcraft:blockCustomOre:4' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Thaumcraft:blockCustomOre:4' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.514 * _default_ * thm4EarthInfusedStoneSize ' range=':= 0.514 * _default_ * thm4EarthInfusedStoneSize ' type='normal' />
@@ -1250,7 +1250,7 @@
                                 Ore generation is doubled in
                                 preferred biomes.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:4")'> <OreBlock block='Thaumcraft:blockCustomOre:4' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Thaumcraft:blockCustomOre:4' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Forest'  />
                             <Setting name='CloudRadius' avg=':= 0.514 * _default_ * thm4EarthInfusedStoneSize ' range=':= 0.514 * _default_ * thm4EarthInfusedStoneSize ' type='normal' />
@@ -1280,7 +1280,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:4")'> <OreBlock block='Thaumcraft:blockCustomOre:4' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Thaumcraft:blockCustomOre:4' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 2.500 * thm4EarthInfusedStoneSize ' range=':= 2.500 * thm4EarthInfusedStoneSize ' type='normal' />
@@ -1314,7 +1314,7 @@
                                 since it is  harder to get an idea of
                                 their  direction while mining.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:5")'> <OreBlock block='Thaumcraft:blockCustomOre:5' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Thaumcraft:blockCustomOre:5' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * thm4OrderInfusedStoneFreq ' range=':= 0.969 * _default_ * thm4OrderInfusedStoneFreq ' type='normal' scaleTo='base' />
@@ -1340,7 +1340,7 @@
                                 Ore generation is doubled in
                                 preferred biomes.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:5")'> <OreBlock block='Thaumcraft:blockCustomOre:5' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Thaumcraft:blockCustomOre:5' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Mushroom'  />
                             <BiomeType name='Mountain'  />
@@ -1380,7 +1380,7 @@
                                 to provide  realistic distribution of
                                 stone  in a strata formation.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:5")'> <OreBlock block='Thaumcraft:blockCustomOre:5' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Thaumcraft:blockCustomOre:5' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.514 * _default_ * thm4OrderInfusedStoneSize ' range=':= 0.514 * _default_ * thm4OrderInfusedStoneSize ' type='normal' />
@@ -1401,7 +1401,7 @@
                                 Ore generation is doubled in
                                 preferred biomes.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:5")'> <OreBlock block='Thaumcraft:blockCustomOre:5' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Thaumcraft:blockCustomOre:5' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Mushroom'  />
                             <BiomeType name='Mountain'  />
@@ -1433,7 +1433,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:5")'> <OreBlock block='Thaumcraft:blockCustomOre:5' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Thaumcraft:blockCustomOre:5' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 2.500 * thm4OrderInfusedStoneSize ' range=':= 2.500 * thm4OrderInfusedStoneSize ' type='normal' />
@@ -1467,7 +1467,7 @@
                                 since it is  harder to get an idea of
                                 their  direction while mining.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:6")'> <OreBlock block='Thaumcraft:blockCustomOre:6' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Thaumcraft:blockCustomOre:6' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * thm4EntropyInfusedStoneFreq ' range=':= 0.969 * _default_ * thm4EntropyInfusedStoneFreq ' type='normal' scaleTo='base' />
@@ -1493,7 +1493,7 @@
                                 Ore generation is doubled in
                                 preferred biomes.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:6")'> <OreBlock block='Thaumcraft:blockCustomOre:6' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Thaumcraft:blockCustomOre:6' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Swamp'  />
                             <BiomeType name='Wasteland'  />
@@ -1532,7 +1532,7 @@
                                 to provide  realistic distribution of
                                 stone  in a strata formation.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:6")'> <OreBlock block='Thaumcraft:blockCustomOre:6' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Thaumcraft:blockCustomOre:6' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.514 * _default_ * thm4EntropyInfusedStoneSize ' range=':= 0.514 * _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
@@ -1553,7 +1553,7 @@
                                 Ore generation is doubled in
                                 preferred biomes.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:6")'> <OreBlock block='Thaumcraft:blockCustomOre:6' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Thaumcraft:blockCustomOre:6' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Swamp'  />
                             <BiomeType name='Wasteland'  />
@@ -1585,7 +1585,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("Thaumcraft:blockCustomOre:6")'> <OreBlock block='Thaumcraft:blockCustomOre:6' weight='1.0' /> </IfCondition>
+                            <OreBlock block='Thaumcraft:blockCustomOre:6' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 2.500 * thm4EntropyInfusedStoneSize ' range=':= 2.500 * thm4EntropyInfusedStoneSize ' type='normal' />

--- a/src/main/resources/config/modules/ThermalFoundation.xml
+++ b/src/main/resources/config/modules/ThermalFoundation.xml
@@ -357,7 +357,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore")'> <OreBlock block='ThermalFoundation:Ore' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ThermalFoundation:Ore' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.583 * _default_ * thfoCopperFreq ' range=':= 1.583 * _default_ * thfoCopperFreq ' type='normal' scaleTo='base' />
@@ -399,7 +399,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore")'> <OreBlock block='ThermalFoundation:Ore' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ThermalFoundation:Ore' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.344 * _default_ * thfoCopperSize ' range=':= 1.344 * _default_ * thfoCopperSize ' type='normal' />
@@ -433,7 +433,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore")'> <OreBlock block='ThermalFoundation:Ore' weight='1.0' /> </IfCondition>
+                                <OreBlock block='ThermalFoundation:Ore' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -451,7 +451,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore")'> <OreBlock block='ThermalFoundation:Ore' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ThermalFoundation:Ore' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * thfoCopperSize ' range=':= 4.000 * thfoCopperSize ' type='normal' />
@@ -476,7 +476,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:1")'> <OreBlock block='ThermalFoundation:Ore:1' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ThermalFoundation:Ore:1' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.416 * _default_ * thfoTinFreq ' range=':= 1.416 * _default_ * thfoTinFreq ' type='normal' scaleTo='base' />
@@ -518,7 +518,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:1")'> <OreBlock block='ThermalFoundation:Ore:1' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ThermalFoundation:Ore:1' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.271 * _default_ * thfoTinSize ' range=':= 1.271 * _default_ * thfoTinSize ' type='normal' />
@@ -552,7 +552,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:1")'> <OreBlock block='ThermalFoundation:Ore:1' weight='1.0' /> </IfCondition>
+                                <OreBlock block='ThermalFoundation:Ore:1' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -570,7 +570,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:1")'> <OreBlock block='ThermalFoundation:Ore:1' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ThermalFoundation:Ore:1' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * thfoTinSize ' range=':= 4.000 * thfoTinSize ' type='normal' />
@@ -595,7 +595,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:2")'> <OreBlock block='ThermalFoundation:Ore:2' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ThermalFoundation:Ore:2' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.226 * _default_ * thfoSilverFreq ' range=':= 1.226 * _default_ * thfoSilverFreq ' type='normal' scaleTo='base' />
@@ -637,7 +637,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:2")'> <OreBlock block='ThermalFoundation:Ore:2' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ThermalFoundation:Ore:2' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.183 * _default_ * thfoSilverSize ' range=':= 1.183 * _default_ * thfoSilverSize ' type='normal' />
@@ -671,7 +671,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:2")'> <OreBlock block='ThermalFoundation:Ore:2' weight='1.0' /> </IfCondition>
+                                <OreBlock block='ThermalFoundation:Ore:2' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -689,7 +689,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:2")'> <OreBlock block='ThermalFoundation:Ore:2' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ThermalFoundation:Ore:2' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * thfoSilverSize ' range=':= 4.000 * thfoSilverSize ' type='normal' />
@@ -714,7 +714,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:3")'> <OreBlock block='ThermalFoundation:Ore:3' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ThermalFoundation:Ore:3' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.416 * _default_ * thfoLeadFreq ' range=':= 1.416 * _default_ * thfoLeadFreq ' type='normal' scaleTo='base' />
@@ -756,7 +756,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:3")'> <OreBlock block='ThermalFoundation:Ore:3' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ThermalFoundation:Ore:3' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.271 * _default_ * thfoLeadSize ' range=':= 1.271 * _default_ * thfoLeadSize ' type='normal' />
@@ -790,7 +790,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:3")'> <OreBlock block='ThermalFoundation:Ore:3' weight='1.0' /> </IfCondition>
+                                <OreBlock block='ThermalFoundation:Ore:3' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -808,7 +808,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:3")'> <OreBlock block='ThermalFoundation:Ore:3' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ThermalFoundation:Ore:3' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * thfoLeadSize ' range=':= 4.000 * thfoLeadSize ' type='normal' />
@@ -833,7 +833,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:4")'> <OreBlock block='ThermalFoundation:Ore:4' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ThermalFoundation:Ore:4' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.613 * _default_ * thfoFerrousFreq ' range=':= 0.613 * _default_ * thfoFerrousFreq ' type='normal' scaleTo='base' />
@@ -875,7 +875,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:4")'> <OreBlock block='ThermalFoundation:Ore:4' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ThermalFoundation:Ore:4' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.837 * _default_ * thfoFerrousSize ' range=':= 0.837 * _default_ * thfoFerrousSize ' type='normal' />
@@ -909,7 +909,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:4")'> <OreBlock block='ThermalFoundation:Ore:4' weight='1.0' /> </IfCondition>
+                                <OreBlock block='ThermalFoundation:Ore:4' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -927,7 +927,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:4")'> <OreBlock block='ThermalFoundation:Ore:4' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ThermalFoundation:Ore:4' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 2.000 * thfoFerrousSize ' range=':= 2.000 * thfoFerrousSize ' type='normal' />
@@ -952,7 +952,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:5")'> <OreBlock block='ThermalFoundation:Ore:5' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ThermalFoundation:Ore:5' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.306 * _default_ * thfoShinyFreq ' range=':= 0.306 * _default_ * thfoShinyFreq ' type='normal' scaleTo='base' />
@@ -994,7 +994,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:5")'> <OreBlock block='ThermalFoundation:Ore:5' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ThermalFoundation:Ore:5' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.592 * _default_ * thfoShinySize ' range=':= 0.592 * _default_ * thfoShinySize ' type='normal' />
@@ -1028,7 +1028,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:5")'> <OreBlock block='ThermalFoundation:Ore:5' weight='1.0' /> </IfCondition>
+                                <OreBlock block='ThermalFoundation:Ore:5' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -1046,7 +1046,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("ThermalFoundation:Ore:5")'> <OreBlock block='ThermalFoundation:Ore:5' weight='1.0' /> </IfCondition>
+                            <OreBlock block='ThermalFoundation:Ore:5' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 1.500 * thfoShinySize ' range=':= 1.500 * thfoShinySize ' type='normal' />

--- a/src/main/resources/config/modules/TinkersConstruct.xml
+++ b/src/main/resources/config/modules/TinkersConstruct.xml
@@ -604,7 +604,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:3")'> <OreBlock block='TConstruct:SearedBrick:3' weight='1.0' /> </IfCondition>
+                            <OreBlock block='TConstruct:SearedBrick:3' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.708 * _default_ * ticoCopperFreq ' range=':= 0.708 * _default_ * ticoCopperFreq ' type='normal' scaleTo='base' />
@@ -646,7 +646,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:3")'> <OreBlock block='TConstruct:SearedBrick:3' weight='1.0' /> </IfCondition>
+                            <OreBlock block='TConstruct:SearedBrick:3' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.899 * _default_ * ticoCopperSize ' range=':= 0.899 * _default_ * ticoCopperSize ' type='normal' />
@@ -680,7 +680,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:3")'> <OreBlock block='TConstruct:SearedBrick:3' weight='1.0' /> </IfCondition>
+                                <OreBlock block='TConstruct:SearedBrick:3' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -698,7 +698,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:3")'> <OreBlock block='TConstruct:SearedBrick:3' weight='1.0' /> </IfCondition>
+                            <OreBlock block='TConstruct:SearedBrick:3' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * ticoCopperSize ' range=':= 4.000 * ticoCopperSize ' type='normal' />
@@ -723,7 +723,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:4")'> <OreBlock block='TConstruct:SearedBrick:4' weight='1.0' /> </IfCondition>
+                            <OreBlock block='TConstruct:SearedBrick:4' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.708 * _default_ * ticoTinFreq ' range=':= 0.708 * _default_ * ticoTinFreq ' type='normal' scaleTo='base' />
@@ -765,7 +765,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:4")'> <OreBlock block='TConstruct:SearedBrick:4' weight='1.0' /> </IfCondition>
+                            <OreBlock block='TConstruct:SearedBrick:4' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.899 * _default_ * ticoTinSize ' range=':= 0.899 * _default_ * ticoTinSize ' type='normal' />
@@ -799,7 +799,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:4")'> <OreBlock block='TConstruct:SearedBrick:4' weight='1.0' /> </IfCondition>
+                                <OreBlock block='TConstruct:SearedBrick:4' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -817,7 +817,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:4")'> <OreBlock block='TConstruct:SearedBrick:4' weight='1.0' /> </IfCondition>
+                            <OreBlock block='TConstruct:SearedBrick:4' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * ticoTinSize ' range=':= 4.000 * ticoTinSize ' type='normal' />
@@ -842,7 +842,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:5")'> <OreBlock block='TConstruct:SearedBrick:5' weight='1.0' /> </IfCondition>
+                            <OreBlock block='TConstruct:SearedBrick:5' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.751 * _default_ * ticoAluminumFreq ' range=':= 0.751 * _default_ * ticoAluminumFreq ' type='normal' scaleTo='base' />
@@ -884,7 +884,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:5")'> <OreBlock block='TConstruct:SearedBrick:5' weight='1.0' /> </IfCondition>
+                            <OreBlock block='TConstruct:SearedBrick:5' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.926 * _default_ * ticoAluminumSize ' range=':= 0.926 * _default_ * ticoAluminumSize ' type='normal' />
@@ -918,7 +918,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:5")'> <OreBlock block='TConstruct:SearedBrick:5' weight='1.0' /> </IfCondition>
+                                <OreBlock block='TConstruct:SearedBrick:5' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -936,7 +936,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:5")'> <OreBlock block='TConstruct:SearedBrick:5' weight='1.0' /> </IfCondition>
+                            <OreBlock block='TConstruct:SearedBrick:5' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.000 * ticoAluminumSize ' range=':= 3.000 * ticoAluminumSize ' type='normal' />
@@ -961,7 +961,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("TConstruct:GravelOre")'> <OreBlock block='TConstruct:GravelOre' weight='1.0' /> </IfCondition>
+                            <OreBlock block='TConstruct:GravelOre' weight='1.0' />
                             <ReplacesOre block='gravel' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.238 * _default_ * ticoIronGravelFreq ' range=':= 2.238 * _default_ * ticoIronGravelFreq ' type='normal' scaleTo='base' />
@@ -1003,7 +1003,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("TConstruct:GravelOre")'> <OreBlock block='TConstruct:GravelOre' weight='1.0' /> </IfCondition>
+                            <OreBlock block='TConstruct:GravelOre' weight='1.0' />
                             <ReplacesOre block='gravel' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.599 * _default_ * ticoIronGravelSize ' range=':= 1.599 * _default_ * ticoIronGravelSize ' type='normal' />
@@ -1037,7 +1037,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("TConstruct:GravelOre")'> <OreBlock block='TConstruct:GravelOre' weight='1.0' /> </IfCondition>
+                                <OreBlock block='TConstruct:GravelOre' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -1056,7 +1056,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("TConstruct:GravelOre")'> <OreBlock block='TConstruct:GravelOre' weight='1.0' /> </IfCondition>
+                            <OreBlock block='TConstruct:GravelOre' weight='1.0' />
                             <ReplacesOre block='gravel' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * ticoIronGravelSize ' range=':= 4.000 * ticoIronGravelSize ' type='normal' />
@@ -1081,7 +1081,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:1")'> <OreBlock block='TConstruct:GravelOre:1' weight='1.0' /> </IfCondition>
+                            <OreBlock block='TConstruct:GravelOre:1' weight='1.0' />
                             <ReplacesOre block='gravel' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.708 * _default_ * ticoGoldGravelFreq ' range=':= 0.708 * _default_ * ticoGoldGravelFreq ' type='normal' scaleTo='base' />
@@ -1123,7 +1123,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:1")'> <OreBlock block='TConstruct:GravelOre:1' weight='1.0' /> </IfCondition>
+                            <OreBlock block='TConstruct:GravelOre:1' weight='1.0' />
                             <ReplacesOre block='gravel' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.899 * _default_ * ticoGoldGravelSize ' range=':= 0.899 * _default_ * ticoGoldGravelSize ' type='normal' />
@@ -1157,7 +1157,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:1")'> <OreBlock block='TConstruct:GravelOre:1' weight='1.0' /> </IfCondition>
+                                <OreBlock block='TConstruct:GravelOre:1' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -1176,7 +1176,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:1")'> <OreBlock block='TConstruct:GravelOre:1' weight='1.0' /> </IfCondition>
+                            <OreBlock block='TConstruct:GravelOre:1' weight='1.0' />
                             <ReplacesOre block='gravel' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * ticoGoldGravelSize ' range=':= 4.000 * ticoGoldGravelSize ' type='normal' />
@@ -1201,7 +1201,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:2")'> <OreBlock block='TConstruct:GravelOre:2' weight='1.0' /> </IfCondition>
+                            <OreBlock block='TConstruct:GravelOre:2' weight='1.0' />
                             <ReplacesOre block='gravel' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.708 * _default_ * ticoCopperGravelFreq ' range=':= 0.708 * _default_ * ticoCopperGravelFreq ' type='normal' scaleTo='base' />
@@ -1245,7 +1245,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:2")'> <OreBlock block='TConstruct:GravelOre:2' weight='1.0' /> </IfCondition>
+                            <OreBlock block='TConstruct:GravelOre:2' weight='1.0' />
                             <ReplacesOre block='gravel' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.899 * _default_ * ticoCopperGravelSize ' range=':= 0.899 * _default_ * ticoCopperGravelSize ' type='normal' />
@@ -1279,7 +1279,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:2")'> <OreBlock block='TConstruct:GravelOre:2' weight='1.0' /> </IfCondition>
+                                <OreBlock block='TConstruct:GravelOre:2' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -1298,7 +1298,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:2")'> <OreBlock block='TConstruct:GravelOre:2' weight='1.0' /> </IfCondition>
+                            <OreBlock block='TConstruct:GravelOre:2' weight='1.0' />
                             <ReplacesOre block='gravel' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * ticoCopperGravelSize ' range=':= 4.000 * ticoCopperGravelSize ' type='normal' />
@@ -1323,7 +1323,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:3")'> <OreBlock block='TConstruct:GravelOre:3' weight='1.0' /> </IfCondition>
+                            <OreBlock block='TConstruct:GravelOre:3' weight='1.0' />
                             <ReplacesOre block='gravel' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.416 * _default_ * ticoTinGravelFreq ' range=':= 1.416 * _default_ * ticoTinGravelFreq ' type='normal' scaleTo='base' />
@@ -1365,7 +1365,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:3")'> <OreBlock block='TConstruct:GravelOre:3' weight='1.0' /> </IfCondition>
+                            <OreBlock block='TConstruct:GravelOre:3' weight='1.0' />
                             <ReplacesOre block='gravel' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 1.271 * _default_ * ticoTinGravelSize ' range=':= 1.271 * _default_ * ticoTinGravelSize ' type='normal' />
@@ -1399,7 +1399,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:3")'> <OreBlock block='TConstruct:GravelOre:3' weight='1.0' /> </IfCondition>
+                                <OreBlock block='TConstruct:GravelOre:3' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -1418,7 +1418,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:3")'> <OreBlock block='TConstruct:GravelOre:3' weight='1.0' /> </IfCondition>
+                            <OreBlock block='TConstruct:GravelOre:3' weight='1.0' />
                             <ReplacesOre block='gravel' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * ticoTinGravelSize ' range=':= 4.000 * ticoTinGravelSize ' type='normal' />
@@ -1443,7 +1443,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:4")'> <OreBlock block='TConstruct:GravelOre:4' weight='1.0' /> </IfCondition>
+                            <OreBlock block='TConstruct:GravelOre:4' weight='1.0' />
                             <ReplacesOre block='gravel' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.751 * _default_ * ticoAluminumGravelFreq ' range=':= 0.751 * _default_ * ticoAluminumGravelFreq ' type='normal' scaleTo='base' />
@@ -1487,7 +1487,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:4")'> <OreBlock block='TConstruct:GravelOre:4' weight='1.0' /> </IfCondition>
+                            <OreBlock block='TConstruct:GravelOre:4' weight='1.0' />
                             <ReplacesOre block='gravel' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.926 * _default_ * ticoAluminumGravelSize ' range=':= 0.926 * _default_ * ticoAluminumGravelSize ' type='normal' />
@@ -1521,7 +1521,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:4")'> <OreBlock block='TConstruct:GravelOre:4' weight='1.0' /> </IfCondition>
+                                <OreBlock block='TConstruct:GravelOre:4' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -1540,7 +1540,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:4")'> <OreBlock block='TConstruct:GravelOre:4' weight='1.0' /> </IfCondition>
+                            <OreBlock block='TConstruct:GravelOre:4' weight='1.0' />
                             <ReplacesOre block='gravel' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 3.000 * ticoAluminumGravelSize ' range=':= 3.000 * ticoAluminumGravelSize ' type='normal' />
@@ -1615,7 +1615,7 @@
                                 produced by StandardGen
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:1")'> <OreBlock block='TConstruct:SearedBrick:1' weight='1.0' /> </IfCondition>
+                            <OreBlock block='TConstruct:SearedBrick:1' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.084 * _default_ * ticoCobaltFreq ' range=':= 1.084 * _default_ * ticoCobaltFreq ' type='normal' scaleTo='base' />
@@ -1657,7 +1657,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:1")'> <OreBlock block='TConstruct:SearedBrick:1' weight='1.0' /> </IfCondition>
+                            <OreBlock block='TConstruct:SearedBrick:1' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.995 * _default_ * ticoCobaltSize ' range=':= 0.995 * _default_ * ticoCobaltSize ' type='normal' />
@@ -1691,7 +1691,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:1")'> <OreBlock block='TConstruct:SearedBrick:1' weight='1.0' /> </IfCondition>
+                                <OreBlock block='TConstruct:SearedBrick:1' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -1709,7 +1709,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:1")'> <OreBlock block='TConstruct:SearedBrick:1' weight='1.0' /> </IfCondition>
+                            <OreBlock block='TConstruct:SearedBrick:1' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 1.500 * ticoCobaltSize ' range=':= 1.500 * ticoCobaltSize ' type='normal' />
@@ -1736,7 +1736,7 @@
                                 produced by StandardGen
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:2")'> <OreBlock block='TConstruct:SearedBrick:2' weight='1.0' /> </IfCondition>
+                            <OreBlock block='TConstruct:SearedBrick:2' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.084 * _default_ * ticoArditeFreq ' range=':= 1.084 * _default_ * ticoArditeFreq ' type='normal' scaleTo='base' />
@@ -1778,7 +1778,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:2")'> <OreBlock block='TConstruct:SearedBrick:2' weight='1.0' /> </IfCondition>
+                            <OreBlock block='TConstruct:SearedBrick:2' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.995 * _default_ * ticoArditeSize ' range=':= 0.995 * _default_ * ticoArditeSize ' type='normal' />
@@ -1812,7 +1812,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:2")'> <OreBlock block='TConstruct:SearedBrick:2' weight='1.0' /> </IfCondition>
+                                <OreBlock block='TConstruct:SearedBrick:2' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -1830,7 +1830,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("TConstruct:SearedBrick:2")'> <OreBlock block='TConstruct:SearedBrick:2' weight='1.0' /> </IfCondition>
+                            <OreBlock block='TConstruct:SearedBrick:2' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 1.500 * ticoArditeSize ' range=':= 1.500 * ticoArditeSize ' type='normal' />
@@ -1857,7 +1857,7 @@
                                 produced by StandardGen
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:5")'> <OreBlock block='TConstruct:GravelOre:5' weight='1.0' /> </IfCondition>
+                            <OreBlock block='TConstruct:GravelOre:5' weight='1.0' />
                             <ReplacesOre block='gravel' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.084 * _default_ * ticoCobaltGravelFreq ' range=':= 1.084 * _default_ * ticoCobaltGravelFreq ' type='normal' scaleTo='base' />
@@ -1901,7 +1901,7 @@
                                 mining base and  spend some time
                                 actually mining  the ore.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:5")'> <OreBlock block='TConstruct:GravelOre:5' weight='1.0' /> </IfCondition>
+                            <OreBlock block='TConstruct:GravelOre:5' weight='1.0' />
                             <ReplacesOre block='gravel' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.995 * _default_ * ticoCobaltGravelSize ' range=':= 0.995 * _default_ * ticoCobaltGravelSize ' type='normal' />
@@ -1935,7 +1935,7 @@
                                     the parent distribution will
                                     already be scaled by that.
                                 </Description>
-                                <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:5")'> <OreBlock block='TConstruct:GravelOre:5' weight='1.0' /> </IfCondition>
+                                <OreBlock block='TConstruct:GravelOre:5' weight='1.0' />
                                 <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                             </Veins>
@@ -1954,7 +1954,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("TConstruct:GravelOre:5")'> <OreBlock block='TConstruct:GravelOre:5' weight='1.0' /> </IfCondition>
+                            <OreBlock block='TConstruct:GravelOre:5' weight='1.0' />
                             <ReplacesOre block='gravel' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 1.500 * ticoCobaltGravelSize ' range=':= 1.500 * ticoCobaltGravelSize ' type='normal' />

--- a/src/main/resources/config/modules/TinkersSteelworks.xml
+++ b/src/main/resources/config/modules/TinkersSteelworks.xml
@@ -122,7 +122,7 @@
                                 to provide  realistic distribution of
                                 stone  in a strata formation.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("TSteelworks:Limestone")'> <OreBlock block='TSteelworks:Limestone' weight='1.0' /> </IfCondition>
+                            <OreBlock block='TSteelworks:Limestone' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='CloudRadius' avg=':= 0.972 * _default_ * tiswLimestoneSize ' range=':= 0.972 * _default_ * tiswLimestoneSize ' type='normal' />
@@ -149,7 +149,7 @@
                                 Small, fairly rare motherlodes  with
                                 2-4 horizontal veins each.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("TSteelworks:Limestone")'> <OreBlock block='TSteelworks:Limestone' weight='1.0' /> </IfCondition>
+                            <OreBlock block='TSteelworks:Limestone' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.416 * _default_ * tiswLimestoneFreq ' range=':= 1.416 * _default_ * tiswLimestoneFreq ' type='normal' scaleTo='base' />
@@ -181,7 +181,7 @@
                                 A master preset for standardgen  ore
                                 distributions.
                             </Description>
-                            <IfCondition condition=':= ?blockExists("TSteelworks:Limestone")'> <OreBlock block='TSteelworks:Limestone' weight='1.0' /> </IfCondition>
+                            <OreBlock block='TSteelworks:Limestone' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 16.000 * tiswLimestoneSize ' range=':= 16.000 * tiswLimestoneSize ' type='normal' />

--- a/src/main/resources/config/modules/VanillaMinecraft.xml
+++ b/src/main/resources/config/modules/VanillaMinecraft.xml
@@ -491,7 +491,7 @@
                         Similar to the deposits produced by
                         StandardGen distributions.
                     </Description>
-                    <IfCondition condition=':= ?blockExists("minecraft:clay")'> <OreBlock block='minecraft:clay' weight='1.0' /> </IfCondition>
+                    <OreBlock block='minecraft:clay' weight='1.0' />
                     <ReplacesOre block='sand' weight='1.0' />
                     <ReplacesOre block='gravel' weight='1.0' />
                     <ReplacesOre block='dirt' weight='1.0' />
@@ -522,7 +522,7 @@
                         Ore generation is doubled in preferred
                         biomes.
                     </Description>
-                    <IfCondition condition=':= ?blockExists("minecraft:clay")'> <OreBlock block='minecraft:clay' weight='1.0' /> </IfCondition>
+                    <OreBlock block='minecraft:clay' weight='1.0' />
                     <ReplacesOre block='sand' weight='1.0' />
                     <ReplacesOre block='gravel' weight='1.0' />
                     <ReplacesOre block='dirt' weight='1.0' />
@@ -565,7 +565,7 @@
                         realistic distribution of stone  in a strata
                         formation.
                     </Description>
-                    <IfCondition condition=':= ?blockExists("minecraft:clay")'> <OreBlock block='minecraft:clay' weight='1.0' /> </IfCondition>
+                    <OreBlock block='minecraft:clay' weight='1.0' />
                     <ReplacesOre block='sand' weight='1.0' />
                     <ReplacesOre block='gravel' weight='1.0' />
                     <ReplacesOre block='dirt' weight='1.0' />
@@ -591,7 +591,7 @@
                         Ore generation is doubled in preferred
                         biomes.
                     </Description>
-                    <IfCondition condition=':= ?blockExists("minecraft:clay")'> <OreBlock block='minecraft:clay' weight='1.0' /> </IfCondition>
+                    <OreBlock block='minecraft:clay' weight='1.0' />
                     <ReplacesOre block='sand' weight='1.0' />
                     <ReplacesOre block='gravel' weight='1.0' />
                     <ReplacesOre block='dirt' weight='1.0' />
@@ -637,7 +637,7 @@
                         to get an idea of  their direction while
                         mining.
                     </Description>
-                    <IfCondition condition=':= ?blockExists("minecraft:coal_ore")'> <OreBlock block='minecraft:coal_ore' weight='1.0' /> </IfCondition>
+                    <OreBlock block='minecraft:coal_ore' weight='1.0' />
                     <ReplacesOre block='stone' weight='1.0' />
                     <Biome name='.*'  />
                     <Setting name='MotherlodeFrequency' avg=':= 7.748 * _default_ * vnlaCoalFreq ' range=':= 7.748 * _default_ * vnlaCoalFreq ' type='normal' scaleTo='base' />
@@ -677,7 +677,7 @@
                         semi-permanent  mining base and spend some
                         time actually  mining the ore.
                     </Description>
-                    <IfCondition condition=':= ?blockExists("minecraft:coal_ore")'> <OreBlock block='minecraft:coal_ore' weight='1.0' /> </IfCondition>
+                    <OreBlock block='minecraft:coal_ore' weight='1.0' />
                     <ReplacesOre block='stone' weight='1.0' />
                     <Biome name='.*'  />
                     <Setting name='CloudRadius' avg=':= 1.901 * _default_ * vnlaCoalSize ' range=':= 1.901 * _default_ * vnlaCoalSize ' type='normal' />
@@ -708,7 +708,7 @@
                             parent  distribution will already be
                             scaled  by that.
                         </Description>
-                        <IfCondition condition=':= ?blockExists("minecraft:coal_ore")'> <OreBlock block='minecraft:coal_ore' weight='1.0' /> </IfCondition>
+                        <OreBlock block='minecraft:coal_ore' weight='1.0' />
                         <Replaces block='minecraft:dirt' weight='1.0' />
                         <Replaces block='minecraft:sandstone' weight='1.0' />
                     </Veins>
@@ -726,7 +726,7 @@
                         A master preset for standardgen ore
                         distributions.
                     </Description>
-                    <IfCondition condition=':= ?blockExists("minecraft:coal_ore")'> <OreBlock block='minecraft:coal_ore' weight='1.0' /> </IfCondition>
+                    <OreBlock block='minecraft:coal_ore' weight='1.0' />
                     <ReplacesOre block='stone' weight='1.0' />
                     <Biome name='.*'  />
                     <Setting name='Size' avg=':= 8.000 * vnlaCoalSize ' range=':= 8.000 * vnlaCoalSize ' type='normal' />
@@ -751,7 +751,7 @@
                         Small, fairly rare motherlodes with 2-4
                         horizontal veins each.
                     </Description>
-                    <IfCondition condition=':= ?blockExists("minecraft:iron_ore")'> <OreBlock block='minecraft:iron_ore' weight='1.0' /> </IfCondition>
+                    <OreBlock block='minecraft:iron_ore' weight='1.0' />
                     <ReplacesOre block='stone' weight='1.0' />
                     <Biome name='.*'  />
                     <Setting name='MotherlodeFrequency' avg=':= 2.238 * _default_ * vnlaIronFreq ' range=':= 2.238 * _default_ * vnlaIronFreq ' type='normal' scaleTo='base' />
@@ -791,7 +791,7 @@
                         semi-permanent  mining base and spend some
                         time actually  mining the ore.
                     </Description>
-                    <IfCondition condition=':= ?blockExists("minecraft:iron_ore")'> <OreBlock block='minecraft:iron_ore' weight='1.0' /> </IfCondition>
+                    <OreBlock block='minecraft:iron_ore' weight='1.0' />
                     <ReplacesOre block='stone' weight='1.0' />
                     <Biome name='.*'  />
                     <Setting name='CloudRadius' avg=':= 1.599 * _default_ * vnlaIronSize ' range=':= 1.599 * _default_ * vnlaIronSize ' type='normal' />
@@ -822,7 +822,7 @@
                             parent  distribution will already be
                             scaled  by that.
                         </Description>
-                        <IfCondition condition=':= ?blockExists("minecraft:iron_ore")'> <OreBlock block='minecraft:iron_ore' weight='1.0' /> </IfCondition>
+                        <OreBlock block='minecraft:iron_ore' weight='1.0' />
                         <Replaces block='minecraft:dirt' weight='1.0' />
                         <Replaces block='minecraft:sandstone' weight='1.0' />
                     </Veins>
@@ -840,7 +840,7 @@
                         A master preset for standardgen ore
                         distributions.
                     </Description>
-                    <IfCondition condition=':= ?blockExists("minecraft:iron_ore")'> <OreBlock block='minecraft:iron_ore' weight='1.0' /> </IfCondition>
+                    <OreBlock block='minecraft:iron_ore' weight='1.0' />
                     <ReplacesOre block='stone' weight='1.0' />
                     <Biome name='.*'  />
                     <Setting name='Size' avg=':= 4.000 * vnlaIronSize ' range=':= 4.000 * vnlaIronSize ' type='normal' />
@@ -865,7 +865,7 @@
                         Small, fairly rare motherlodes with 2-4
                         horizontal veins each.
                     </Description>
-                    <IfCondition condition=':= ?blockExists("minecraft:gold_ore")'> <OreBlock block='minecraft:gold_ore' weight='1.0' /> </IfCondition>
+                    <OreBlock block='minecraft:gold_ore' weight='1.0' />
                     <ReplacesOre block='stone' weight='1.0' />
                     <Biome name='.*'  />
                     <Setting name='MotherlodeFrequency' avg=':= 0.708 * _default_ * vnlaGoldFreq ' range=':= 0.708 * _default_ * vnlaGoldFreq ' type='normal' scaleTo='base' />
@@ -905,7 +905,7 @@
                         semi-permanent  mining base and spend some
                         time actually  mining the ore.
                     </Description>
-                    <IfCondition condition=':= ?blockExists("minecraft:gold_ore")'> <OreBlock block='minecraft:gold_ore' weight='1.0' /> </IfCondition>
+                    <OreBlock block='minecraft:gold_ore' weight='1.0' />
                     <ReplacesOre block='stone' weight='1.0' />
                     <Biome name='.*'  />
                     <Setting name='CloudRadius' avg=':= 0.899 * _default_ * vnlaGoldSize ' range=':= 0.899 * _default_ * vnlaGoldSize ' type='normal' />
@@ -936,7 +936,7 @@
                             parent  distribution will already be
                             scaled  by that.
                         </Description>
-                        <IfCondition condition=':= ?blockExists("minecraft:gold_ore")'> <OreBlock block='minecraft:gold_ore' weight='1.0' /> </IfCondition>
+                        <OreBlock block='minecraft:gold_ore' weight='1.0' />
                         <Replaces block='minecraft:dirt' weight='1.0' />
                         <Replaces block='minecraft:sandstone' weight='1.0' />
                     </Veins>
@@ -954,7 +954,7 @@
                         A master preset for standardgen ore
                         distributions.
                     </Description>
-                    <IfCondition condition=':= ?blockExists("minecraft:gold_ore")'> <OreBlock block='minecraft:gold_ore' weight='1.0' /> </IfCondition>
+                    <OreBlock block='minecraft:gold_ore' weight='1.0' />
                     <ReplacesOre block='stone' weight='1.0' />
                     <Biome name='.*'  />
                     <Setting name='Size' avg=':= 4.000 * vnlaGoldSize ' range=':= 4.000 * vnlaGoldSize ' type='normal' />
@@ -979,7 +979,7 @@
                         Single vertical veins that occur with no
                         motherlodes.
                     </Description>
-                    <IfCondition condition=':= ?blockExists("minecraft:redstone_ore")'> <OreBlock block='minecraft:redstone_ore' weight='1.0' /> </IfCondition>
+                    <OreBlock block='minecraft:redstone_ore' weight='1.0' />
                     <ReplacesOre block='stone' weight='1.0' />
                     <Biome name='.*'  />
                     <Setting name='MotherlodeFrequency' avg=':= 2.406 * _default_ * vnlaRedstoneFreq ' range=':= 2.406 * _default_ * vnlaRedstoneFreq ' type='normal' scaleTo='base' />
@@ -1019,7 +1019,7 @@
                         semi-permanent  mining base and spend some
                         time actually  mining the ore.
                     </Description>
-                    <IfCondition condition=':= ?blockExists("minecraft:redstone_ore")'> <OreBlock block='minecraft:redstone_ore' weight='1.0' /> </IfCondition>
+                    <OreBlock block='minecraft:redstone_ore' weight='1.0' />
                     <ReplacesOre block='stone' weight='1.0' />
                     <Biome name='.*'  />
                     <Setting name='CloudRadius' avg=':= 1.230 * _default_ * vnlaRedstoneSize ' range=':= 1.230 * _default_ * vnlaRedstoneSize ' type='normal' />
@@ -1050,7 +1050,7 @@
                             parent  distribution will already be
                             scaled  by that.
                         </Description>
-                        <IfCondition condition=':= ?blockExists("minecraft:redstone_ore")'> <OreBlock block='minecraft:redstone_ore' weight='1.0' /> </IfCondition>
+                        <OreBlock block='minecraft:redstone_ore' weight='1.0' />
                         <Replaces block='minecraft:dirt' weight='1.0' />
                         <Replaces block='minecraft:sandstone' weight='1.0' />
                     </Veins>
@@ -1068,7 +1068,7 @@
                         A master preset for standardgen ore
                         distributions.
                     </Description>
-                    <IfCondition condition=':= ?blockExists("minecraft:redstone_ore")'> <OreBlock block='minecraft:redstone_ore' weight='1.0' /> </IfCondition>
+                    <OreBlock block='minecraft:redstone_ore' weight='1.0' />
                     <ReplacesOre block='stone' weight='1.0' />
                     <Biome name='.*'  />
                     <Setting name='Size' avg=':= 3.500 * vnlaRedstoneSize ' range=':= 3.500 * vnlaRedstoneSize ' type='normal' />
@@ -1093,7 +1093,7 @@
                         Short sparsely filled veins sloping up  from
                         near the bottom of the map.
                     </Description>
-                    <IfCondition condition=':= ?blockExists("minecraft:diamond_ore")'> <OreBlock block='minecraft:diamond_ore' weight='1.0' /> </IfCondition>
+                    <OreBlock block='minecraft:diamond_ore' weight='1.0' />
                     <ReplacesOre block='stone' weight='1.0' />
                     <Biome name='.*'  />
                     <Setting name='MotherlodeFrequency' avg=':= 0.714 * _default_ * vnlaDiamondFreq ' range=':= 0.714 * _default_ * vnlaDiamondFreq ' type='normal' scaleTo='base' />
@@ -1115,7 +1115,7 @@
 
                 <!-- Configuring contained material. -->
                 <Veins name='vnlaDiamondVeinsPipe'  inherits='vnlaDiamondVeins' seed='0x197B' drawWireframe='true' wireframeColor='0x608BF4E3' drawBoundBox='false' boundBoxColor='0x608BF4E3'>
-                    <IfCondition condition=':= ?blockExists("minecraft:lava")'> <OreBlock block='minecraft:lava' weight='1.0' /> </IfCondition>
+                    <OreBlock block='minecraft:lava' weight='1.0' />
                     <ReplacesOre block='stone' weight='1.0' />
                     <Replaces block='minecraft:diamond_ore' weight='1.0' />
                     <Setting name='MotherlodeSize' avg=':= 0 * _default_ * vnlaDiamondSize  * 0.5 ' range=':= 0 * _default_ * vnlaDiamondSize  * 0.5 ' type='normal' />
@@ -1143,7 +1143,7 @@
                         semi-permanent  mining base and spend some
                         time actually  mining the ore.
                     </Description>
-                    <IfCondition condition=':= ?blockExists("minecraft:diamond_ore")'> <OreBlock block='minecraft:diamond_ore' weight='1.0' /> </IfCondition>
+                    <OreBlock block='minecraft:diamond_ore' weight='1.0' />
                     <ReplacesOre block='stone' weight='1.0' />
                     <Biome name='.*'  />
                     <Setting name='CloudRadius' avg=':= 0.731 * _default_ * vnlaDiamondSize ' range=':= 0.731 * _default_ * vnlaDiamondSize ' type='normal' />
@@ -1174,7 +1174,7 @@
                             parent  distribution will already be
                             scaled  by that.
                         </Description>
-                        <IfCondition condition=':= ?blockExists("minecraft:diamond_ore")'> <OreBlock block='minecraft:diamond_ore' weight='1.0' /> </IfCondition>
+                        <OreBlock block='minecraft:diamond_ore' weight='1.0' />
                         <Replaces block='minecraft:dirt' weight='1.0' />
                         <Replaces block='minecraft:sandstone' weight='1.0' />
                     </Veins>
@@ -1192,7 +1192,7 @@
                         A master preset for standardgen ore
                         distributions.
                     </Description>
-                    <IfCondition condition=':= ?blockExists("minecraft:diamond_ore")'> <OreBlock block='minecraft:diamond_ore' weight='1.0' /> </IfCondition>
+                    <OreBlock block='minecraft:diamond_ore' weight='1.0' />
                     <ReplacesOre block='stone' weight='1.0' />
                     <Biome name='.*'  />
                     <Setting name='Size' avg=':= 3.500 * vnlaDiamondSize ' range=':= 3.500 * vnlaDiamondSize ' type='normal' />
@@ -1217,7 +1217,7 @@
                         Single vertical veins that occur with no
                         motherlodes.
                     </Description>
-                    <IfCondition condition=':= ?blockExists("minecraft:lapis_ore")'> <OreBlock block='minecraft:lapis_ore' weight='1.0' /> </IfCondition>
+                    <OreBlock block='minecraft:lapis_ore' weight='1.0' />
                     <ReplacesOre block='stone' weight='1.0' />
                     <Biome name='.*'  />
                     <Setting name='MotherlodeFrequency' avg=':= 0.787 * _default_ * vnlaLapisLazuliFreq ' range=':= 0.787 * _default_ * vnlaLapisLazuliFreq ' type='normal' scaleTo='base' />
@@ -1257,7 +1257,7 @@
                         semi-permanent  mining base and spend some
                         time actually  mining the ore.
                     </Description>
-                    <IfCondition condition=':= ?blockExists("minecraft:lapis_ore")'> <OreBlock block='minecraft:lapis_ore' weight='1.0' /> </IfCondition>
+                    <OreBlock block='minecraft:lapis_ore' weight='1.0' />
                     <ReplacesOre block='stone' weight='1.0' />
                     <Biome name='.*'  />
                     <Setting name='CloudRadius' avg=':= 0.703 * _default_ * vnlaLapisLazuliSize ' range=':= 0.703 * _default_ * vnlaLapisLazuliSize ' type='normal' />
@@ -1288,7 +1288,7 @@
                             parent  distribution will already be
                             scaled  by that.
                         </Description>
-                        <IfCondition condition=':= ?blockExists("minecraft:lapis_ore")'> <OreBlock block='minecraft:lapis_ore' weight='1.0' /> </IfCondition>
+                        <OreBlock block='minecraft:lapis_ore' weight='1.0' />
                         <Replaces block='minecraft:dirt' weight='1.0' />
                         <Replaces block='minecraft:sandstone' weight='1.0' />
                     </Veins>
@@ -1306,7 +1306,7 @@
                         A master preset for standardgen ore
                         distributions.
                     </Description>
-                    <IfCondition condition=':= ?blockExists("minecraft:lapis_ore")'> <OreBlock block='minecraft:lapis_ore' weight='1.0' /> </IfCondition>
+                    <OreBlock block='minecraft:lapis_ore' weight='1.0' />
                     <ReplacesOre block='stone' weight='1.0' />
                     <Biome name='.*'  />
                     <Setting name='Size' avg=':= 3.000 * vnlaLapisLazuliSize ' range=':= 3.000 * vnlaLapisLazuliSize ' type='normal' />
@@ -1331,7 +1331,7 @@
                         Short sparsely filled veins sloping up  from
                         near the bottom of the map.
                     </Description>
-                    <IfCondition condition=':= ?blockExists("minecraft:emerald_ore")'> <OreBlock block='minecraft:emerald_ore' weight='1.0' /> </IfCondition>
+                    <OreBlock block='minecraft:emerald_ore' weight='1.0' />
                     <ReplacesOre block='stone' weight='1.0' />
                     <BiomeType name='Mountain'  />
                     <Setting name='MotherlodeFrequency' avg=':= 1.145 * _default_ * vnlaEmeraldFreq ' range=':= 1.145 * _default_ * vnlaEmeraldFreq ' type='normal' scaleTo='base' />
@@ -1353,7 +1353,7 @@
 
                 <!-- Configuring contained material. -->
                 <Veins name='vnlaEmeraldVeinsPipe'  inherits='vnlaEmeraldVeins' seed='0x54B3' drawWireframe='true' wireframeColor='0x606CE391' drawBoundBox='false' boundBoxColor='0x606CE391'>
-                    <IfCondition condition=':= ?blockExists("minecraft:monster_egg")'> <OreBlock block='minecraft:monster_egg' weight='1.0' /> </IfCondition>
+                    <OreBlock block='minecraft:monster_egg' weight='1.0' />
                     <ReplacesOre block='stone' weight='1.0' />
                     <Replaces block='minecraft:emerald_ore' weight='1.0' />
                     <Setting name='MotherlodeSize' avg=':= 0 * _default_ * vnlaEmeraldSize  * 0.5 ' range=':= 0 * _default_ * vnlaEmeraldSize  * 0.5 ' type='normal' />
@@ -1381,7 +1381,7 @@
                         semi-permanent  mining base and spend some
                         time actually  mining the ore.
                     </Description>
-                    <IfCondition condition=':= ?blockExists("minecraft:emerald_ore")'> <OreBlock block='minecraft:emerald_ore' weight='1.0' /> </IfCondition>
+                    <OreBlock block='minecraft:emerald_ore' weight='1.0' />
                     <ReplacesOre block='stone' weight='1.0' />
                     <BiomeType name='Mountain'  />
                     <Setting name='CloudRadius' avg=':= 0.926 * _default_ * vnlaEmeraldSize ' range=':= 0.926 * _default_ * vnlaEmeraldSize ' type='normal' />
@@ -1412,7 +1412,7 @@
                             parent  distribution will already be
                             scaled  by that.
                         </Description>
-                        <IfCondition condition=':= ?blockExists("minecraft:emerald_ore")'> <OreBlock block='minecraft:emerald_ore' weight='1.0' /> </IfCondition>
+                        <OreBlock block='minecraft:emerald_ore' weight='1.0' />
                         <Replaces block='minecraft:dirt' weight='1.0' />
                         <Replaces block='minecraft:sandstone' weight='1.0' />
                     </Veins>
@@ -1430,7 +1430,7 @@
                         A master preset for standardgen ore
                         distributions.
                     </Description>
-                    <IfCondition condition=':= ?blockExists("minecraft:emerald_ore")'> <OreBlock block='minecraft:emerald_ore' weight='1.0' /> </IfCondition>
+                    <OreBlock block='minecraft:emerald_ore' weight='1.0' />
                     <ReplacesOre block='stone' weight='1.0' />
                     <BiomeType name='Mountain'  />
                     <Setting name='Size' avg=':= 1.000 * vnlaEmeraldSize ' range=':= 1.000 * vnlaEmeraldSize ' type='normal' />
@@ -1492,7 +1492,7 @@
                         to get an idea of  their direction while
                         mining.
                     </Description>
-                    <IfCondition condition=':= ?blockExists("minecraft:quartz_ore")'> <OreBlock block='minecraft:quartz_ore' weight='1.0' /> </IfCondition>
+                    <OreBlock block='minecraft:quartz_ore' weight='1.0' />
                     <Replaces block='minecraft:netherrack' weight='1.0' />
                     <Biome name='.*'  />
                     <Setting name='MotherlodeFrequency' avg=':= 6.247 * _default_ * vnlaNetherQuartzFreq ' range=':= 6.247 * _default_ * vnlaNetherQuartzFreq ' type='normal' scaleTo='base' />
@@ -1532,7 +1532,7 @@
                         semi-permanent  mining base and spend some
                         time actually  mining the ore.
                     </Description>
-                    <IfCondition condition=':= ?blockExists("minecraft:quartz_ore")'> <OreBlock block='minecraft:quartz_ore' weight='1.0' /> </IfCondition>
+                    <OreBlock block='minecraft:quartz_ore' weight='1.0' />
                     <Replaces block='minecraft:netherrack' weight='1.0' />
                     <Biome name='.*'  />
                     <Setting name='CloudRadius' avg=':= 1.707 * _default_ * vnlaNetherQuartzSize ' range=':= 1.707 * _default_ * vnlaNetherQuartzSize ' type='normal' />
@@ -1563,7 +1563,7 @@
                             parent  distribution will already be
                             scaled  by that.
                         </Description>
-                        <IfCondition condition=':= ?blockExists("minecraft:quartz_ore")'> <OreBlock block='minecraft:quartz_ore' weight='1.0' /> </IfCondition>
+                        <OreBlock block='minecraft:quartz_ore' weight='1.0' />
                         <Replaces block='minecraft:dirt' weight='1.0' />
                         <Replaces block='minecraft:sandstone' weight='1.0' />
                     </Veins>
@@ -1581,7 +1581,7 @@
                         A master preset for standardgen ore
                         distributions.
                     </Description>
-                    <IfCondition condition=':= ?blockExists("minecraft:quartz_ore")'> <OreBlock block='minecraft:quartz_ore' weight='1.0' /> </IfCondition>
+                    <OreBlock block='minecraft:quartz_ore' weight='1.0' />
                     <Replaces block='minecraft:netherrack' weight='1.0' />
                     <Biome name='.*'  />
                     <Setting name='Size' avg=':= 8.000 * vnlaNetherQuartzSize ' range=':= 8.000 * vnlaNetherQuartzSize ' type='normal' />


### PR DESCRIPTION
* All ore and block (re)placement commands have had their block checks removed. 
* All distributions now check for block existence before adding distribution options other than "None"
* All block checks for distributions now use AND instead of OR; if one single block is missing, the distribution won't show anything but NONE.

NOTE: Railcraft's blocks continue to exist, even if they've been disabled in the config.  It's the weirdest thing, but that's something that will need to be handled on Railcraft's side.