### PR TITLE
Removed dirt and gravel oredicts from hint veins.

### DIFF
--- a/src/main/resources/config/modules/AppliedEnergistics.xml
+++ b/src/main/resources/config/modules/AppliedEnergistics.xml
@@ -212,10 +212,10 @@
                                 </Description>
                                 <OreBlock block='appliedenergistics2:tile.OreQuartz' weight='0.90' />
                                 <OreBlock block='appliedenergistics2:tile.OreQuartzCharged' weight='0.10' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>

--- a/src/main/resources/config/modules/ArsMagica2.xml
+++ b/src/main/resources/config/modules/ArsMagica2.xml
@@ -299,10 +299,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='arsmagica2:vinteumOre' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -428,10 +428,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='arsmagica2:vinteumOre:1' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -557,10 +557,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='arsmagica2:vinteumOre:2' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>

--- a/src/main/resources/config/modules/BiomesOPlenty.xml
+++ b/src/main/resources/config/modules/BiomesOPlenty.xml
@@ -537,10 +537,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='BiomesOPlenty:gemOre:2' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -669,10 +669,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='BiomesOPlenty:gemOre:4' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -801,10 +801,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='BiomesOPlenty:gemOre:6' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -937,10 +937,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='BiomesOPlenty:gemOre:8' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1071,10 +1071,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='BiomesOPlenty:gemOre:10' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1215,10 +1215,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='BiomesOPlenty:gemOre:12' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1359,10 +1359,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='BiomesOPlenty:gemOre:14' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1527,10 +1527,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='BiomesOPlenty:gemOre' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>

--- a/src/main/resources/config/modules/DenseOres.xml
+++ b/src/main/resources/config/modules/DenseOres.xml
@@ -544,10 +544,10 @@
                                 </Description>
                                 <OreBlock block='minecraft:coal_ore' weight='0.9' />
                                 <OreBlock block='denseores:block0:6' weight='0.1' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -670,10 +670,10 @@
                                 </Description>
                                 <OreBlock block='minecraft:iron_ore' weight='0.9' />
                                 <OreBlock block='denseores:block0' weight='0.1' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -796,10 +796,10 @@
                                 </Description>
                                 <OreBlock block='minecraft:gold_ore' weight='0.9' />
                                 <OreBlock block='denseores:block0:1' weight='0.1' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -922,10 +922,10 @@
                                 </Description>
                                 <OreBlock block='minecraft:redstone_ore' weight='0.9' />
                                 <OreBlock block='denseores:block0:5' weight='0.1' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1059,10 +1059,10 @@
                                 </Description>
                                 <OreBlock block='minecraft:diamond_ore' weight='0.9' />
                                 <OreBlock block='denseores:block0:3' weight='0.1' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1186,10 +1186,10 @@
                                 </Description>
                                 <OreBlock block='minecraft:lapis_ore' weight='0.9' />
                                 <OreBlock block='denseores:block0:2' weight='0.1' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1324,10 +1324,10 @@
                                 </Description>
                                 <OreBlock block='minecraft:emerald_ore' weight='0.9' />
                                 <OreBlock block='denseores:block0:4' weight='0.1' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1491,10 +1491,10 @@
                                 </Description>
                                 <OreBlock block='minecraft:quartz_ore' weight='0.9' />
                                 <OreBlock block='denseores:block0:7' weight='0.1' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>

--- a/src/main/resources/config/modules/ElectriCraft.xml
+++ b/src/main/resources/config/modules/ElectriCraft.xml
@@ -434,10 +434,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='ElectriCraft:electricraft_block_ore' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -556,10 +556,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='ElectriCraft:electricraft_block_ore:1' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -678,10 +678,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='ElectriCraft:electricraft_block_ore:2' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -800,10 +800,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='ElectriCraft:electricraft_block_ore:3' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -922,10 +922,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='ElectriCraft:electricraft_block_ore:4' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1044,10 +1044,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='ElectriCraft:electricraft_block_ore:5' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>

--- a/src/main/resources/config/modules/Factorization.xml
+++ b/src/main/resources/config/modules/Factorization.xml
@@ -245,10 +245,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='factorization:ResourceBlock' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -378,10 +378,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='factorization:DarkIronOre' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>

--- a/src/main/resources/config/modules/FlaxbeardsSteamcraft.xml
+++ b/src/main/resources/config/modules/FlaxbeardsSteamcraft.xml
@@ -245,10 +245,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='Steamcraft:steamcraftOre' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -367,10 +367,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='Steamcraft:steamcraftOre:1' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>

--- a/src/main/resources/config/modules/Forestry.xml
+++ b/src/main/resources/config/modules/Forestry.xml
@@ -299,10 +299,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='Forestry:resources' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -421,10 +421,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='Forestry:resources:1' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -543,10 +543,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='Forestry:resources:2' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>

--- a/src/main/resources/config/modules/FossilsandArchaeology.xml
+++ b/src/main/resources/config/modules/FossilsandArchaeology.xml
@@ -283,10 +283,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='fossil:fossil' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
 
@@ -316,10 +316,10 @@
                                     preferred biomes.
                                 </Description>
                                 <OreBlock block='fossil:fossil' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                         <!-- "Preferred" configuration complete. -->
@@ -449,10 +449,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='fossil:permafrost' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>

--- a/src/main/resources/config/modules/Galacticraft.xml
+++ b/src/main/resources/config/modules/Galacticraft.xml
@@ -340,10 +340,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='GalacticraftCore:tile.gcBlockCore:5' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -462,10 +462,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='GalacticraftCore:tile.gcBlockCore:6' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -584,10 +584,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='GalacticraftCore:tile.gcBlockCore:7' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -706,10 +706,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='GalacticraftCore:tile.gcBlockCore:8' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>

--- a/src/main/resources/config/modules/ImmersiveEngineering.xml
+++ b/src/main/resources/config/modules/ImmersiveEngineering.xml
@@ -386,10 +386,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='ImmersiveEngineering:ore:0' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -508,10 +508,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='ImmersiveEngineering:ore:1' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -630,10 +630,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='ImmersiveEngineering:ore:2' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -752,10 +752,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='ImmersiveEngineering:ore:3' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -874,10 +874,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='ImmersiveEngineering:ore:4' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>

--- a/src/main/resources/config/modules/IndustrialCraft2.xml
+++ b/src/main/resources/config/modules/IndustrialCraft2.xml
@@ -338,10 +338,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='IC2:blockOreCopper' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -460,10 +460,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='IC2:blockOreTin' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -589,10 +589,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='IC2:blockOreUran' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -711,10 +711,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='IC2:blockOreLead' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>

--- a/src/main/resources/config/modules/MagnetiCraft.xml
+++ b/src/main/resources/config/modules/MagnetiCraft.xml
@@ -527,10 +527,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='Magneticraft:copper_ore' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -656,10 +656,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='Magneticraft:tungsten_ore' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -788,10 +788,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='Magneticraft:sulfur_ore' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -917,10 +917,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='Magneticraft:uranium_ore' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1041,10 +1041,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='Magneticraft:thorium_ore' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1170,10 +1170,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='Magneticraft:salt_ore' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1292,10 +1292,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='Magneticraft:zinc_ore' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>

--- a/src/main/resources/config/modules/Mariculture.xml
+++ b/src/main/resources/config/modules/Mariculture.xml
@@ -244,10 +244,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='Mariculture:rocks:2' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -366,10 +366,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='Mariculture:rocks:1' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>

--- a/src/main/resources/config/modules/Mekanism.xml
+++ b/src/main/resources/config/modules/Mekanism.xml
@@ -291,10 +291,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='Mekanism:OreBlock' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -413,10 +413,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='Mekanism:OreBlock:1' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -535,10 +535,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='Mekanism:OreBlock:2' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>

--- a/src/main/resources/config/modules/Metallurgy4.xml
+++ b/src/main/resources/config/modules/Metallurgy4.xml
@@ -1798,10 +1798,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='Metallurgy:utility.ore' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1927,10 +1927,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='Metallurgy:utility.ore:1' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -2057,10 +2057,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='Metallurgy:utility.ore:2' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -2186,10 +2186,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='Metallurgy:utility.ore:3' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -2315,10 +2315,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='Metallurgy:utility.ore:4' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -2444,10 +2444,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='Metallurgy:utility.ore:5' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -2566,10 +2566,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='Metallurgy:base.ore' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -2688,10 +2688,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='Metallurgy:base.ore:1' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -2810,10 +2810,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='Metallurgy:base.ore:2' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -2932,10 +2932,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='Metallurgy:precious.ore' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -3054,10 +3054,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='Metallurgy:precious.ore:1' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -3176,10 +3176,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='Metallurgy:precious.ore:2' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -3298,10 +3298,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='Metallurgy:fantasy.ore' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -3421,10 +3421,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='Metallurgy:fantasy.ore:1' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -3543,10 +3543,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='Metallurgy:fantasy.ore:2' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -3666,10 +3666,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='Metallurgy:fantasy.ore:4' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -3790,10 +3790,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='Metallurgy:fantasy.ore:5' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -3913,10 +3913,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='Metallurgy:fantasy.ore:6' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -4035,10 +4035,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='Metallurgy:fantasy.ore:7' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -4157,10 +4157,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='Metallurgy:fantasy.ore:8' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -4279,10 +4279,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='Metallurgy:fantasy.ore:11' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -4402,10 +4402,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='Metallurgy:fantasy.ore:13' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -4525,10 +4525,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='Metallurgy:fantasy.ore:14' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -4688,10 +4688,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -4810,10 +4810,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='Metallurgy:nether.ore:1' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -4933,10 +4933,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='Metallurgy:nether.ore:2' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -5055,10 +5055,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='Metallurgy:nether.ore:3' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -5177,10 +5177,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='Metallurgy:nether.ore:4' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -5299,10 +5299,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='Metallurgy:nether.ore:5' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -5421,10 +5421,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='Metallurgy:nether.ore:6' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -5543,10 +5543,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='Metallurgy:nether.ore:7' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -5666,10 +5666,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='Metallurgy:nether.ore:8' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -5788,10 +5788,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='Metallurgy:nether.ore:9' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -5944,10 +5944,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='Metallurgy:ender.ore' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -6066,10 +6066,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='Metallurgy:ender.ore:1' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>

--- a/src/main/resources/config/modules/MineChem.xml
+++ b/src/main/resources/config/modules/MineChem.xml
@@ -198,10 +198,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='minechem:tile.oreUranium' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>

--- a/src/main/resources/config/modules/MinecraftComesAlive.xml
+++ b/src/main/resources/config/modules/MinecraftComesAlive.xml
@@ -200,10 +200,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='MCA:tile.roseGoldOre' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>

--- a/src/main/resources/config/modules/NetherOres.xml
+++ b/src/main/resources/config/modules/NetherOres.xml
@@ -1667,10 +1667,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='NetherOres:tile.netherores.ore.0' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1799,10 +1799,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='NetherOres:tile.netherores.ore.0:1' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1921,10 +1921,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='NetherOres:tile.netherores.ore.0:2' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -2043,10 +2043,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='NetherOres:tile.netherores.ore.0:3' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -2166,10 +2166,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='NetherOres:tile.netherores.ore.0:4' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -2289,10 +2289,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='NetherOres:tile.netherores.ore.0:5' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -2411,10 +2411,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='NetherOres:tile.netherores.ore.0:6' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -2533,10 +2533,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='NetherOres:tile.netherores.ore.0:7' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -2665,10 +2665,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='NetherOres:tile.netherores.ore.0:8' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -2787,10 +2787,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='NetherOres:tile.netherores.ore.0:9' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -2909,10 +2909,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='NetherOres:tile.netherores.ore.0:10' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -3038,10 +3038,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='NetherOres:tile.netherores.ore.0:11' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -3160,10 +3160,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='NetherOres:tile.netherores.ore.0:12' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -3292,10 +3292,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='NetherOres:tile.netherores.ore.0:13' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -3424,10 +3424,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='NetherOres:tile.netherores.ore.0:14' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -3556,10 +3556,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='NetherOres:tile.netherores.ore.0:15' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -3678,10 +3678,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='NetherOres:tile.netherores.ore.1' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -3800,10 +3800,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='NetherOres:tile.netherores.ore.1:1' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -3922,10 +3922,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='NetherOres:tile.netherores.ore.1:2' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -4046,10 +4046,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='NetherOres:tile.netherores.ore.1:3' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -4168,10 +4168,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='NetherOres:tile.netherores.ore.1:4' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -4300,10 +4300,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='NetherOres:tile.netherores.ore.1:5' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -4422,10 +4422,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='NetherOres:tile.netherores.ore.1:6' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -4544,10 +4544,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='NetherOres:tile.netherores.ore.1:7' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -4666,10 +4666,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='NetherOres:tile.netherores.ore.1:8' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -4789,10 +4789,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='NetherOres:tile.netherores.ore.1:9' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -4911,10 +4911,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='NetherOres:tile.netherores.ore.1:10' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -5040,10 +5040,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='NetherOres:tile.netherores.ore.1:11' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -5162,10 +5162,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='NetherOres:tile.netherores.ore.1:12' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -5292,10 +5292,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='NetherOres:tile.netherores.ore.1:13' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -5421,10 +5421,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='NetherOres:tile.netherores.ore.1:14' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -5550,10 +5550,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='NetherOres:tile.netherores.ore.1:15' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>

--- a/src/main/resources/config/modules/Netherrocks.xml
+++ b/src/main/resources/config/modules/Netherrocks.xml
@@ -431,10 +431,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='netherrocks:fyrite_ore' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -553,10 +553,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='netherrocks:malachite_ore' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -675,10 +675,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='netherrocks:ashstone_ore' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -822,10 +822,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='netherrocks:dragonstone_ore' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -945,10 +945,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='netherrocks:argonite_ore' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>

--- a/src/main/resources/config/modules/Nuclearcraft.xml
+++ b/src/main/resources/config/modules/Nuclearcraft.xml
@@ -580,10 +580,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='NuclearCraft:blockOre:4' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -702,10 +702,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='NuclearCraft:blockOre' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -824,10 +824,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='NuclearCraft:blockOre:1' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -946,10 +946,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='NuclearCraft:blockOre:2' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1068,10 +1068,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='NuclearCraft:blockOre:3' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1197,10 +1197,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='NuclearCraft:blockOre:7' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1326,10 +1326,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='NuclearCraft:blockOre:8' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1455,10 +1455,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='NuclearCraft:blockOre:5' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1616,10 +1616,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='NuclearCraft:blockOre:6' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>

--- a/src/main/resources/config/modules/PamsHarvestCraft.xml
+++ b/src/main/resources/config/modules/PamsHarvestCraft.xml
@@ -206,10 +206,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='harvestcraft:salt' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>

--- a/src/main/resources/config/modules/ProjectRed.xml
+++ b/src/main/resources/config/modules/ProjectRed.xml
@@ -538,10 +538,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='ProjRed|Exploration:projectred.exploration.ore' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -670,10 +670,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:1' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -802,10 +802,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:2' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -924,10 +924,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:3' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1046,10 +1046,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:4' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1168,10 +1168,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:5' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1290,10 +1290,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:6' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>

--- a/src/main/resources/config/modules/RailCraft.xml
+++ b/src/main/resources/config/modules/RailCraft.xml
@@ -667,10 +667,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='Railcraft:ore:7' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -796,10 +796,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='Railcraft:ore:8' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -925,10 +925,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='Railcraft:ore:9' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1055,10 +1055,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='Railcraft:ore:10' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1184,10 +1184,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='Railcraft:ore:11' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1316,10 +1316,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='Railcraft:ore' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1447,10 +1447,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='Railcraft:ore:1' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1604,10 +1604,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='Railcraft:ore:5' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>

--- a/src/main/resources/config/modules/ReactorCraft.xml
+++ b/src/main/resources/config/modules/ReactorCraft.xml
@@ -962,10 +962,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='ReactorCraft:reactorcraft_block_ore:1' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1087,10 +1087,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='ReactorCraft:reactorcraft_block_ore:2' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1209,10 +1209,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='ReactorCraft:reactorcraft_block_ore:3' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1331,10 +1331,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='ReactorCraft:reactorcraft_block_ore:4' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1460,10 +1460,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='ReactorCraft:reactorcraft_block_ore:7' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1589,10 +1589,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='ReactorCraft:reactorcraft_block_ore:8' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1713,10 +1713,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1838,10 +1838,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:1' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1963,10 +1963,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:2' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -2089,10 +2089,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:3' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -2214,10 +2214,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:4' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -2337,10 +2337,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:5' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -2462,10 +2462,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:6' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -2587,10 +2587,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:7' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -2753,10 +2753,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='ReactorCraft:reactorcraft_block_ore:6' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -2883,10 +2883,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='ReactorCraft:reactorcraft_block_ore:9' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -3046,10 +3046,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='ReactorCraft:reactorcraft_block_ore:5' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>

--- a/src/main/resources/config/modules/SimpleOres.xml
+++ b/src/main/resources/config/modules/SimpleOres.xml
@@ -385,10 +385,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='simpleores:copper_ore' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -507,10 +507,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='simpleores:tin_ore' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -629,10 +629,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='simpleores:mythril_ore' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -751,10 +751,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='simpleores:adamantium_ore' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -916,10 +916,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='simpleores:onyx_ore' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>

--- a/src/main/resources/config/modules/Thaumcraft4.xml
+++ b/src/main/resources/config/modules/Thaumcraft4.xml
@@ -486,10 +486,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='Thaumcraft:blockCustomOre:7' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -617,10 +617,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='Thaumcraft:blockCustomOre' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>

--- a/src/main/resources/config/modules/ThermalFoundation.xml
+++ b/src/main/resources/config/modules/ThermalFoundation.xml
@@ -435,10 +435,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='ThermalFoundation:Ore' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -557,10 +557,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='ThermalFoundation:Ore:1' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -679,10 +679,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='ThermalFoundation:Ore:2' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -801,10 +801,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='ThermalFoundation:Ore:3' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -923,10 +923,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='ThermalFoundation:Ore:4' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1045,10 +1045,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='ThermalFoundation:Ore:5' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>

--- a/src/main/resources/config/modules/TinkersConstruct.xml
+++ b/src/main/resources/config/modules/TinkersConstruct.xml
@@ -682,10 +682,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='TConstruct:SearedBrick:3' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -804,10 +804,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='TConstruct:SearedBrick:4' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -926,10 +926,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='TConstruct:SearedBrick:5' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1048,10 +1048,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='TConstruct:GravelOre' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1171,10 +1171,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='TConstruct:GravelOre:1' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1296,10 +1296,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='TConstruct:GravelOre:2' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1419,10 +1419,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='TConstruct:GravelOre:3' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1544,10 +1544,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='TConstruct:GravelOre:4' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1717,10 +1717,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='TConstruct:SearedBrick:1' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1841,10 +1841,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='TConstruct:SearedBrick:2' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>
@@ -1967,10 +1967,10 @@
                                     already be scaled by that.
                                 </Description>
                                 <OreBlock block='TConstruct:GravelOre:5' weight='1.0' />
-                                <ReplacesOre block='dirt' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
                                 <Replaces block='minecraft:sandstone' weight='1.0' />
                                 <ReplacesOre block='stone' weight='1.0' />
-                                <ReplacesOre block='gravel' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
                             </Veins>
                         </Cloud>
                     </IfCondition>

--- a/src/main/resources/config/modules/VanillaMinecraft.xml
+++ b/src/main/resources/config/modules/VanillaMinecraft.xml
@@ -639,10 +639,10 @@
                             scaled  by that.
                         </Description>
                         <OreBlock block='minecraft:coal_ore' weight='1.0' />
-                        <ReplacesOre block='dirt' weight='1.0' />
+                        <Replaces block='minecraft:dirt' weight='1.0' />
                         <Replaces block='minecraft:sandstone' weight='1.0' />
                         <ReplacesOre block='stone' weight='1.0' />
-                        <ReplacesOre block='gravel' weight='1.0' />
+                        <Replaces block='minecraft:gravel' weight='1.0' />
                     </Veins>
                 </Cloud>
             </IfCondition>
@@ -756,10 +756,10 @@
                             scaled  by that.
                         </Description>
                         <OreBlock block='minecraft:iron_ore' weight='1.0' />
-                        <ReplacesOre block='dirt' weight='1.0' />
+                        <Replaces block='minecraft:dirt' weight='1.0' />
                         <Replaces block='minecraft:sandstone' weight='1.0' />
                         <ReplacesOre block='stone' weight='1.0' />
-                        <ReplacesOre block='gravel' weight='1.0' />
+                        <Replaces block='minecraft:gravel' weight='1.0' />
                     </Veins>
                 </Cloud>
             </IfCondition>
@@ -873,10 +873,10 @@
                             scaled  by that.
                         </Description>
                         <OreBlock block='minecraft:gold_ore' weight='1.0' />
-                        <ReplacesOre block='dirt' weight='1.0' />
+                        <Replaces block='minecraft:dirt' weight='1.0' />
                         <Replaces block='minecraft:sandstone' weight='1.0' />
                         <ReplacesOre block='stone' weight='1.0' />
-                        <ReplacesOre block='gravel' weight='1.0' />
+                        <Replaces block='minecraft:gravel' weight='1.0' />
                     </Veins>
                 </Cloud>
             </IfCondition>
@@ -990,10 +990,10 @@
                             scaled  by that.
                         </Description>
                         <OreBlock block='minecraft:redstone_ore' weight='1.0' />
-                        <ReplacesOre block='dirt' weight='1.0' />
+                        <Replaces block='minecraft:dirt' weight='1.0' />
                         <Replaces block='minecraft:sandstone' weight='1.0' />
                         <ReplacesOre block='stone' weight='1.0' />
-                        <ReplacesOre block='gravel' weight='1.0' />
+                        <Replaces block='minecraft:gravel' weight='1.0' />
                     </Veins>
                 </Cloud>
             </IfCondition>
@@ -1117,10 +1117,10 @@
                             scaled  by that.
                         </Description>
                         <OreBlock block='minecraft:diamond_ore' weight='1.0' />
-                        <ReplacesOre block='dirt' weight='1.0' />
+                        <Replaces block='minecraft:dirt' weight='1.0' />
                         <Replaces block='minecraft:sandstone' weight='1.0' />
                         <ReplacesOre block='stone' weight='1.0' />
-                        <ReplacesOre block='gravel' weight='1.0' />
+                        <Replaces block='minecraft:gravel' weight='1.0' />
                     </Veins>
                 </Cloud>
             </IfCondition>
@@ -1234,10 +1234,10 @@
                             scaled  by that.
                         </Description>
                         <OreBlock block='minecraft:lapis_ore' weight='1.0' />
-                        <ReplacesOre block='dirt' weight='1.0' />
+                        <Replaces block='minecraft:dirt' weight='1.0' />
                         <Replaces block='minecraft:sandstone' weight='1.0' />
                         <ReplacesOre block='stone' weight='1.0' />
-                        <ReplacesOre block='gravel' weight='1.0' />
+                        <Replaces block='minecraft:gravel' weight='1.0' />
                     </Veins>
                 </Cloud>
             </IfCondition>
@@ -1361,10 +1361,10 @@
                             scaled  by that.
                         </Description>
                         <OreBlock block='minecraft:emerald_ore' weight='1.0' />
-                        <ReplacesOre block='dirt' weight='1.0' />
+                        <Replaces block='minecraft:dirt' weight='1.0' />
                         <Replaces block='minecraft:sandstone' weight='1.0' />
                         <ReplacesOre block='stone' weight='1.0' />
-                        <ReplacesOre block='gravel' weight='1.0' />
+                        <Replaces block='minecraft:gravel' weight='1.0' />
                     </Veins>
                 </Cloud>
             </IfCondition>
@@ -1515,10 +1515,10 @@
                             scaled  by that.
                         </Description>
                         <OreBlock block='minecraft:quartz_ore' weight='1.0' />
-                        <ReplacesOre block='dirt' weight='1.0' />
+                        <Replaces block='minecraft:dirt' weight='1.0' />
                         <Replaces block='minecraft:sandstone' weight='1.0' />
                         <ReplacesOre block='stone' weight='1.0' />
-                        <ReplacesOre block='gravel' weight='1.0' />
+                        <Replaces block='minecraft:gravel' weight='1.0' />
                     </Veins>
                 </Cloud>
             </IfCondition>


### PR DESCRIPTION
Now, dirt and gravel are no longer using the oredicts; they are using the standard block names again.