### PR TITLE
Clamped supplemental caves to <y=60.

### DIFF
--- a/src/main/resources/config/modules/MinecraftSpecialRules.xml
+++ b/src/main/resources/config/modules/MinecraftSpecialRules.xml
@@ -174,7 +174,7 @@
         <!-- Starting CustomVeins Preset for Supplemental Caves. -->
         <ConfigSection>
             <IfCondition condition=':= spruSupplementalCavesDist = "CustomVeins"'>
-                <Veins name='spruSupplementalCavesVeins'   branchType='Bezier' drawWireframe='true' wireframeColor='0x60888888' drawBoundBox='false' boundBoxColor='0x60888888'>
+                <Veins name='spruSupplementalCavesVeins'  minHeight='0'  maxHeight='60'   branchType='Bezier' drawWireframe='true' wireframeColor='0x60888888' drawBoundBox='false' boundBoxColor='0x60888888'>
                     <!-- EDITED: Changed description to match the original -->
                     <Description>
                         Very large veins intended for generating caves, supplementary to the vanilla cave generator.


### PR DESCRIPTION
Supplemental caves now can never pass Y=60 in height; this should preserve villages, and keep the caverns underground.