### PR TITLE
Some oregen fixes

### DIFF
--- a/src/main/resources/config/modules/BiomesOPlenty.xml
+++ b/src/main/resources/config/modules/BiomesOPlenty.xml
@@ -1444,7 +1444,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.270 * _default_ * boplAmathystFreq ' range=':= 0.270 * _default_ * boplAmathystFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * boplAmathystSize ' range=':= 0 * _default_ * boplAmathystSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 19 ' range=':= 13 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1498,7 +1498,7 @@
                             <Setting name='CloudRadius' avg=':= 0.449 * _default_ * boplAmathystSize ' range=':= 0.449 * _default_ * boplAmathystSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.449 * _default_ * boplAmathystSize ' range=':= 0.449 * _default_ * boplAmathystSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.202 * _default_ * boplAmathystFreq ' range=':= 0.202 * _default_ * boplAmathystFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 19 ' range=':= 13 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1551,7 +1551,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 0.500 * boplAmathystSize ' range=':= 0.500 * boplAmathystSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 0.500 * boplAmathystFreq ' range=':= 0.500 * boplAmathystFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 19 ' range=':= 13 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>

--- a/src/main/resources/config/modules/DenseOres.xml
+++ b/src/main/resources/config/modules/DenseOres.xml
@@ -1415,7 +1415,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 6.247 * _default_ * dnsoNetherQuartzFreq ' range=':= 6.247 * _default_ * dnsoNetherQuartzFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * dnsoNetherQuartzSize ' range=':= 0 * _default_ * dnsoNetherQuartzSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 59 ' range=':= 49 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 59 ' range=':= 49 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1461,7 +1461,7 @@
                             <Setting name='CloudRadius' avg=':= 1.707 * _default_ * dnsoNetherQuartzSize ' range=':= 1.707 * _default_ * dnsoNetherQuartzSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.707 * _default_ * dnsoNetherQuartzSize ' range=':= 1.707 * _default_ * dnsoNetherQuartzSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 2.914 * _default_ * dnsoNetherQuartzFreq ' range=':= 2.914 * _default_ * dnsoNetherQuartzFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 59 ' range=':= 49 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 59 ' range=':= 49 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1517,7 +1517,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 8.000 * dnsoNetherQuartzSize ' range=':= 8.000 * dnsoNetherQuartzSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 6.500 * dnsoNetherQuartzFreq ' range=':= 6.500 * dnsoNetherQuartzFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 59 ' range=':= 49 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 59 ' range=':= 49 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>

--- a/src/main/resources/config/modules/MagnetiCraft.xml
+++ b/src/main/resources/config/modules/MagnetiCraft.xml
@@ -966,8 +966,8 @@
                             <OreBlock block='Magneticraft:thorium_ore' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.303 * _default_ * mgntThoriumFreq ' range=':= 0.303 * _default_ * mgntThoriumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.301 * _default_ * mgntThoriumSize ' range=':= 1.301 * _default_ * mgntThoriumSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 1.212 * _default_ * mgntThoriumFreq ' range=':= 1.212 * _default_ * mgntThoriumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 1.033 * _default_ * mgntThoriumSize ' range=':= 1.033 * _default_ * mgntThoriumSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 10 ' range=':= 10 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />

--- a/src/main/resources/config/modules/Mariculture.xml
+++ b/src/main/resources/config/modules/Mariculture.xml
@@ -171,7 +171,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.002 * _default_ * mrclBauxiteFreq ' range=':= 2.002 * _default_ * mrclBauxiteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.123 * _default_ * mrclBauxiteSize ' range=':= 1.123 * _default_ * mrclBauxiteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 96 ' range=':= 32 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 96 ' range=':= 32 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -215,7 +215,7 @@
                             <Setting name='CloudRadius' avg=':= 1.512 * _default_ * mrclBauxiteSize ' range=':= 1.512 * _default_ * mrclBauxiteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.512 * _default_ * mrclBauxiteSize ' range=':= 1.512 * _default_ * mrclBauxiteSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 2.286 * _default_ * mrclBauxiteFreq ' range=':= 2.286 * _default_ * mrclBauxiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 96 ' range=':= 32 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 96 ' range=':= 32 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -268,7 +268,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * mrclBauxiteSize ' range=':= 4.000 * mrclBauxiteSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 8.000 * mrclBauxiteFreq ' range=':= 8.000 * mrclBauxiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 96 ' range=':= 32 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 96 ' range=':= 32 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>

--- a/src/main/resources/config/modules/Nuclearcraft.xml
+++ b/src/main/resources/config/modules/Nuclearcraft.xml
@@ -1543,7 +1543,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.678 * _default_ * nclcPlutoniumFreq ' range=':= 1.678 * _default_ * nclcPlutoniumFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nclcPlutoniumSize ' range=':= 0 * _default_ * nclcPlutoniumSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64 ' range=':= 64 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 64 ' range=':= 64 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1587,7 +1587,7 @@
                             <Setting name='CloudRadius' avg=':= 0.885 * _default_ * nclcPlutoniumSize ' range=':= 0.885 * _default_ * nclcPlutoniumSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.885 * _default_ * nclcPlutoniumSize ' range=':= 0.885 * _default_ * nclcPlutoniumSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.782 * _default_ * nclcPlutoniumFreq ' range=':= 0.782 * _default_ * nclcPlutoniumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64 ' range=':= 64 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64 ' range=':= 64 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1640,7 +1640,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 2.500 * nclcPlutoniumSize ' range=':= 2.500 * nclcPlutoniumSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 1.500 * nclcPlutoniumFreq ' range=':= 1.500 * nclcPlutoniumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64 ' range=':= 64 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64 ' range=':= 64 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>

--- a/src/main/resources/config/modules/ProjectRed.xml
+++ b/src/main/resources/config/modules/ProjectRed.xml
@@ -1220,7 +1220,7 @@
                             <Setting name='MotherlodeHeight' avg=':= 11 ' range=':= 5 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchInclination' avg=':= -_default_ ' range=':= -_default_ ' type='normal' />
+                            <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchLength' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />

--- a/src/main/resources/config/modules/RailCraft.xml
+++ b/src/main/resources/config/modules/RailCraft.xml
@@ -443,8 +443,8 @@
 
                 <!-- Starting Original "Overworld" Block Removal -->
 
-                <IfCondition condition=':= ?blockExists("Replaces:minecraft:sand")'>
-                    <Substitute name='rlcrOverworldBlockSubstitute0' block='Replaces:minecraft:sand'>
+                <IfCondition condition=':= ?blockExists("minecraft:sand")'>
+                    <Substitute name='rlcrOverworldBlockSubstitute4' block='minecraft:sand'>
                         <Description>
                             Replace vanilla-generated ore clusters.
                         </Description>
@@ -459,7 +459,7 @@
 
 
                 <IfCondition condition=':= ?blockExists("minecraft:stone")'>
-                    <Substitute name='rlcrOverworldBlockSubstitute7' block='minecraft:stone'>
+                    <Substitute name='rlcrOverworldBlockSubstitute6' block='minecraft:stone'>
                         <Description>
                             Replace vanilla-generated ore clusters.
                         </Description>
@@ -509,8 +509,8 @@
                             <Replaces block='minecraft:air' weight='1.0' />
                             <Biome name='Ocean'  />
                             <Biome name='Deep Ocean'  />
-                            <Setting name='MotherlodeFrequency' avg=':= _default_ * 0.5 * rlcrAbyssalOresFreq ' range=':= _default_ * rlcrAbyssalOresFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= _default_ * 6  * rlcrAbyssalOresSize ' range=':= _default_ * 6 * rlcrAbyssalOresSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= _default_ * 0.25 * rlcrAbyssalOresFreq ' range=':= _default_ * 0.25 * rlcrAbyssalOresFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= _default_ * 8  * rlcrAbyssalOresSize ' range=':= _default_ * 2 * rlcrAbyssalOresSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 30 ' range=':= 10 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1368,7 +1368,7 @@
                                 their  direction while mining.
                             </Description>
                             <OreBlock block='Railcraft:ore:1' weight='1.0' />
-                            <Replaces block='Replaces:minecraft:sand' weight='1.0' />
+                            <ReplacesOre block='sand' weight='1.0' />
                             <Replaces block='minecraft:sandstone' weight='1.0' />
                             <BiomeType name='Desert'  minRainfall='0' maxRainfall='0.1' minTemperature='1.5' maxTemperature='2.0' />
                             <Setting name='MotherlodeFrequency' avg=':= 3.465 * _default_ * rlcrSaltpeterFreq ' range=':= 3.465 * _default_ * rlcrSaltpeterFreq ' type='normal' scaleTo='base' />
@@ -1412,7 +1412,7 @@
                                 actually mining  the ore.
                             </Description>
                             <OreBlock block='Railcraft:ore:1' weight='1.0' />
-                            <Replaces block='Replaces:minecraft:sand' weight='1.0' />
+                            <ReplacesOre block='sand' weight='1.0' />
                             <Replaces block='minecraft:sandstone' weight='1.0' />
                             <BiomeType name='Desert'  minRainfall='0' maxRainfall='0.1' minTemperature='1.5' maxTemperature='2.0' />
                             <Setting name='CloudRadius' avg=':= 1.271 * _default_ * rlcrSaltpeterSize ' range=':= 1.271 * _default_ * rlcrSaltpeterSize ' type='normal' />
@@ -1467,7 +1467,7 @@
                                 distributions.
                             </Description>
                             <OreBlock block='Railcraft:ore:1' weight='1.0' />
-                            <Replaces block='Replaces:minecraft:sand' weight='1.0' />
+                            <ReplacesOre block='sand' weight='1.0' />
                             <Replaces block='minecraft:sandstone' weight='1.0' />
                             <BiomeType name='Desert'  minRainfall='0' maxRainfall='0.1' minTemperature='1.5' maxTemperature='2.0' />
                             <Setting name='Size' avg=':= 0.500 * rlcrSaltpeterSize ' range=':= 0.500 * rlcrSaltpeterSize ' type='normal' />
@@ -1529,9 +1529,9 @@
                             <OreBlock block='Railcraft:ore:5' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.221 * _default_ * rlcrFirestoneFreq ' range=':= 0.221 * _default_ * rlcrFirestoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0.778 * _default_ * rlcrFirestoneSize ' range=':= 0.778 * _default_ * rlcrFirestoneSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 16 ' range=':= 15 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.111 * _default_ * rlcrFirestoneFreq ' range=':= 0.111 * _default_ * rlcrFirestoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.693 * _default_ * rlcrFirestoneSize ' range=':= 0.693 * _default_ * rlcrFirestoneSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 16 ' range=':= 15 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1572,10 +1572,10 @@
                             <OreBlock block='Railcraft:ore:5' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.449 * _default_ * rlcrFirestoneSize ' range=':= 0.449 * _default_ * rlcrFirestoneSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.449 * _default_ * rlcrFirestoneSize ' range=':= 0.449 * _default_ * rlcrFirestoneSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.202 * _default_ * rlcrFirestoneFreq ' range=':= 0.202 * _default_ * rlcrFirestoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 16 ' range=':= 15 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.318 * _default_ * rlcrFirestoneSize ' range=':= 0.318 * _default_ * rlcrFirestoneSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.318 * _default_ * rlcrFirestoneSize ' range=':= 0.318 * _default_ * rlcrFirestoneSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.101 * _default_ * rlcrFirestoneFreq ' range=':= 0.101 * _default_ * rlcrFirestoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 16 ' range=':= 15 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1627,8 +1627,8 @@
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 0.500 * rlcrFirestoneSize ' range=':= 0.500 * rlcrFirestoneSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 0.500 * rlcrFirestoneFreq ' range=':= 0.500 * rlcrFirestoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 16 ' range=':= 15 ' type='normal' scaleTo='base' />
+                            <Setting name='Frequency' avg=':= 0.125 * rlcrFirestoneFreq ' range=':= 0.125 * rlcrFirestoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 16 ' range=':= 15 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>

--- a/src/main/resources/config/modules/ReactorCraft.xml
+++ b/src/main/resources/config/modules/ReactorCraft.xml
@@ -1636,20 +1636,20 @@
                             <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.734 * _default_ * recrBlueFluoriteFreq ' range=':= 1.734 * _default_ * recrBlueFluoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.096 * _default_ * recrBlueFluoriteSize ' range=':= 1.096 * _default_ * recrBlueFluoriteSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.613 * _default_ * recrBlueFluoriteFreq ' range=':= 0.613 * _default_ * recrBlueFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * recrBlueFluoriteSize ' range=':= 0.922 * _default_ * recrBlueFluoriteSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.317 * _default_ ' range=':= 1.317 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.783 * _default_ ' range=':= 0.783 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * recrBlueFluoriteSize ' range=':= _default_ * recrBlueFluoriteSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentPitch' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.147 * _default_ * recrBlueFluoriteSize ' range=':= 1.147 * _default_ * recrBlueFluoriteSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.885 * _default_ * recrBlueFluoriteSize ' range=':= 0.885 * _default_ * recrBlueFluoriteSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1681,9 +1681,9 @@
                             <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.407 * _default_ * recrBlueFluoriteSize ' range=':= 1.407 * _default_ * recrBlueFluoriteSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.407 * _default_ * recrBlueFluoriteSize ' range=':= 1.407 * _default_ * recrBlueFluoriteSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.979 * _default_ * recrBlueFluoriteFreq ' range=':= 1.979 * _default_ * recrBlueFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.837 * _default_ * recrBlueFluoriteSize ' range=':= 0.837 * _default_ * recrBlueFluoriteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.837 * _default_ * recrBlueFluoriteSize ' range=':= 0.837 * _default_ * recrBlueFluoriteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.700 * _default_ * recrBlueFluoriteFreq ' range=':= 0.700 * _default_ * recrBlueFluoriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1737,7 +1737,7 @@
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * recrBlueFluoriteSize ' range=':= 4.000 * recrBlueFluoriteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 6.000 * recrBlueFluoriteFreq ' range=':= 6.000 * recrBlueFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Frequency' avg=':= 0.750 * recrBlueFluoriteFreq ' range=':= 0.750 * recrBlueFluoriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -1761,20 +1761,20 @@
                             <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:1' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.734 * _default_ * recrPinkFluoriteFreq ' range=':= 1.734 * _default_ * recrPinkFluoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.096 * _default_ * recrPinkFluoriteSize ' range=':= 1.096 * _default_ * recrPinkFluoriteSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.613 * _default_ * recrPinkFluoriteFreq ' range=':= 0.613 * _default_ * recrPinkFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * recrPinkFluoriteSize ' range=':= 0.922 * _default_ * recrPinkFluoriteSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.317 * _default_ ' range=':= 1.317 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.783 * _default_ ' range=':= 0.783 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * recrPinkFluoriteSize ' range=':= _default_ * recrPinkFluoriteSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentPitch' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.147 * _default_ * recrPinkFluoriteSize ' range=':= 1.147 * _default_ * recrPinkFluoriteSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.885 * _default_ * recrPinkFluoriteSize ' range=':= 0.885 * _default_ * recrPinkFluoriteSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1806,9 +1806,9 @@
                             <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:1' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.407 * _default_ * recrPinkFluoriteSize ' range=':= 1.407 * _default_ * recrPinkFluoriteSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.407 * _default_ * recrPinkFluoriteSize ' range=':= 1.407 * _default_ * recrPinkFluoriteSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.979 * _default_ * recrPinkFluoriteFreq ' range=':= 1.979 * _default_ * recrPinkFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.837 * _default_ * recrPinkFluoriteSize ' range=':= 0.837 * _default_ * recrPinkFluoriteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.837 * _default_ * recrPinkFluoriteSize ' range=':= 0.837 * _default_ * recrPinkFluoriteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.700 * _default_ * recrPinkFluoriteFreq ' range=':= 0.700 * _default_ * recrPinkFluoriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1862,7 +1862,7 @@
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * recrPinkFluoriteSize ' range=':= 4.000 * recrPinkFluoriteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 6.000 * recrPinkFluoriteFreq ' range=':= 6.000 * recrPinkFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Frequency' avg=':= 0.750 * recrPinkFluoriteFreq ' range=':= 0.750 * recrPinkFluoriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -1886,20 +1886,20 @@
                             <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:2' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.734 * _default_ * recrOrangeFluoriteFreq ' range=':= 1.734 * _default_ * recrOrangeFluoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.096 * _default_ * recrOrangeFluoriteSize ' range=':= 1.096 * _default_ * recrOrangeFluoriteSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.613 * _default_ * recrOrangeFluoriteFreq ' range=':= 0.613 * _default_ * recrOrangeFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * recrOrangeFluoriteSize ' range=':= 0.922 * _default_ * recrOrangeFluoriteSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.317 * _default_ ' range=':= 1.317 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.783 * _default_ ' range=':= 0.783 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * recrOrangeFluoriteSize ' range=':= _default_ * recrOrangeFluoriteSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentPitch' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.147 * _default_ * recrOrangeFluoriteSize ' range=':= 1.147 * _default_ * recrOrangeFluoriteSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.885 * _default_ * recrOrangeFluoriteSize ' range=':= 0.885 * _default_ * recrOrangeFluoriteSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1931,9 +1931,9 @@
                             <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:2' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.407 * _default_ * recrOrangeFluoriteSize ' range=':= 1.407 * _default_ * recrOrangeFluoriteSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.407 * _default_ * recrOrangeFluoriteSize ' range=':= 1.407 * _default_ * recrOrangeFluoriteSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.979 * _default_ * recrOrangeFluoriteFreq ' range=':= 1.979 * _default_ * recrOrangeFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.837 * _default_ * recrOrangeFluoriteSize ' range=':= 0.837 * _default_ * recrOrangeFluoriteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.837 * _default_ * recrOrangeFluoriteSize ' range=':= 0.837 * _default_ * recrOrangeFluoriteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.700 * _default_ * recrOrangeFluoriteFreq ' range=':= 0.700 * _default_ * recrOrangeFluoriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1987,7 +1987,7 @@
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * recrOrangeFluoriteSize ' range=':= 4.000 * recrOrangeFluoriteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 6.000 * recrOrangeFluoriteFreq ' range=':= 6.000 * recrOrangeFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Frequency' avg=':= 0.750 * recrOrangeFluoriteFreq ' range=':= 0.750 * recrOrangeFluoriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -2012,20 +2012,20 @@
                             <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:3' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.734 * _default_ * recrMagentaFluoriteFreq ' range=':= 1.734 * _default_ * recrMagentaFluoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.096 * _default_ * recrMagentaFluoriteSize ' range=':= 1.096 * _default_ * recrMagentaFluoriteSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.613 * _default_ * recrMagentaFluoriteFreq ' range=':= 0.613 * _default_ * recrMagentaFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * recrMagentaFluoriteSize ' range=':= 0.922 * _default_ * recrMagentaFluoriteSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.317 * _default_ ' range=':= 1.317 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.783 * _default_ ' range=':= 0.783 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * recrMagentaFluoriteSize ' range=':= _default_ * recrMagentaFluoriteSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentPitch' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.147 * _default_ * recrMagentaFluoriteSize ' range=':= 1.147 * _default_ * recrMagentaFluoriteSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.885 * _default_ * recrMagentaFluoriteSize ' range=':= 0.885 * _default_ * recrMagentaFluoriteSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -2057,9 +2057,9 @@
                             <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:3' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.407 * _default_ * recrMagentaFluoriteSize ' range=':= 1.407 * _default_ * recrMagentaFluoriteSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.407 * _default_ * recrMagentaFluoriteSize ' range=':= 1.407 * _default_ * recrMagentaFluoriteSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.979 * _default_ * recrMagentaFluoriteFreq ' range=':= 1.979 * _default_ * recrMagentaFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.837 * _default_ * recrMagentaFluoriteSize ' range=':= 0.837 * _default_ * recrMagentaFluoriteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.837 * _default_ * recrMagentaFluoriteSize ' range=':= 0.837 * _default_ * recrMagentaFluoriteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.700 * _default_ * recrMagentaFluoriteFreq ' range=':= 0.700 * _default_ * recrMagentaFluoriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2113,7 +2113,7 @@
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * recrMagentaFluoriteSize ' range=':= 4.000 * recrMagentaFluoriteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 6.000 * recrMagentaFluoriteFreq ' range=':= 6.000 * recrMagentaFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Frequency' avg=':= 0.750 * recrMagentaFluoriteFreq ' range=':= 0.750 * recrMagentaFluoriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -2137,20 +2137,20 @@
                             <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:4' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.734 * _default_ * recrGreenFluoriteFreq ' range=':= 1.734 * _default_ * recrGreenFluoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.096 * _default_ * recrGreenFluoriteSize ' range=':= 1.096 * _default_ * recrGreenFluoriteSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.613 * _default_ * recrGreenFluoriteFreq ' range=':= 0.613 * _default_ * recrGreenFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * recrGreenFluoriteSize ' range=':= 0.922 * _default_ * recrGreenFluoriteSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.317 * _default_ ' range=':= 1.317 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.783 * _default_ ' range=':= 0.783 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * recrGreenFluoriteSize ' range=':= _default_ * recrGreenFluoriteSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentPitch' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.147 * _default_ * recrGreenFluoriteSize ' range=':= 1.147 * _default_ * recrGreenFluoriteSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.885 * _default_ * recrGreenFluoriteSize ' range=':= 0.885 * _default_ * recrGreenFluoriteSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -2182,9 +2182,9 @@
                             <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:4' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.407 * _default_ * recrGreenFluoriteSize ' range=':= 1.407 * _default_ * recrGreenFluoriteSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.407 * _default_ * recrGreenFluoriteSize ' range=':= 1.407 * _default_ * recrGreenFluoriteSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.979 * _default_ * recrGreenFluoriteFreq ' range=':= 1.979 * _default_ * recrGreenFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.837 * _default_ * recrGreenFluoriteSize ' range=':= 0.837 * _default_ * recrGreenFluoriteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.837 * _default_ * recrGreenFluoriteSize ' range=':= 0.837 * _default_ * recrGreenFluoriteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.700 * _default_ * recrGreenFluoriteFreq ' range=':= 0.700 * _default_ * recrGreenFluoriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2238,7 +2238,7 @@
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * recrGreenFluoriteSize ' range=':= 4.000 * recrGreenFluoriteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 6.000 * recrGreenFluoriteFreq ' range=':= 6.000 * recrGreenFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Frequency' avg=':= 0.750 * recrGreenFluoriteFreq ' range=':= 0.750 * recrGreenFluoriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -2262,20 +2262,20 @@
                             <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:5' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.734 * _default_ * recrRedFluoriteFreq ' range=':= 1.734 * _default_ * recrRedFluoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.096 * _default_ * recrRedFluoriteSize ' range=':= 1.096 * _default_ * recrRedFluoriteSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.613 * _default_ * recrRedFluoriteFreq ' range=':= 0.613 * _default_ * recrRedFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * recrRedFluoriteSize ' range=':= 0.922 * _default_ * recrRedFluoriteSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.317 * _default_ ' range=':= 1.317 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.783 * _default_ ' range=':= 0.783 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * recrRedFluoriteSize ' range=':= _default_ * recrRedFluoriteSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentPitch' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.147 * _default_ * recrRedFluoriteSize ' range=':= 1.147 * _default_ * recrRedFluoriteSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.885 * _default_ * recrRedFluoriteSize ' range=':= 0.885 * _default_ * recrRedFluoriteSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -2305,9 +2305,9 @@
                             <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:5' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.407 * _default_ * recrRedFluoriteSize ' range=':= 1.407 * _default_ * recrRedFluoriteSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.407 * _default_ * recrRedFluoriteSize ' range=':= 1.407 * _default_ * recrRedFluoriteSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.979 * _default_ * recrRedFluoriteFreq ' range=':= 1.979 * _default_ * recrRedFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.837 * _default_ * recrRedFluoriteSize ' range=':= 0.837 * _default_ * recrRedFluoriteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.837 * _default_ * recrRedFluoriteSize ' range=':= 0.837 * _default_ * recrRedFluoriteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.700 * _default_ * recrRedFluoriteFreq ' range=':= 0.700 * _default_ * recrRedFluoriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2361,7 +2361,7 @@
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * recrRedFluoriteSize ' range=':= 4.000 * recrRedFluoriteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 6.000 * recrRedFluoriteFreq ' range=':= 6.000 * recrRedFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Frequency' avg=':= 0.750 * recrRedFluoriteFreq ' range=':= 0.750 * recrRedFluoriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -2385,20 +2385,20 @@
                             <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:6' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.734 * _default_ * recrWhiteFluoriteFreq ' range=':= 1.734 * _default_ * recrWhiteFluoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.096 * _default_ * recrWhiteFluoriteSize ' range=':= 1.096 * _default_ * recrWhiteFluoriteSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.613 * _default_ * recrWhiteFluoriteFreq ' range=':= 0.613 * _default_ * recrWhiteFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * recrWhiteFluoriteSize ' range=':= 0.922 * _default_ * recrWhiteFluoriteSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.317 * _default_ ' range=':= 1.317 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.783 * _default_ ' range=':= 0.783 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * recrWhiteFluoriteSize ' range=':= _default_ * recrWhiteFluoriteSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentPitch' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.147 * _default_ * recrWhiteFluoriteSize ' range=':= 1.147 * _default_ * recrWhiteFluoriteSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.885 * _default_ * recrWhiteFluoriteSize ' range=':= 0.885 * _default_ * recrWhiteFluoriteSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -2430,9 +2430,9 @@
                             <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:6' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.407 * _default_ * recrWhiteFluoriteSize ' range=':= 1.407 * _default_ * recrWhiteFluoriteSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.407 * _default_ * recrWhiteFluoriteSize ' range=':= 1.407 * _default_ * recrWhiteFluoriteSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.979 * _default_ * recrWhiteFluoriteFreq ' range=':= 1.979 * _default_ * recrWhiteFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.837 * _default_ * recrWhiteFluoriteSize ' range=':= 0.837 * _default_ * recrWhiteFluoriteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.837 * _default_ * recrWhiteFluoriteSize ' range=':= 0.837 * _default_ * recrWhiteFluoriteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.700 * _default_ * recrWhiteFluoriteFreq ' range=':= 0.700 * _default_ * recrWhiteFluoriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2486,7 +2486,7 @@
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * recrWhiteFluoriteSize ' range=':= 4.000 * recrWhiteFluoriteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 6.000 * recrWhiteFluoriteFreq ' range=':= 6.000 * recrWhiteFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Frequency' avg=':= 0.750 * recrWhiteFluoriteFreq ' range=':= 0.750 * recrWhiteFluoriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -2510,20 +2510,20 @@
                             <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:7' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 1.734 * _default_ * recrYellowFluoriteFreq ' range=':= 1.734 * _default_ * recrYellowFluoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 1.096 * _default_ * recrYellowFluoriteSize ' range=':= 1.096 * _default_ * recrYellowFluoriteSize ' type='normal' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.613 * _default_ * recrYellowFluoriteFreq ' range=':= 0.613 * _default_ * recrYellowFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * recrYellowFluoriteSize ' range=':= 0.922 * _default_ * recrYellowFluoriteSize ' type='normal' />
                             <Setting name='MotherlodeHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.317 * _default_ ' range=':= 1.317 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0.783 * _default_ ' range=':= 0.783 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * recrYellowFluoriteSize ' range=':= _default_ * recrYellowFluoriteSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentPitch' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.147 * _default_ * recrYellowFluoriteSize ' range=':= 1.147 * _default_ * recrYellowFluoriteSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.885 * _default_ * recrYellowFluoriteSize ' range=':= 0.885 * _default_ * recrYellowFluoriteSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -2555,9 +2555,9 @@
                             <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:7' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 1.407 * _default_ * recrYellowFluoriteSize ' range=':= 1.407 * _default_ * recrYellowFluoriteSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 1.407 * _default_ * recrYellowFluoriteSize ' range=':= 1.407 * _default_ * recrYellowFluoriteSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 1.979 * _default_ * recrYellowFluoriteFreq ' range=':= 1.979 * _default_ * recrYellowFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.837 * _default_ * recrYellowFluoriteSize ' range=':= 0.837 * _default_ * recrYellowFluoriteSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.837 * _default_ * recrYellowFluoriteSize ' range=':= 0.837 * _default_ * recrYellowFluoriteSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.700 * _default_ * recrYellowFluoriteFreq ' range=':= 0.700 * _default_ * recrYellowFluoriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='CloudHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2611,7 +2611,7 @@
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * recrYellowFluoriteSize ' range=':= 4.000 * recrYellowFluoriteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 6.000 * recrYellowFluoriteFreq ' range=':= 6.000 * recrYellowFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Frequency' avg=':= 0.750 * recrYellowFluoriteFreq ' range=':= 0.750 * recrYellowFluoriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -2678,7 +2678,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 3.001 * _default_ * recrAmmoniumChlorideFreq ' range=':= 3.001 * _default_ * recrAmmoniumChlorideFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * recrAmmoniumChlorideSize ' range=':= 0 * _default_ * recrAmmoniumChlorideSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 32 ' range=':= 0 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 32 ' range=':= 0 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2724,7 +2724,7 @@
                             <Setting name='CloudRadius' avg=':= 1.183 * _default_ * recrAmmoniumChlorideSize ' range=':= 1.183 * _default_ * recrAmmoniumChlorideSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.183 * _default_ * recrAmmoniumChlorideSize ' range=':= 1.183 * _default_ * recrAmmoniumChlorideSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.400 * _default_ * recrAmmoniumChlorideFreq ' range=':= 1.400 * _default_ * recrAmmoniumChlorideFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 32 ' range=':= 0 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 32 ' range=':= 0 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2778,7 +2778,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 4.000 * recrAmmoniumChlorideSize ' range=':= 4.000 * recrAmmoniumChlorideSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 3.000 * recrAmmoniumChlorideFreq ' range=':= 3.000 * recrAmmoniumChlorideFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 32 ' range=':= 0 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 32 ' range=':= 0 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -2810,7 +2810,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.122 * _default_ * recrThoriteFreq ' range=':= 2.122 * _default_ * recrThoriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * recrThoriteSize ' range=':= 0 * _default_ * recrThoriteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 18.5 ' range=':= 13.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 18.5 ' range=':= 13.5 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2854,7 +2854,7 @@
                             <Setting name='CloudRadius' avg=':= 0.995 * _default_ * recrThoriteSize ' range=':= 0.995 * _default_ * recrThoriteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.995 * _default_ * recrThoriteSize ' range=':= 0.995 * _default_ * recrThoriteSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.990 * _default_ * recrThoriteFreq ' range=':= 0.990 * _default_ * recrThoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 18.5 ' range=':= 13.5 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 18.5 ' range=':= 13.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2907,7 +2907,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 12.000 * recrThoriteSize ' range=':= 12.000 * recrThoriteSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 0.500 * recrThoriteFreq ' range=':= 0.500 * recrThoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 18.5 ' range=':= 13.5 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 18.5 ' range=':= 13.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -2971,7 +2971,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 4.244 * _default_ * recrEndPitchblendeFreq ' range=':= 4.244 * _default_ * recrEndPitchblendeFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * recrEndPitchblendeSize ' range=':= 0 * _default_ * recrEndPitchblendeSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 34.5 ' range=':= 29.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 34.5 ' range=':= 29.5 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3017,7 +3017,7 @@
                             <Setting name='CloudRadius' avg=':= 1.407 * _default_ * recrEndPitchblendeSize ' range=':= 1.407 * _default_ * recrEndPitchblendeSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.407 * _default_ * recrEndPitchblendeSize ' range=':= 1.407 * _default_ * recrEndPitchblendeSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.979 * _default_ * recrEndPitchblendeFreq ' range=':= 1.979 * _default_ * recrEndPitchblendeFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 34.5 ' range=':= 29.5 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 34.5 ' range=':= 29.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3071,7 +3071,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 8.000 * recrEndPitchblendeSize ' range=':= 8.000 * recrEndPitchblendeSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 3.000 * recrEndPitchblendeFreq ' range=':= 3.000 * recrEndPitchblendeFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 34.5 ' range=':= 29.5 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 34.5 ' range=':= 29.5 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>

--- a/src/main/resources/config/modules/Thaumcraft4.xml
+++ b/src/main/resources/config/modules/Thaumcraft4.xml
@@ -144,6 +144,15 @@
 
                     <IfCondition condition=':= (?blockExists("Thaumcraft:blockCustomOre:1")) '>
 
+                    <Choice value='StrategicClouds' displayValue='Strategic Clouds'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    </IfCondition>
+
+                    <IfCondition condition=':= (?blockExists("Thaumcraft:blockCustomOre:1")) '>
+
                     <Choice value='Vanilla' displayValue='Vanilla'>
                         <Description>
                             Simulates Vanilla Minecraft.
@@ -175,6 +184,15 @@
                     <Choice value='SparseVeins' displayValue='Sparse Veins'>
                         <Description>
                             Large veins filled very lightly with ore.
+                        </Description>
+                    </Choice>
+                    </IfCondition>
+
+                    <IfCondition condition=':= (?blockExists("Thaumcraft:blockCustomOre:2")) '>
+
+                    <Choice value='StrategicClouds' displayValue='Strategic Clouds'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
                         </Description>
                     </Choice>
                     </IfCondition>
@@ -218,6 +236,15 @@
 
                     <IfCondition condition=':= (?blockExists("Thaumcraft:blockCustomOre:3")) '>
 
+                    <Choice value='StrategicClouds' displayValue='Strategic Clouds'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    </IfCondition>
+
+                    <IfCondition condition=':= (?blockExists("Thaumcraft:blockCustomOre:3")) '>
+
                     <Choice value='Vanilla' displayValue='Vanilla'>
                         <Description>
                             Simulates Vanilla Minecraft.
@@ -249,6 +276,15 @@
                     <Choice value='SparseVeins' displayValue='Sparse Veins'>
                         <Description>
                             Large veins filled very lightly with ore.
+                        </Description>
+                    </Choice>
+                    </IfCondition>
+
+                    <IfCondition condition=':= (?blockExists("Thaumcraft:blockCustomOre:4")) '>
+
+                    <Choice value='StrategicClouds' displayValue='Strategic Clouds'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
                         </Description>
                     </Choice>
                     </IfCondition>
@@ -292,6 +328,15 @@
 
                     <IfCondition condition=':= (?blockExists("Thaumcraft:blockCustomOre:5")) '>
 
+                    <Choice value='StrategicClouds' displayValue='Strategic Clouds'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
+                        </Description>
+                    </Choice>
+                    </IfCondition>
+
+                    <IfCondition condition=':= (?blockExists("Thaumcraft:blockCustomOre:5")) '>
+
                     <Choice value='Vanilla' displayValue='Vanilla'>
                         <Description>
                             Simulates Vanilla Minecraft.
@@ -323,6 +368,15 @@
                     <Choice value='SparseVeins' displayValue='Sparse Veins'>
                         <Description>
                             Large veins filled very lightly with ore.
+                        </Description>
+                    </Choice>
+                    </IfCondition>
+
+                    <IfCondition condition=':= (?blockExists("Thaumcraft:blockCustomOre:6")) '>
+
+                    <Choice value='StrategicClouds' displayValue='Strategic Clouds'>
+                        <Description>
+                            Large irregular clouds filled lightly with ore.
                         </Description>
                     </Choice>
                     </IfCondition>
@@ -724,6 +778,106 @@
                      complete. -->
 
 
+                <!-- Starting StrategicClouds Preset for Air Infused
+                     Stone. -->
+                <ConfigSection>
+                    <IfCondition condition=':= thm4AirInfusedStoneDist = "StrategicClouds"'>
+                        <Cloud name='thm4AirInfusedStoneCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60FEFEAB' drawBoundBox='false' boundBoxColor='0x60FEFEAB'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <OreBlock block='Thaumcraft:blockCustomOre:1' weight='1.0' />
+                            <ReplacesOre block='stone' weight='1.0' />
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.905 * _default_ * thm4AirInfusedStoneSize ' range=':= 0.905 * _default_ * thm4AirInfusedStoneSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.905 * _default_ * thm4AirInfusedStoneSize ' range=':= 0.905 * _default_ * thm4AirInfusedStoneSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.818 * _default_ * thm4AirInfusedStoneFreq ' range=':= 0.818 * _default_ * thm4AirInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 32 ' range=':= 27 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Veins name='thm4AirInfusedStoneHintVeins' branchType='Bezier'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FEFEAB' drawBoundBox='false' boundBoxColor='0x60FEFEAB'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <OreBlock block='Thaumcraft:blockCustomOre:1' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
+                                <ReplacesOre block='stone' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
+                            </Veins>
+                        </Cloud>
+
+                        <!-- Beginning "Preferred" configuration. -->
+                        <Cloud name='thm4AirInfusedStonePreferredCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60FEFEAB' drawBoundBox='false' boundBoxColor='0x60FEFEAB'>
+                            <Description>
+                                Ore generation is doubled in
+                                preferred biomes.
+                            </Description>
+                            <OreBlock block='Thaumcraft:blockCustomOre:1' weight='1.0' />
+                            <ReplacesOre block='stone' weight='1.0' />
+                            <BiomeType name='Plains'  />
+                            <Setting name='CloudRadius' avg=':= 0.905 * _default_ * thm4AirInfusedStoneSize ' range=':= 0.905 * _default_ * thm4AirInfusedStoneSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.905 * _default_ * thm4AirInfusedStoneSize ' range=':= 0.905 * _default_ * thm4AirInfusedStoneSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.818 * _default_ * thm4AirInfusedStoneFreq ' range=':= 0.818 * _default_ * thm4AirInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 32 ' range=':= 27 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Veins name='thm4AirInfusedStonePreferredHintVeins' branchType='Bezier'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FEFEAB' drawBoundBox='false' boundBoxColor='0x60FEFEAB'>
+                                <Description>
+                                    Ore generation is doubled in
+                                    preferred biomes.
+                                </Description>
+                                <OreBlock block='Thaumcraft:blockCustomOre:1' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
+                                <ReplacesOre block='stone' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
+                            </Veins>
+                        </Cloud>
+                        <!-- "Preferred" configuration complete. -->
+
+                    </IfCondition>
+                </ConfigSection>
+                <!-- StrategicClouds Preset for Air Infused Stone is
+                     complete. -->
+
+
                 <!-- Starting Vanilla Preset for Air Infused Stone. -->
                 <ConfigSection>
                     <IfCondition condition=':= thm4AirInfusedStoneDist = "Vanilla"'>
@@ -817,6 +971,106 @@
                     </IfCondition>
                 </ConfigSection>
                 <!-- SparseVeins Preset for Fire Infused Stone is
+                     complete. -->
+
+
+                <!-- Starting StrategicClouds Preset for Fire Infused
+                     Stone. -->
+                <ConfigSection>
+                    <IfCondition condition=':= thm4FireInfusedStoneDist = "StrategicClouds"'>
+                        <Cloud name='thm4FireInfusedStoneCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60FC5100' drawBoundBox='false' boundBoxColor='0x60FC5100'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <OreBlock block='Thaumcraft:blockCustomOre:2' weight='1.0' />
+                            <ReplacesOre block='stone' weight='1.0' />
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.905 * _default_ * thm4FireInfusedStoneSize ' range=':= 0.905 * _default_ * thm4FireInfusedStoneSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.905 * _default_ * thm4FireInfusedStoneSize ' range=':= 0.905 * _default_ * thm4FireInfusedStoneSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.818 * _default_ * thm4FireInfusedStoneFreq ' range=':= 0.818 * _default_ * thm4FireInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 32 ' range=':= 27 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Veins name='thm4FireInfusedStoneHintVeins' branchType='Bezier'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FC5100' drawBoundBox='false' boundBoxColor='0x60FC5100'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <OreBlock block='Thaumcraft:blockCustomOre:2' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
+                                <ReplacesOre block='stone' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
+                            </Veins>
+                        </Cloud>
+
+                        <!-- Beginning "Preferred" configuration. -->
+                        <Cloud name='thm4FireInfusedStonePreferredCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60FC5100' drawBoundBox='false' boundBoxColor='0x60FC5100'>
+                            <Description>
+                                Ore generation is doubled in
+                                preferred biomes.
+                            </Description>
+                            <OreBlock block='Thaumcraft:blockCustomOre:2' weight='1.0' />
+                            <ReplacesOre block='stone' weight='1.0' />
+                            <BiomeType name='Desert'  />
+                            <Setting name='CloudRadius' avg=':= 0.905 * _default_ * thm4FireInfusedStoneSize ' range=':= 0.905 * _default_ * thm4FireInfusedStoneSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.905 * _default_ * thm4FireInfusedStoneSize ' range=':= 0.905 * _default_ * thm4FireInfusedStoneSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.818 * _default_ * thm4FireInfusedStoneFreq ' range=':= 0.818 * _default_ * thm4FireInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 32 ' range=':= 27 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Veins name='thm4FireInfusedStonePreferredHintVeins' branchType='Bezier'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60FC5100' drawBoundBox='false' boundBoxColor='0x60FC5100'>
+                                <Description>
+                                    Ore generation is doubled in
+                                    preferred biomes.
+                                </Description>
+                                <OreBlock block='Thaumcraft:blockCustomOre:2' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
+                                <ReplacesOre block='stone' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
+                            </Veins>
+                        </Cloud>
+                        <!-- "Preferred" configuration complete. -->
+
+                    </IfCondition>
+                </ConfigSection>
+                <!-- StrategicClouds Preset for Fire Infused Stone is
                      complete. -->
 
 
@@ -918,6 +1172,107 @@
                      complete. -->
 
 
+                <!-- Starting StrategicClouds Preset for Water Infused
+                     Stone. -->
+                <ConfigSection>
+                    <IfCondition condition=':= thm4WaterInfusedStoneDist = "StrategicClouds"'>
+                        <Cloud name='thm4WaterInfusedStoneCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x6000C0FA' drawBoundBox='false' boundBoxColor='0x6000C0FA'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <OreBlock block='Thaumcraft:blockCustomOre:3' weight='1.0' />
+                            <ReplacesOre block='stone' weight='1.0' />
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.905 * _default_ * thm4WaterInfusedStoneSize ' range=':= 0.905 * _default_ * thm4WaterInfusedStoneSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.905 * _default_ * thm4WaterInfusedStoneSize ' range=':= 0.905 * _default_ * thm4WaterInfusedStoneSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.818 * _default_ * thm4WaterInfusedStoneFreq ' range=':= 0.818 * _default_ * thm4WaterInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 32 ' range=':= 27 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Veins name='thm4WaterInfusedStoneHintVeins' branchType='Bezier'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x6000C0FA' drawBoundBox='false' boundBoxColor='0x6000C0FA'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <OreBlock block='Thaumcraft:blockCustomOre:3' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
+                                <ReplacesOre block='stone' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
+                            </Veins>
+                        </Cloud>
+
+                        <!-- Beginning "Preferred" configuration. -->
+                        <Cloud name='thm4WaterInfusedStonePreferredCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x6000C0FA' drawBoundBox='false' boundBoxColor='0x6000C0FA'>
+                            <Description>
+                                Ore generation is doubled in
+                                preferred biomes.
+                            </Description>
+                            <OreBlock block='Thaumcraft:blockCustomOre:3' weight='1.0' />
+                            <ReplacesOre block='stone' weight='1.0' />
+                            <BiomeType name='Water'  />
+                            <BiomeType name='Swamp'  />
+                            <Setting name='CloudRadius' avg=':= 0.905 * _default_ * thm4WaterInfusedStoneSize ' range=':= 0.905 * _default_ * thm4WaterInfusedStoneSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.905 * _default_ * thm4WaterInfusedStoneSize ' range=':= 0.905 * _default_ * thm4WaterInfusedStoneSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.818 * _default_ * thm4WaterInfusedStoneFreq ' range=':= 0.818 * _default_ * thm4WaterInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 32 ' range=':= 27 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Veins name='thm4WaterInfusedStonePreferredHintVeins' branchType='Bezier'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x6000C0FA' drawBoundBox='false' boundBoxColor='0x6000C0FA'>
+                                <Description>
+                                    Ore generation is doubled in
+                                    preferred biomes.
+                                </Description>
+                                <OreBlock block='Thaumcraft:blockCustomOre:3' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
+                                <ReplacesOre block='stone' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
+                            </Veins>
+                        </Cloud>
+                        <!-- "Preferred" configuration complete. -->
+
+                    </IfCondition>
+                </ConfigSection>
+                <!-- StrategicClouds Preset for Water Infused Stone is
+                     complete. -->
+
+
                 <!-- Starting Vanilla Preset for Water Infused Stone. -->
                 <ConfigSection>
                     <IfCondition condition=':= thm4WaterInfusedStoneDist = "Vanilla"'>
@@ -1012,6 +1367,106 @@
                     </IfCondition>
                 </ConfigSection>
                 <!-- SparseVeins Preset for Earth Infused Stone is
+                     complete. -->
+
+
+                <!-- Starting StrategicClouds Preset for Earth Infused
+                     Stone. -->
+                <ConfigSection>
+                    <IfCondition condition=':= thm4EarthInfusedStoneDist = "StrategicClouds"'>
+                        <Cloud name='thm4EarthInfusedStoneCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x6000D900' drawBoundBox='false' boundBoxColor='0x6000D900'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <OreBlock block='Thaumcraft:blockCustomOre:4' weight='1.0' />
+                            <ReplacesOre block='stone' weight='1.0' />
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.905 * _default_ * thm4EarthInfusedStoneSize ' range=':= 0.905 * _default_ * thm4EarthInfusedStoneSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.905 * _default_ * thm4EarthInfusedStoneSize ' range=':= 0.905 * _default_ * thm4EarthInfusedStoneSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.818 * _default_ * thm4EarthInfusedStoneFreq ' range=':= 0.818 * _default_ * thm4EarthInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 32 ' range=':= 27 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Veins name='thm4EarthInfusedStoneHintVeins' branchType='Bezier'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x6000D900' drawBoundBox='false' boundBoxColor='0x6000D900'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <OreBlock block='Thaumcraft:blockCustomOre:4' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
+                                <ReplacesOre block='stone' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
+                            </Veins>
+                        </Cloud>
+
+                        <!-- Beginning "Preferred" configuration. -->
+                        <Cloud name='thm4EarthInfusedStonePreferredCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x6000D900' drawBoundBox='false' boundBoxColor='0x6000D900'>
+                            <Description>
+                                Ore generation is doubled in
+                                preferred biomes.
+                            </Description>
+                            <OreBlock block='Thaumcraft:blockCustomOre:4' weight='1.0' />
+                            <ReplacesOre block='stone' weight='1.0' />
+                            <BiomeType name='Forest'  />
+                            <Setting name='CloudRadius' avg=':= 0.905 * _default_ * thm4EarthInfusedStoneSize ' range=':= 0.905 * _default_ * thm4EarthInfusedStoneSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.905 * _default_ * thm4EarthInfusedStoneSize ' range=':= 0.905 * _default_ * thm4EarthInfusedStoneSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.818 * _default_ * thm4EarthInfusedStoneFreq ' range=':= 0.818 * _default_ * thm4EarthInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 32 ' range=':= 27 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Veins name='thm4EarthInfusedStonePreferredHintVeins' branchType='Bezier'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x6000D900' drawBoundBox='false' boundBoxColor='0x6000D900'>
+                                <Description>
+                                    Ore generation is doubled in
+                                    preferred biomes.
+                                </Description>
+                                <OreBlock block='Thaumcraft:blockCustomOre:4' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
+                                <ReplacesOre block='stone' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
+                            </Veins>
+                        </Cloud>
+                        <!-- "Preferred" configuration complete. -->
+
+                    </IfCondition>
+                </ConfigSection>
+                <!-- StrategicClouds Preset for Earth Infused Stone is
                      complete. -->
 
 
@@ -1114,6 +1569,108 @@
                      complete. -->
 
 
+                <!-- Starting StrategicClouds Preset for Order Infused
+                     Stone. -->
+                <ConfigSection>
+                    <IfCondition condition=':= thm4OrderInfusedStoneDist = "StrategicClouds"'>
+                        <Cloud name='thm4OrderInfusedStoneCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60EBEBF9' drawBoundBox='false' boundBoxColor='0x60EBEBF9'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <OreBlock block='Thaumcraft:blockCustomOre:5' weight='1.0' />
+                            <ReplacesOre block='stone' weight='1.0' />
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.905 * _default_ * thm4OrderInfusedStoneSize ' range=':= 0.905 * _default_ * thm4OrderInfusedStoneSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.905 * _default_ * thm4OrderInfusedStoneSize ' range=':= 0.905 * _default_ * thm4OrderInfusedStoneSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.818 * _default_ * thm4OrderInfusedStoneFreq ' range=':= 0.818 * _default_ * thm4OrderInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 32 ' range=':= 27 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Veins name='thm4OrderInfusedStoneHintVeins' branchType='Bezier'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60EBEBF9' drawBoundBox='false' boundBoxColor='0x60EBEBF9'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <OreBlock block='Thaumcraft:blockCustomOre:5' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
+                                <ReplacesOre block='stone' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
+                            </Veins>
+                        </Cloud>
+
+                        <!-- Beginning "Preferred" configuration. -->
+                        <Cloud name='thm4OrderInfusedStonePreferredCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60EBEBF9' drawBoundBox='false' boundBoxColor='0x60EBEBF9'>
+                            <Description>
+                                Ore generation is doubled in
+                                preferred biomes.
+                            </Description>
+                            <OreBlock block='Thaumcraft:blockCustomOre:5' weight='1.0' />
+                            <ReplacesOre block='stone' weight='1.0' />
+                            <BiomeType name='Mushroom'  />
+                            <BiomeType name='Mountain'  />
+                            <BiomeType name='Magical'  />
+                            <Setting name='CloudRadius' avg=':= 0.905 * _default_ * thm4OrderInfusedStoneSize ' range=':= 0.905 * _default_ * thm4OrderInfusedStoneSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.905 * _default_ * thm4OrderInfusedStoneSize ' range=':= 0.905 * _default_ * thm4OrderInfusedStoneSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.818 * _default_ * thm4OrderInfusedStoneFreq ' range=':= 0.818 * _default_ * thm4OrderInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 32 ' range=':= 27 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Veins name='thm4OrderInfusedStonePreferredHintVeins' branchType='Bezier'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60EBEBF9' drawBoundBox='false' boundBoxColor='0x60EBEBF9'>
+                                <Description>
+                                    Ore generation is doubled in
+                                    preferred biomes.
+                                </Description>
+                                <OreBlock block='Thaumcraft:blockCustomOre:5' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
+                                <ReplacesOre block='stone' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
+                            </Veins>
+                        </Cloud>
+                        <!-- "Preferred" configuration complete. -->
+
+                    </IfCondition>
+                </ConfigSection>
+                <!-- StrategicClouds Preset for Order Infused Stone is
+                     complete. -->
+
+
                 <!-- Starting Vanilla Preset for Order Infused Stone. -->
                 <ConfigSection>
                     <IfCondition condition=':= thm4OrderInfusedStoneDist = "Vanilla"'>
@@ -1210,6 +1767,107 @@
                 </ConfigSection>
                 <!-- SparseVeins Preset for Entropy Infused Stone is
                      complete. -->
+
+
+                <!-- Starting StrategicClouds Preset for Entropy
+                     Infused Stone. -->
+                <ConfigSection>
+                    <IfCondition condition=':= thm4EntropyInfusedStoneDist = "StrategicClouds"'>
+                        <Cloud name='thm4EntropyInfusedStoneCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60260920' drawBoundBox='false' boundBoxColor='0x60260920'>
+                            <Description>
+                                Large irregular clouds filled  lightly
+                                with ore.  These are  huge, spanning
+                                several adjacent  chunks, and
+                                consequently rather  rare.  They
+                                contain a sizeable  amount of ore, but
+                                it takes some  time and effort to mine
+                                due to  low density. The intent for
+                                strategic clouds is that the  player
+                                will need to actively  search for one
+                                and then set up a  semi-permanent
+                                mining base and  spend some time
+                                actually mining  the ore.
+                            </Description>
+                            <OreBlock block='Thaumcraft:blockCustomOre:6' weight='1.0' />
+                            <ReplacesOre block='stone' weight='1.0' />
+                            <Biome name='.*'  />
+                            <Setting name='CloudRadius' avg=':= 0.905 * _default_ * thm4EntropyInfusedStoneSize ' range=':= 0.905 * _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.905 * _default_ * thm4EntropyInfusedStoneSize ' range=':= 0.905 * _default_ * thm4EntropyInfusedStoneSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.818 * _default_ * thm4EntropyInfusedStoneFreq ' range=':= 0.818 * _default_ * thm4EntropyInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 32 ' range=':= 27 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Veins name='thm4EntropyInfusedStoneHintVeins' branchType='Bezier'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60260920' drawBoundBox='false' boundBoxColor='0x60260920'>
+                                <Description>
+                                    Single blocks, generously
+                                    scattered through all heights
+                                    (density is about that of  vanilla
+                                    iron ore). They will  replace dirt
+                                    and sandstone  (but not grass or
+                                    sand), so  they can be found
+                                    nearer to  the surface than most
+                                    ores.  Intened to be used as a
+                                    child  distribution for large,
+                                    rare  strategic deposits that
+                                    would  otherwise be very difficult
+                                    to find.  Note that the  frequency
+                                    is multiplied by  ground level to
+                                    maintain a  constant density, but
+                                    not by  ore frequency because it
+                                    is  assumed that the frequency of
+                                    the parent distribution will
+                                    already be scaled by that.
+                                </Description>
+                                <OreBlock block='Thaumcraft:blockCustomOre:6' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
+                                <ReplacesOre block='stone' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
+                            </Veins>
+                        </Cloud>
+
+                        <!-- Beginning "Preferred" configuration. -->
+                        <Cloud name='thm4EntropyInfusedStonePreferredCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60260920' drawBoundBox='false' boundBoxColor='0x60260920'>
+                            <Description>
+                                Ore generation is doubled in
+                                preferred biomes.
+                            </Description>
+                            <OreBlock block='Thaumcraft:blockCustomOre:6' weight='1.0' />
+                            <ReplacesOre block='stone' weight='1.0' />
+                            <BiomeType name='Swamp'  />
+                            <BiomeType name='Wasteland'  />
+                            <Setting name='CloudRadius' avg=':= 0.905 * _default_ * thm4EntropyInfusedStoneSize ' range=':= 0.905 * _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.905 * _default_ * thm4EntropyInfusedStoneSize ' range=':= 0.905 * _default_ * thm4EntropyInfusedStoneSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.818 * _default_ * thm4EntropyInfusedStoneFreq ' range=':= 0.818 * _default_ * thm4EntropyInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 32 ' range=':= 27 ' type='normal' scaleTo='base' />
+                            <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
+                            <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
+                            <Veins name='thm4EntropyInfusedStonePreferredHintVeins' branchType='Bezier'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60260920' drawBoundBox='false' boundBoxColor='0x60260920'>
+                                <Description>
+                                    Ore generation is doubled in
+                                    preferred biomes.
+                                </Description>
+                                <OreBlock block='Thaumcraft:blockCustomOre:6' weight='1.0' />
+                                <Replaces block='minecraft:dirt' weight='1.0' />
+                                <Replaces block='minecraft:sandstone' weight='1.0' />
+                                <ReplacesOre block='stone' weight='1.0' />
+                                <Replaces block='minecraft:gravel' weight='1.0' />
+                            </Veins>
+                        </Cloud>
+                        <!-- "Preferred" configuration complete. -->
+
+                    </IfCondition>
+                </ConfigSection>
+                <!-- StrategicClouds Preset for Entropy Infused Stone
+                     is complete. -->
 
 
                 <!-- Starting Vanilla Preset for Entropy Infused

--- a/src/main/resources/config/modules/TinkersConstruct.xml
+++ b/src/main/resources/config/modules/TinkersConstruct.xml
@@ -1644,7 +1644,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.084 * _default_ * ticoCobaltFreq ' range=':= 1.084 * _default_ * ticoCobaltFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.014 * _default_ * ticoCobaltSize ' range=':= 1.014 * _default_ * ticoCobaltSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64 ' range=':= 64 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 64 ' range=':= 64 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1688,7 +1688,7 @@
                             <Setting name='CloudRadius' avg=':= 0.995 * _default_ * ticoCobaltSize ' range=':= 0.995 * _default_ * ticoCobaltSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.995 * _default_ * ticoCobaltSize ' range=':= 0.995 * _default_ * ticoCobaltSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.990 * _default_ * ticoCobaltFreq ' range=':= 0.990 * _default_ * ticoCobaltFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64 ' range=':= 64 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64 ' range=':= 64 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1741,7 +1741,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 1.500 * ticoCobaltSize ' range=':= 1.500 * ticoCobaltSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 4.000 * ticoCobaltFreq ' range=':= 4.000 * ticoCobaltFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64 ' range=':= 64 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64 ' range=':= 64 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1768,7 +1768,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.084 * _default_ * ticoArditeFreq ' range=':= 1.084 * _default_ * ticoArditeFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.014 * _default_ * ticoArditeSize ' range=':= 1.014 * _default_ * ticoArditeSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64 ' range=':= 64 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 64 ' range=':= 64 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1812,7 +1812,7 @@
                             <Setting name='CloudRadius' avg=':= 0.995 * _default_ * ticoArditeSize ' range=':= 0.995 * _default_ * ticoArditeSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.995 * _default_ * ticoArditeSize ' range=':= 0.995 * _default_ * ticoArditeSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.990 * _default_ * ticoArditeFreq ' range=':= 0.990 * _default_ * ticoArditeFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64 ' range=':= 64 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64 ' range=':= 64 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1865,7 +1865,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 1.500 * ticoArditeSize ' range=':= 1.500 * ticoArditeSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 4.000 * ticoArditeFreq ' range=':= 4.000 * ticoArditeFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64 ' range=':= 64 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64 ' range=':= 64 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1892,18 +1892,18 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.084 * _default_ * ticoCobaltGravelFreq ' range=':= 1.084 * _default_ * ticoCobaltGravelFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.014 * _default_ * ticoCobaltGravelSize ' range=':= 1.014 * _default_ * ticoCobaltGravelSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64 ' range=':= 64 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 64 ' range=':= 64 ' type='uniform' scaleTo='base' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 1.041 * _default_ ' range=':= 1.041 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= 0 * _default_ ' range=':= 0 * _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * ticoCobaltGravelSize ' range=':= _default_ * ticoCobaltGravelSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentPitch' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 1.020 * _default_ * ticoCobaltGravelSize ' range=':= 1.020 * _default_ * ticoCobaltGravelSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0 * _default_ * ticoCobaltGravelSize ' range=':= 0 * _default_ * ticoCobaltGravelSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
@@ -1938,7 +1938,7 @@
                             <Setting name='CloudRadius' avg=':= 0.995 * _default_ * ticoCobaltGravelSize ' range=':= 0.995 * _default_ * ticoCobaltGravelSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.995 * _default_ * ticoCobaltGravelSize ' range=':= 0.995 * _default_ * ticoCobaltGravelSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.990 * _default_ * ticoCobaltGravelFreq ' range=':= 0.990 * _default_ * ticoCobaltGravelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64 ' range=':= 64 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64 ' range=':= 64 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1992,7 +1992,7 @@
                             <Biome name='.*'  />
                             <Setting name='Size' avg=':= 1.500 * ticoCobaltGravelSize ' range=':= 1.500 * ticoCobaltGravelSize ' type='normal' />
                             <Setting name='Frequency' avg=':= 4.000 * ticoCobaltGravelFreq ' range=':= 4.000 * ticoCobaltGravelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64 ' range=':= 64 ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64 ' range=':= 64 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>

--- a/src/main/resources/config/modules/VanillaMinecraft.xml
+++ b/src/main/resources/config/modules/VanillaMinecraft.xml
@@ -1447,7 +1447,7 @@
                     <Biome name='.*'  />
                     <Setting name='MotherlodeFrequency' avg=':= 6.247 * _default_ * vnlaNetherQuartzFreq ' range=':= 6.247 * _default_ * vnlaNetherQuartzFreq ' type='normal' scaleTo='base' />
                     <Setting name='MotherlodeSize' avg=':= 0 * _default_ * vnlaNetherQuartzSize ' range=':= 0 * _default_ * vnlaNetherQuartzSize ' type='normal' />
-                    <Setting name='MotherlodeHeight' avg=':= 59 ' range=':= 49 ' type='normal' scaleTo='base' />
+                    <Setting name='MotherlodeHeight' avg=':= 59 ' range=':= 49 ' type='uniform' scaleTo='base' />
                     <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1489,7 +1489,7 @@
                     <Setting name='CloudRadius' avg=':= 1.707 * _default_ * vnlaNetherQuartzSize ' range=':= 1.707 * _default_ * vnlaNetherQuartzSize ' type='normal' />
                     <Setting name='CloudThickness' avg=':= 1.707 * _default_ * vnlaNetherQuartzSize ' range=':= 1.707 * _default_ * vnlaNetherQuartzSize ' type='normal' scaleTo='base' />
                     <Setting name='DistributionFrequency' avg=':= 2.914 * _default_ * vnlaNetherQuartzFreq ' range=':= 2.914 * _default_ * vnlaNetherQuartzFreq ' type='normal' scaleTo='base' />
-                    <Setting name='CloudHeight' avg=':= 59 ' range=':= 49 ' type='normal' scaleTo='base' />
+                    <Setting name='CloudHeight' avg=':= 59 ' range=':= 49 ' type='uniform' scaleTo='base' />
                     <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1539,7 +1539,7 @@
                     <Biome name='.*'  />
                     <Setting name='Size' avg=':= 8.000 * vnlaNetherQuartzSize ' range=':= 8.000 * vnlaNetherQuartzSize ' type='normal' />
                     <Setting name='Frequency' avg=':= 6.500 * vnlaNetherQuartzFreq ' range=':= 6.500 * vnlaNetherQuartzFreq ' type='normal' scaleTo='base' />
-                    <Setting name='Height' avg=':= 59 ' range=':= 49 ' type='normal' scaleTo='base' />
+                    <Setting name='Height' avg=':= 59 ' range=':= 49 ' type='uniform' scaleTo='base' />
                     <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                 </StandardGen>
             </IfCondition>


### PR DESCRIPTION
* Ores with an average spawn height of >64 now use uniform distribution to prevent the bulk of ores from spawning in midair (which means that they won't spawn).
* ReactorCraft Fluorite ore has been heavily nerfed; each distribution is now 1/8 the size and frequency.  Now the ore is more in-line with the original spawn distribution, while keeping the veins single-color.
* Added Cloud distributions to Thaumcraft infused stone.
* Tweaked some other oregens.