### PR TITLE
Vanilla ranges updated

### DIFF
--- a/src/main/resources/config/modules/AppliedEnergistics.xml
+++ b/src/main/resources/config/modules/AppliedEnergistics.xml
@@ -136,7 +136,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 3.355 * _default_ * apenCertusQuartzFreq ' range=':= 3.355 * _default_ * apenCertusQuartzFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * apenCertusQuartzSize ' range=':= 0 * _default_ * apenCertusQuartzSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 43 ' range=':= 26 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 43 ' range=':= 26 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -182,7 +182,7 @@
                             <Setting name='CloudRadius' avg=':= 1.251 * _default_ * apenCertusQuartzSize ' range=':= 1.251 * _default_ * apenCertusQuartzSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.251 * _default_ * apenCertusQuartzSize ' range=':= 1.251 * _default_ * apenCertusQuartzSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.565 * _default_ * apenCertusQuartzFreq ' range=':= 1.565 * _default_ * apenCertusQuartzFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 43 ' range=':= 26 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 43 ' range=':= 26 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -236,9 +236,9 @@
                             <OreBlock block='appliedenergistics2:tile.OreQuartzCharged' weight='0.10' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 2.000 * apenCertusQuartzSize ' range=':= 2.000 * apenCertusQuartzSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 7.500 * apenCertusQuartzFreq ' range=':= 7.500 * apenCertusQuartzFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 43 ' range=':= 26 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.667 * apenCertusQuartzSize ' range=':= 1.33 * apenCertusQuartzSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 10.0 * apenCertusQuartzFreq ' range=':= 5.0 * apenCertusQuartzFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 43 ' range=':= 26 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>

--- a/src/main/resources/config/modules/ArsMagica2.xml
+++ b/src/main/resources/config/modules/ArsMagica2.xml
@@ -226,7 +226,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.122 * _default_ * arsmVinteumFreq ' range=':= 2.122 * _default_ * arsmVinteumFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * arsmVinteumSize ' range=':= 0 * _default_ * arsmVinteumSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 27.5 ' range=':= 17.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 27.5 ' range=':= 17.5 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -270,7 +270,7 @@
                             <Setting name='CloudRadius' avg=':= 0.995 * _default_ * arsmVinteumSize ' range=':= 0.995 * _default_ * arsmVinteumSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.995 * _default_ * arsmVinteumSize ' range=':= 0.995 * _default_ * arsmVinteumSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.990 * _default_ * arsmVinteumFreq ' range=':= 0.990 * _default_ * arsmVinteumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 27.5 ' range=':= 17.5 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 27.5 ' range=':= 17.5 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -321,9 +321,9 @@
                             <OreBlock block='arsmagica2:vinteumOre' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 2.000 * arsmVinteumSize ' range=':= 2.000 * arsmVinteumSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 3.000 * arsmVinteumFreq ' range=':= 3.000 * arsmVinteumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 27.5 ' range=':= 17.5 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.667 * arsmVinteumSize ' range=':= 1.33 * arsmVinteumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4.0 * arsmVinteumFreq ' range=':= 2.0 * arsmVinteumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 27.5 ' range=':= 17.5 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -355,7 +355,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 3.001 * _default_ * arsmChimeriteFreq ' range=':= 3.001 * _default_ * arsmChimeriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * arsmChimeriteSize ' range=':= 0 * _default_ * arsmChimeriteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 45 ' range=':= 35 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 45 ' range=':= 35 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -399,7 +399,7 @@
                             <Setting name='CloudRadius' avg=':= 1.183 * _default_ * arsmChimeriteSize ' range=':= 1.183 * _default_ * arsmChimeriteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.183 * _default_ * arsmChimeriteSize ' range=':= 1.183 * _default_ * arsmChimeriteSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.400 * _default_ * arsmChimeriteFreq ' range=':= 1.400 * _default_ * arsmChimeriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 45 ' range=':= 35 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 45 ' range=':= 35 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -450,9 +450,9 @@
                             <OreBlock block='arsmagica2:vinteumOre:1' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3.000 * arsmChimeriteSize ' range=':= 3.000 * arsmChimeriteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 4.000 * arsmChimeriteFreq ' range=':= 4.000 * arsmChimeriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 45 ' range=':= 35 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.0 * arsmChimeriteSize ' range=':= 2.0 * arsmChimeriteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 5.333 * arsmChimeriteFreq ' range=':= 2.67 * arsmChimeriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 45 ' range=':= 35 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -484,7 +484,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 3.001 * _default_ * arsmBlueTopazFreq ' range=':= 3.001 * _default_ * arsmBlueTopazFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * arsmBlueTopazSize ' range=':= 0 * _default_ * arsmBlueTopazSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 45 ' range=':= 35 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 45 ' range=':= 35 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -528,7 +528,7 @@
                             <Setting name='CloudRadius' avg=':= 1.183 * _default_ * arsmBlueTopazSize ' range=':= 1.183 * _default_ * arsmBlueTopazSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.183 * _default_ * arsmBlueTopazSize ' range=':= 1.183 * _default_ * arsmBlueTopazSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.400 * _default_ * arsmBlueTopazFreq ' range=':= 1.400 * _default_ * arsmBlueTopazFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 45 ' range=':= 35 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 45 ' range=':= 35 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -580,9 +580,9 @@
                             <OreBlock block='arsmagica2:vinteumOre:2' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3.000 * arsmBlueTopazSize ' range=':= 3.000 * arsmBlueTopazSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 4.000 * arsmBlueTopazFreq ' range=':= 4.000 * arsmBlueTopazFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 45 ' range=':= 35 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.0 * arsmBlueTopazSize ' range=':= 2.0 * arsmBlueTopazSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 5.333 * arsmBlueTopazFreq ' range=':= 2.67 * arsmBlueTopazFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 45 ' range=':= 35 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>

--- a/src/main/resources/config/modules/BiomesOPlenty.xml
+++ b/src/main/resources/config/modules/BiomesOPlenty.xml
@@ -1,6 +1,6 @@
 <!-- =================================================================
      Custom Ore Generation "Biomes O Plenty" Module: This
-     configuration covers amathyst, ruby, peridot, topaz, tanzanite,
+     configuration covers amethyst, ruby, peridot, topaz, tanzanite,
      malachite, sapphire, and amber.
      ================================================================= -->
 
@@ -34,11 +34,11 @@
                 <Choice value=':= ?false' displayValue='No' description='Biomes O Plenty ores will be handled by the mod itself.'/>
             </OptionChoice>
 
-            <!-- Amathyst Configuration UI Starting -->
+            <!-- Amethyst Configuration UI Starting -->
             <ConfigSection>
-                <OptionChoice name='boplAmathystDist'  displayState=':= if(?enableBiomesOPlenty, "shown", "hidden")' displayGroup='groupBiomesOPlenty'>
-                    <Description> Controls how Amathyst is generated </Description>
-                    <DisplayName>Biomes O Plenty Amathyst</DisplayName>
+                <OptionChoice name='boplAmethystDist'  displayState=':= if(?enableBiomesOPlenty, "shown", "hidden")' displayGroup='groupBiomesOPlenty'>
+                    <Description> Controls how Amethyst is generated </Description>
+                    <DisplayName>Biomes O Plenty Amethyst</DisplayName>
                     <IfCondition condition=':= (?blockExists("BiomesOPlenty:gemOre")) &amp; (?blockExists("minecraft:lava")) '>
 
                     <Choice value='PipeVeins' displayValue='Pipe Veins'>
@@ -66,18 +66,18 @@
                     </Choice>
                     </IfCondition>
 
-                    <Choice value='none' displayValue='None' description='Amathyst is not generated in the world.'/>
+                    <Choice value='none' displayValue='None' description='Amethyst is not generated in the world.'/>
                 </OptionChoice>
-                <OptionNumeric name='boplAmathystFreq' default='1'  min='0' max='5' displayState=':= if(?enableBiomesOPlenty, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupBiomesOPlenty'>
-                    <Description> Frequency multiplier for Biomes O Plenty Amathyst distributions </Description>
-                    <DisplayName>Biomes O Plenty Amathyst Freq.</DisplayName>
+                <OptionNumeric name='boplAmethystFreq' default='1'  min='0' max='5' displayState=':= if(?enableBiomesOPlenty, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupBiomesOPlenty'>
+                    <Description> Frequency multiplier for Biomes O Plenty Amethyst distributions </Description>
+                    <DisplayName>Biomes O Plenty Amethyst Freq.</DisplayName>
                 </OptionNumeric>
-                <OptionNumeric name='boplAmathystSize' default='1'  min='0' max='5' displayState=':= if(?enableBiomesOPlenty, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupBiomesOPlenty'>
-                    <Description> Size multiplier for Biomes O Plenty Amathyst distributions </Description>
-                    <DisplayName>Biomes O Plenty Amathyst Size</DisplayName>
+                <OptionNumeric name='boplAmethystSize' default='1'  min='0' max='5' displayState=':= if(?enableBiomesOPlenty, if(?advOptions, "shown", "hidden"), "hidden")' displayGroup='groupBiomesOPlenty'>
+                    <Description> Size multiplier for Biomes O Plenty Amethyst distributions </Description>
+                    <DisplayName>Biomes O Plenty Amethyst Size</DisplayName>
                 </OptionNumeric>
             </ConfigSection>
-            <!-- Amathyst Configuration UI Complete -->
+            <!-- Amethyst Configuration UI Complete -->
 
 
             <!-- Ruby Configuration UI Starting -->
@@ -454,7 +454,7 @@
                             <BiomeType name='Desert'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.270 * _default_ * boplRubyFreq ' range=':= 0.270 * _default_ * boplRubyFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * boplRubySize ' range=':= 0 * _default_ * boplRubySize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -508,7 +508,7 @@
                             <Setting name='CloudRadius' avg=':= 0.449 * _default_ * boplRubySize ' range=':= 0.449 * _default_ * boplRubySize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.449 * _default_ * boplRubySize ' range=':= 0.449 * _default_ * boplRubySize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.202 * _default_ * boplRubyFreq ' range=':= 0.202 * _default_ * boplRubyFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -559,9 +559,9 @@
                             <OreBlock block='BiomesOPlenty:gemOre:2' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Desert'  />
-                            <Setting name='Size' avg=':= 0.500 * boplRubySize ' range=':= 0.500 * boplRubySize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 0.500 * boplRubyFreq ' range=':= 0.500 * boplRubyFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 0.667 * boplRubySize ' range=':= 0.33 * boplRubySize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 0.667 * boplRubyFreq ' range=':= 0.33 * boplRubyFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -586,7 +586,7 @@
                             <BiomeType name='Plains'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.270 * _default_ * boplPeridotFreq ' range=':= 0.270 * _default_ * boplPeridotFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * boplPeridotSize ' range=':= 0 * _default_ * boplPeridotSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -640,7 +640,7 @@
                             <Setting name='CloudRadius' avg=':= 0.449 * _default_ * boplPeridotSize ' range=':= 0.449 * _default_ * boplPeridotSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.449 * _default_ * boplPeridotSize ' range=':= 0.449 * _default_ * boplPeridotSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.202 * _default_ * boplPeridotFreq ' range=':= 0.202 * _default_ * boplPeridotFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -691,9 +691,9 @@
                             <OreBlock block='BiomesOPlenty:gemOre:4' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Plains'  />
-                            <Setting name='Size' avg=':= 0.500 * boplPeridotSize ' range=':= 0.500 * boplPeridotSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 0.500 * boplPeridotFreq ' range=':= 0.500 * boplPeridotFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 0.667 * boplPeridotSize ' range=':= 0.33 * boplPeridotSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 0.667 * boplPeridotFreq ' range=':= 0.33 * boplPeridotFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -718,7 +718,7 @@
                             <BiomeType name='Jungle'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.270 * _default_ * boplTopazFreq ' range=':= 0.270 * _default_ * boplTopazFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * boplTopazSize ' range=':= 0 * _default_ * boplTopazSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -772,7 +772,7 @@
                             <Setting name='CloudRadius' avg=':= 0.449 * _default_ * boplTopazSize ' range=':= 0.449 * _default_ * boplTopazSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.449 * _default_ * boplTopazSize ' range=':= 0.449 * _default_ * boplTopazSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.202 * _default_ * boplTopazFreq ' range=':= 0.202 * _default_ * boplTopazFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -823,9 +823,9 @@
                             <OreBlock block='BiomesOPlenty:gemOre:6' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Jungle'  />
-                            <Setting name='Size' avg=':= 0.500 * boplTopazSize ' range=':= 0.500 * boplTopazSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 0.500 * boplTopazFreq ' range=':= 0.500 * boplTopazFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 0.667 * boplTopazSize ' range=':= 0.33 * boplTopazSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 0.667 * boplTopazFreq ' range=':= 0.33 * boplTopazFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -852,7 +852,7 @@
                             <Biome name='Alps Forest'  weight='-1' />
                             <Setting name='MotherlodeFrequency' avg=':= 0.270 * _default_ * boplTanzaniteFreq ' range=':= 0.270 * _default_ * boplTanzaniteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * boplTanzaniteSize ' range=':= 0 * _default_ * boplTanzaniteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -908,7 +908,7 @@
                             <Setting name='CloudRadius' avg=':= 0.449 * _default_ * boplTanzaniteSize ' range=':= 0.449 * _default_ * boplTanzaniteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.449 * _default_ * boplTanzaniteSize ' range=':= 0.449 * _default_ * boplTanzaniteSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.202 * _default_ * boplTanzaniteFreq ' range=':= 0.202 * _default_ * boplTanzaniteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -961,9 +961,9 @@
                             <BiomeType name='Frozen'  />
                             <Biome name='Alps'  weight='-1' />
                             <Biome name='Alps Forest'  weight='-1' />
-                            <Setting name='Size' avg=':= 0.500 * boplTanzaniteSize ' range=':= 0.500 * boplTanzaniteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 0.500 * boplTanzaniteFreq ' range=':= 0.500 * boplTanzaniteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 0.667 * boplTanzaniteSize ' range=':= 0.33 * boplTanzaniteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 0.667 * boplTanzaniteFreq ' range=':= 0.33 * boplTanzaniteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -988,7 +988,7 @@
                             <BiomeType name='Swamp'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.270 * _default_ * boplMalachiteFreq ' range=':= 0.270 * _default_ * boplMalachiteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * boplMalachiteSize ' range=':= 0 * _default_ * boplMalachiteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1042,7 +1042,7 @@
                             <Setting name='CloudRadius' avg=':= 0.449 * _default_ * boplMalachiteSize ' range=':= 0.449 * _default_ * boplMalachiteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.449 * _default_ * boplMalachiteSize ' range=':= 0.449 * _default_ * boplMalachiteSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.202 * _default_ * boplMalachiteFreq ' range=':= 0.202 * _default_ * boplMalachiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1093,9 +1093,9 @@
                             <OreBlock block='BiomesOPlenty:gemOre:10' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Swamp'  />
-                            <Setting name='Size' avg=':= 0.500 * boplMalachiteSize ' range=':= 0.500 * boplMalachiteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 0.500 * boplMalachiteFreq ' range=':= 0.500 * boplMalachiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 0.667 * boplMalachiteSize ' range=':= 0.33 * boplMalachiteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 0.667 * boplMalachiteFreq ' range=':= 0.33 * boplMalachiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1126,7 +1126,7 @@
                             <Biome name='Tropics'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.270 * _default_ * boplSapphireFreq ' range=':= 0.270 * _default_ * boplSapphireFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * boplSapphireSize ' range=':= 0 * _default_ * boplSapphireSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1186,7 +1186,7 @@
                             <Setting name='CloudRadius' avg=':= 0.449 * _default_ * boplSapphireSize ' range=':= 0.449 * _default_ * boplSapphireSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.449 * _default_ * boplSapphireSize ' range=':= 0.449 * _default_ * boplSapphireSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.202 * _default_ * boplSapphireFreq ' range=':= 0.202 * _default_ * boplSapphireFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1243,9 +1243,9 @@
                             <Biome name='Mangrove'  />
                             <Biome name='Sacred Springs'  />
                             <Biome name='Tropics'  />
-                            <Setting name='Size' avg=':= 0.500 * boplSapphireSize ' range=':= 0.500 * boplSapphireSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 0.500 * boplSapphireFreq ' range=':= 0.500 * boplSapphireFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 0.667 * boplSapphireSize ' range=':= 0.33 * boplSapphireSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 0.667 * boplSapphireFreq ' range=':= 0.33 * boplSapphireFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1273,7 +1273,7 @@
                             <Biome name='Thicket'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.270 * _default_ * boplAmberFreq ' range=':= 0.270 * _default_ * boplAmberFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * boplAmberSize ' range=':= 0 * _default_ * boplAmberSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1330,7 +1330,7 @@
                             <Setting name='CloudRadius' avg=':= 0.449 * _default_ * boplAmberSize ' range=':= 0.449 * _default_ * boplAmberSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.449 * _default_ * boplAmberSize ' range=':= 0.449 * _default_ * boplAmberSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.202 * _default_ * boplAmberFreq ' range=':= 0.202 * _default_ * boplAmberFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1384,9 +1384,9 @@
                             <Biome name='Grove'  />
                             <Biome name='Shield'  />
                             <Biome name='Thicket'  />
-                            <Setting name='Size' avg=':= 0.500 * boplAmberSize ' range=':= 0.500 * boplAmberSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 0.500 * boplAmberFreq ' range=':= 0.500 * boplAmberFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 0.667 * boplAmberSize ' range=':= 0.33 * boplAmberSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 0.667 * boplAmberFreq ' range=':= 0.33 * boplAmberFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1429,12 +1429,12 @@
 
                 <!-- Adding blocks -->
 
-                <!-- Begin Amathyst Generation -->
+                <!-- Begin Amethyst Generation -->
 
-                <!-- Starting PipeVeins Preset for Amathyst. -->
+                <!-- Starting PipeVeins Preset for Amethyst. -->
                 <ConfigSection>
-                    <IfCondition condition=':= boplAmathystDist = "PipeVeins"'>
-                        <Veins name='boplAmathystVeins'  inherits='PresetPipeVeins' branchType='Bezier' seed='0x58D8' drawWireframe='true' wireframeColor='0x60DD4EEA' drawBoundBox='false' boundBoxColor='0x60DD4EEA'>
+                    <IfCondition condition=':= boplAmethystDist = "PipeVeins"'>
+                        <Veins name='boplAmethystVeins'  inherits='PresetPipeVeins' branchType='Bezier' seed='0x58D8' drawWireframe='true' wireframeColor='0x60DD4EEA' drawBoundBox='false' boundBoxColor='0x60DD4EEA'>
                             <Description>
                                 Short sparsely filled veins  sloping
                                 up from near the bottom  of the map.
@@ -1442,9 +1442,9 @@
                             <OreBlock block='BiomesOPlenty:gemOre' weight='1.0' />
                             <Replaces block='minecraft:end_stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='MotherlodeFrequency' avg=':= 0.270 * _default_ * boplAmathystFreq ' range=':= 0.270 * _default_ * boplAmathystFreq ' type='normal' scaleTo='base' />
-                            <Setting name='MotherlodeSize' avg=':= 0 * _default_ * boplAmathystSize ' range=':= 0 * _default_ * boplAmathystSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 19 ' range=':= 13 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeFrequency' avg=':= 0.270 * _default_ * boplAmethystFreq ' range=':= 0.270 * _default_ * boplAmethystFreq ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * _default_ * boplAmethystSize ' range=':= 0 * _default_ * boplAmethystSize ' type='normal' />
+                            <Setting name='MotherlodeHeight' avg=':= 19 ' range=':= 13 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1452,32 +1452,32 @@
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentLength' avg=':= _default_ * boplAmathystSize ' range=':= _default_ * boplAmathystSize ' type='normal' />
+                            <Setting name='SegmentLength' avg=':= _default_ * boplAmethystSize ' range=':= _default_ * boplAmethystSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentPitch' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.721 * _default_ * boplAmathystSize ' range=':= 0.721 * _default_ * boplAmathystSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.721 * _default_ * boplAmethystSize ' range=':= 0.721 * _default_ * boplAmethystSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
 
                         <!-- Configuring contained material. -->
-                        <Veins name='boplAmathystVeinsPipe'  inherits='boplAmathystVeins' branchType='Bezier' seed='0x58D8' drawWireframe='true' wireframeColor='0x60DD4EEA' drawBoundBox='false' boundBoxColor='0x60DD4EEA'>
+                        <Veins name='boplAmethystVeinsPipe'  inherits='boplAmethystVeins' branchType='Bezier' seed='0x58D8' drawWireframe='true' wireframeColor='0x60DD4EEA' drawBoundBox='false' boundBoxColor='0x60DD4EEA'>
                             <OreBlock block='minecraft:lava' weight='1.0' />
                             <Replaces block='minecraft:end_stone' weight='1.0' />
                             <Replaces block='BiomesOPlenty:gemOre' weight='1.0' />
-                            <Setting name='MotherlodeSize' avg=':= 0 * _default_ * boplAmathystSize  * 0.5 ' range=':= 0 * _default_ * boplAmathystSize  * 0.5 ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.721 * _default_ * boplAmathystSize  * 0.5 ' range=':= 0.721 * _default_ * boplAmathystSize  * 0.5 ' type='normal' />
+                            <Setting name='MotherlodeSize' avg=':= 0 * _default_ * boplAmethystSize  * 0.5 ' range=':= 0 * _default_ * boplAmethystSize  * 0.5 ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.721 * _default_ * boplAmethystSize  * 0.5 ' range=':= 0.721 * _default_ * boplAmethystSize  * 0.5 ' type='normal' />
                             <Setting name='OreDensity' avg=':= 1.0 ' range=':= 0 ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
-                <!-- PipeVeins Preset for Amathyst is complete. -->
+                <!-- PipeVeins Preset for Amethyst is complete. -->
 
 
-                <!-- Starting StrategicClouds Preset for Amathyst. -->
+                <!-- Starting StrategicClouds Preset for Amethyst. -->
                 <ConfigSection>
-                    <IfCondition condition=':= boplAmathystDist = "StrategicClouds"'>
-                        <Cloud name='boplAmathystCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60DD4EEA' drawBoundBox='false' boundBoxColor='0x60DD4EEA'>
+                    <IfCondition condition=':= boplAmethystDist = "StrategicClouds"'>
+                        <Cloud name='boplAmethystCloud'  inherits='PresetStrategicCloud' drawWireframe='true' wireframeColor='0x60DD4EEA' drawBoundBox='false' boundBoxColor='0x60DD4EEA'>
                             <Description>
                                 Large irregular clouds filled  lightly
                                 with ore.  These are  huge, spanning
@@ -1495,17 +1495,17 @@
                             <OreBlock block='BiomesOPlenty:gemOre' weight='1.0' />
                             <Replaces block='minecraft:end_stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='CloudRadius' avg=':= 0.449 * _default_ * boplAmathystSize ' range=':= 0.449 * _default_ * boplAmathystSize ' type='normal' />
-                            <Setting name='CloudThickness' avg=':= 0.449 * _default_ * boplAmathystSize ' range=':= 0.449 * _default_ * boplAmathystSize ' type='normal' scaleTo='base' />
-                            <Setting name='DistributionFrequency' avg=':= 0.202 * _default_ * boplAmathystFreq ' range=':= 0.202 * _default_ * boplAmathystFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 19 ' range=':= 13 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudRadius' avg=':= 0.449 * _default_ * boplAmethystSize ' range=':= 0.449 * _default_ * boplAmethystSize ' type='normal' />
+                            <Setting name='CloudThickness' avg=':= 0.449 * _default_ * boplAmethystSize ' range=':= 0.449 * _default_ * boplAmethystSize ' type='normal' scaleTo='base' />
+                            <Setting name='DistributionFrequency' avg=':= 0.202 * _default_ * boplAmethystFreq ' range=':= 0.202 * _default_ * boplAmethystFreq ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 19 ' range=':= 13 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='OreVolumeNoiseCutoff' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Veins name='boplAmathystHintVeins' branchType='Bezier'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60DD4EEA' drawBoundBox='false' boundBoxColor='0x60DD4EEA'>
+                            <Veins name='boplAmethystHintVeins' branchType='Bezier'  inherits='PresetHintVeins' drawWireframe='true' wireframeColor='0x60DD4EEA' drawBoundBox='false' boundBoxColor='0x60DD4EEA'>
                                 <Description>
                                     Single blocks, generously
                                     scattered through all heights
@@ -1535,13 +1535,13 @@
                         </Cloud>
                     </IfCondition>
                 </ConfigSection>
-                <!-- StrategicClouds Preset for Amathyst is complete. -->
+                <!-- StrategicClouds Preset for Amethyst is complete. -->
 
 
-                <!-- Starting Vanilla Preset for Amathyst. -->
+                <!-- Starting Vanilla Preset for Amethyst. -->
                 <ConfigSection>
-                    <IfCondition condition=':= boplAmathystDist = "Vanilla"'>
-                        <StandardGen name='boplAmathystStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60DD4EEA' drawBoundBox='false' boundBoxColor='0x60DD4EEA'>
+                    <IfCondition condition=':= boplAmethystDist = "Vanilla"'>
+                        <StandardGen name='boplAmethystStandard'  inherits='PresetStandardGen' drawWireframe='true' wireframeColor='0x60DD4EEA' drawBoundBox='false' boundBoxColor='0x60DD4EEA'>
                             <Description>
                                 A master preset for standardgen  ore
                                 distributions.
@@ -1549,16 +1549,16 @@
                             <OreBlock block='BiomesOPlenty:gemOre' weight='1.0' />
                             <Replaces block='minecraft:end_stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 0.500 * boplAmathystSize ' range=':= 0.500 * boplAmathystSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 0.500 * boplAmathystFreq ' range=':= 0.500 * boplAmathystFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 19 ' range=':= 13 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 0.667 * boplAmethystSize ' range=':= 0.33 * boplAmethystSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 0.667 * boplAmethystFreq ' range=':= 0.33 * boplAmethystFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 19 ' range=':= 13 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
                 </ConfigSection>
-                <!-- Vanilla Preset for Amathyst is complete. -->
+                <!-- Vanilla Preset for Amethyst is complete. -->
 
-                <!-- End Amathyst Generation -->
+                <!-- End Amethyst Generation -->
 
                 <!-- Finished adding blocks -->
 

--- a/src/main/resources/config/modules/Chisel2.xml
+++ b/src/main/resources/config/modules/Chisel2.xml
@@ -317,7 +317,7 @@
                             <Setting name='CloudRadius' avg=':= 1.156 * _default_ * chslAndesiteSize ' range=':= 1.156 * _default_ * chslAndesiteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.156 * _default_ * chslAndesiteSize ' range=':= 1.156 * _default_ * chslAndesiteSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.336 * _default_ * chslAndesiteFreq ' range=':= 1.336 * _default_ * chslAndesiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -343,7 +343,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.002 * _default_ * chslAndesiteFreq ' range=':= 2.002 * _default_ * chslAndesiteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.123 * _default_ * chslAndesiteSize ' range=':= 1.123 * _default_ * chslAndesiteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -374,9 +374,9 @@
                             <OreBlock block='chisel:andesite' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 8.000 * chslAndesiteSize ' range=':= 8.000 * chslAndesiteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 4.000 * chslAndesiteFreq ' range=':= 4.000 * chslAndesiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 10.667 * chslAndesiteSize ' range=':= 5.33 * chslAndesiteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 5.333 * chslAndesiteFreq ' range=':= 2.67 * chslAndesiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -404,7 +404,7 @@
                             <Setting name='CloudRadius' avg=':= 1.156 * _default_ * chslDioriteSize ' range=':= 1.156 * _default_ * chslDioriteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.156 * _default_ * chslDioriteSize ' range=':= 1.156 * _default_ * chslDioriteSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.336 * _default_ * chslDioriteFreq ' range=':= 1.336 * _default_ * chslDioriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -430,7 +430,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.002 * _default_ * chslDioriteFreq ' range=':= 2.002 * _default_ * chslDioriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.123 * _default_ * chslDioriteSize ' range=':= 1.123 * _default_ * chslDioriteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -461,9 +461,9 @@
                             <OreBlock block='chisel:diorite' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 8.000 * chslDioriteSize ' range=':= 8.000 * chslDioriteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 4.000 * chslDioriteFreq ' range=':= 4.000 * chslDioriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 10.667 * chslDioriteSize ' range=':= 5.33 * chslDioriteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 5.333 * chslDioriteFreq ' range=':= 2.67 * chslDioriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -491,7 +491,7 @@
                             <Setting name='CloudRadius' avg=':= 1.156 * _default_ * chslGraniteSize ' range=':= 1.156 * _default_ * chslGraniteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.156 * _default_ * chslGraniteSize ' range=':= 1.156 * _default_ * chslGraniteSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.336 * _default_ * chslGraniteFreq ' range=':= 1.336 * _default_ * chslGraniteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -517,7 +517,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.002 * _default_ * chslGraniteFreq ' range=':= 2.002 * _default_ * chslGraniteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.123 * _default_ * chslGraniteSize ' range=':= 1.123 * _default_ * chslGraniteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -548,9 +548,9 @@
                             <OreBlock block='chisel:granite' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 8.000 * chslGraniteSize ' range=':= 8.000 * chslGraniteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 4.000 * chslGraniteFreq ' range=':= 4.000 * chslGraniteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 10.667 * chslGraniteSize ' range=':= 5.33 * chslGraniteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 5.333 * chslGraniteFreq ' range=':= 2.67 * chslGraniteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -578,7 +578,7 @@
                             <Setting name='CloudRadius' avg=':= 1.252 * _default_ * chslLimestoneSize ' range=':= 1.252 * _default_ * chslLimestoneSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.252 * _default_ * chslLimestoneSize ' range=':= 1.252 * _default_ * chslLimestoneSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.567 * _default_ * chslLimestoneFreq ' range=':= 1.567 * _default_ * chslLimestoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -604,7 +604,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.348 * _default_ * chslLimestoneFreq ' range=':= 2.348 * _default_ * chslLimestoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.153 * _default_ * chslLimestoneSize ' range=':= 1.153 * _default_ * chslLimestoneSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -635,9 +635,9 @@
                             <OreBlock block='chisel:limestone' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 11.000 * chslLimestoneSize ' range=':= 11.000 * chslLimestoneSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 4.000 * chslLimestoneFreq ' range=':= 4.000 * chslLimestoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 14.667 * chslLimestoneSize ' range=':= 7.33 * chslLimestoneSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 5.333 * chslLimestoneFreq ' range=':= 2.67 * chslLimestoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -665,7 +665,7 @@
                             <Setting name='CloudRadius' avg=':= 1.211 * _default_ * chslMarbleSize ' range=':= 1.211 * _default_ * chslMarbleSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.211 * _default_ * chslMarbleSize ' range=':= 1.211 * _default_ * chslMarbleSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.466 * _default_ * chslMarbleFreq ' range=':= 1.466 * _default_ * chslMarbleFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -691,7 +691,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.196 * _default_ * chslMarbleFreq ' range=':= 2.196 * _default_ * chslMarbleFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.140 * _default_ * chslMarbleSize ' range=':= 1.140 * _default_ * chslMarbleSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -722,9 +722,9 @@
                             <OreBlock block='chisel:marble' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 11.000 * chslMarbleSize ' range=':= 11.000 * chslMarbleSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 3.500 * chslMarbleFreq ' range=':= 3.500 * chslMarbleFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 14.667 * chslMarbleSize ' range=':= 7.33 * chslMarbleSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4.667 * chslMarbleFreq ' range=':= 2.33 * chslMarbleFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>

--- a/src/main/resources/config/modules/DenseOres.xml
+++ b/src/main/resources/config/modules/DenseOres.xml
@@ -469,7 +469,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 7.748 * _default_ * dnsoCoalFreq ' range=':= 7.748 * _default_ * dnsoCoalFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * dnsoCoalSize ' range=':= 0 * _default_ * dnsoCoalSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64 ' range=':= 64 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 64 ' range=':= 64 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -514,7 +514,7 @@
                             <Setting name='CloudRadius' avg=':= 1.901 * _default_ * dnsoCoalSize ' range=':= 1.901 * _default_ * dnsoCoalSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.901 * _default_ * dnsoCoalSize ' range=':= 1.901 * _default_ * dnsoCoalSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 3.614 * _default_ * dnsoCoalFreq ' range=':= 3.614 * _default_ * dnsoCoalFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64 ' range=':= 64 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64 ' range=':= 64 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -567,9 +567,9 @@
                             <OreBlock block='denseores:block0:6' weight='0.1' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 8.000 * dnsoCoalSize ' range=':= 8.000 * dnsoCoalSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 10.000 * dnsoCoalFreq ' range=':= 10.000 * dnsoCoalFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64 ' range=':= 64 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 10.667 * dnsoCoalSize ' range=':= 5.33 * dnsoCoalSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 13.333 * dnsoCoalFreq ' range=':= 6.67 * dnsoCoalFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64 ' range=':= 64 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -595,7 +595,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.238 * _default_ * dnsoIronFreq ' range=':= 2.238 * _default_ * dnsoIronFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.144 * _default_ * dnsoIronSize ' range=':= 1.144 * _default_ * dnsoIronSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 32 ' range=':= 32 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 32 ' range=':= 32 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -640,7 +640,7 @@
                             <Setting name='CloudRadius' avg=':= 1.599 * _default_ * dnsoIronSize ' range=':= 1.599 * _default_ * dnsoIronSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.599 * _default_ * dnsoIronSize ' range=':= 1.599 * _default_ * dnsoIronSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 2.556 * _default_ * dnsoIronFreq ' range=':= 2.556 * _default_ * dnsoIronFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 32 ' range=':= 32 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 32 ' range=':= 32 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -693,9 +693,9 @@
                             <OreBlock block='denseores:block0' weight='0.1' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.000 * dnsoIronSize ' range=':= 4.000 * dnsoIronSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 10.000 * dnsoIronFreq ' range=':= 10.000 * dnsoIronFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 32 ' range=':= 32 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 5.333 * dnsoIronSize ' range=':= 2.67 * dnsoIronSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 13.333 * dnsoIronFreq ' range=':= 6.67 * dnsoIronFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 32 ' range=':= 32 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -721,7 +721,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.708 * _default_ * dnsoGoldFreq ' range=':= 0.708 * _default_ * dnsoGoldFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.944 * _default_ * dnsoGoldSize ' range=':= 0.944 * _default_ * dnsoGoldSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 16 ' range=':= 16 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 16 ' range=':= 16 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -766,7 +766,7 @@
                             <Setting name='CloudRadius' avg=':= 0.899 * _default_ * dnsoGoldSize ' range=':= 0.899 * _default_ * dnsoGoldSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.899 * _default_ * dnsoGoldSize ' range=':= 0.899 * _default_ * dnsoGoldSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.808 * _default_ * dnsoGoldFreq ' range=':= 0.808 * _default_ * dnsoGoldFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 16 ' range=':= 16 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 16 ' range=':= 16 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -819,9 +819,9 @@
                             <OreBlock block='denseores:block0:1' weight='0.1' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.000 * dnsoGoldSize ' range=':= 4.000 * dnsoGoldSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.000 * dnsoGoldFreq ' range=':= 1.000 * dnsoGoldFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 16 ' range=':= 16 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 5.333 * dnsoGoldSize ' range=':= 2.67 * dnsoGoldSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.333 * dnsoGoldFreq ' range=':= 0.67 * dnsoGoldFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 16 ' range=':= 16 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -847,7 +847,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.406 * _default_ * dnsoRedstoneFreq ' range=':= 2.406 * _default_ * dnsoRedstoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * dnsoRedstoneSize ' range=':= 0 * _default_ * dnsoRedstoneSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 8 ' range=':= 8 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 8 ' range=':= 8 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= -_default_ ' range=':= -_default_ ' type='normal' />
@@ -892,7 +892,7 @@
                             <Setting name='CloudRadius' avg=':= 1.230 * _default_ * dnsoRedstoneSize ' range=':= 1.230 * _default_ * dnsoRedstoneSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.230 * _default_ * dnsoRedstoneSize ' range=':= 1.230 * _default_ * dnsoRedstoneSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.512 * _default_ * dnsoRedstoneFreq ' range=':= 1.512 * _default_ * dnsoRedstoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 8 ' range=':= 8 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 8 ' range=':= 8 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -945,9 +945,9 @@
                             <OreBlock block='denseores:block0:5' weight='0.1' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3.500 * dnsoRedstoneSize ' range=':= 3.500 * dnsoRedstoneSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 4.000 * dnsoRedstoneFreq ' range=':= 4.000 * dnsoRedstoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 8 ' range=':= 8 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.667 * dnsoRedstoneSize ' range=':= 2.33 * dnsoRedstoneSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 5.333 * dnsoRedstoneFreq ' range=':= 2.67 * dnsoRedstoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 8 ' range=':= 8 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -973,7 +973,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.714 * _default_ * dnsoDiamondFreq ' range=':= 0.714 * _default_ * dnsoDiamondFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * dnsoDiamondSize ' range=':= 0 * _default_ * dnsoDiamondSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 8 ' range=':= 8 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 8 ' range=':= 8 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1029,7 +1029,7 @@
                             <Setting name='CloudRadius' avg=':= 0.731 * _default_ * dnsoDiamondSize ' range=':= 0.731 * _default_ * dnsoDiamondSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.731 * _default_ * dnsoDiamondSize ' range=':= 0.731 * _default_ * dnsoDiamondSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.535 * _default_ * dnsoDiamondFreq ' range=':= 0.535 * _default_ * dnsoDiamondFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 8 ' range=':= 8 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 8 ' range=':= 8 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1082,9 +1082,9 @@
                             <OreBlock block='denseores:block0:3' weight='0.1' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3.500 * dnsoDiamondSize ' range=':= 3.500 * dnsoDiamondSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 0.500 * dnsoDiamondFreq ' range=':= 0.500 * dnsoDiamondFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 8 ' range=':= 8 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.667 * dnsoDiamondSize ' range=':= 2.33 * dnsoDiamondSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 0.667 * dnsoDiamondFreq ' range=':= 0.33 * dnsoDiamondFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 8 ' range=':= 8 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1110,7 +1110,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.787 * _default_ * dnsoLapisLazuliFreq ' range=':= 0.787 * _default_ * dnsoLapisLazuliFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * dnsoLapisLazuliSize ' range=':= 0 * _default_ * dnsoLapisLazuliSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 16 ' range=':= 0 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 16 ' range=':= 0 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= -_default_ ' range=':= -_default_ ' type='normal' />
@@ -1156,7 +1156,7 @@
                             <Setting name='CloudRadius' avg=':= 0.703 * _default_ * dnsoLapisLazuliSize ' range=':= 0.703 * _default_ * dnsoLapisLazuliSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.703 * _default_ * dnsoLapisLazuliSize ' range=':= 0.703 * _default_ * dnsoLapisLazuliSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.495 * _default_ * dnsoLapisLazuliFreq ' range=':= 0.495 * _default_ * dnsoLapisLazuliFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 16 ' range=':= 0 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 16 ' range=':= 0 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1210,9 +1210,9 @@
                             <OreBlock block='denseores:block0:2' weight='0.1' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3.000 * dnsoLapisLazuliSize ' range=':= 3.000 * dnsoLapisLazuliSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 0.500 * dnsoLapisLazuliFreq ' range=':= 0.500 * dnsoLapisLazuliFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 16 ' range=':= 0 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.0 * dnsoLapisLazuliSize ' range=':= 2.0 * dnsoLapisLazuliSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 0.667 * dnsoLapisLazuliFreq ' range=':= 0.33 * dnsoLapisLazuliFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 16 ' range=':= 0 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1238,7 +1238,7 @@
                             <BiomeType name='Mountain'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.145 * _default_ * dnsoEmeraldFreq ' range=':= 1.145 * _default_ * dnsoEmeraldFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * dnsoEmeraldSize ' range=':= 0 * _default_ * dnsoEmeraldSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 16 ' range=':= 12 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 16 ' range=':= 12 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1294,7 +1294,7 @@
                             <Setting name='CloudRadius' avg=':= 0.926 * _default_ * dnsoEmeraldSize ' range=':= 0.926 * _default_ * dnsoEmeraldSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.926 * _default_ * dnsoEmeraldSize ' range=':= 0.926 * _default_ * dnsoEmeraldSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.857 * _default_ * dnsoEmeraldFreq ' range=':= 0.857 * _default_ * dnsoEmeraldFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 16 ' range=':= 12 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 16 ' range=':= 12 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1347,9 +1347,9 @@
                             <OreBlock block='denseores:block0:4' weight='0.1' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <BiomeType name='Mountain'  />
-                            <Setting name='Size' avg=':= 1.000 * dnsoEmeraldSize ' range=':= 1.000 * dnsoEmeraldSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 4.500 * dnsoEmeraldFreq ' range=':= 4.500 * dnsoEmeraldFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 16 ' range=':= 12 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 1.333 * dnsoEmeraldSize ' range=':= 0.67 * dnsoEmeraldSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 6.0 * dnsoEmeraldFreq ' range=':= 3.0 * dnsoEmeraldFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 16 ' range=':= 12 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1415,7 +1415,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 6.247 * _default_ * dnsoNetherQuartzFreq ' range=':= 6.247 * _default_ * dnsoNetherQuartzFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * dnsoNetherQuartzSize ' range=':= 0 * _default_ * dnsoNetherQuartzSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 59 ' range=':= 49 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 59 ' range=':= 49 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1461,7 +1461,7 @@
                             <Setting name='CloudRadius' avg=':= 1.707 * _default_ * dnsoNetherQuartzSize ' range=':= 1.707 * _default_ * dnsoNetherQuartzSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.707 * _default_ * dnsoNetherQuartzSize ' range=':= 1.707 * _default_ * dnsoNetherQuartzSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 2.914 * _default_ * dnsoNetherQuartzFreq ' range=':= 2.914 * _default_ * dnsoNetherQuartzFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 59 ' range=':= 49 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 59 ' range=':= 49 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1515,9 +1515,9 @@
                             <OreBlock block='denseores:block0:7' weight='0.1' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 8.000 * dnsoNetherQuartzSize ' range=':= 8.000 * dnsoNetherQuartzSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 6.500 * dnsoNetherQuartzFreq ' range=':= 6.500 * dnsoNetherQuartzFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 59 ' range=':= 49 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 10.667 * dnsoNetherQuartzSize ' range=':= 5.33 * dnsoNetherQuartzSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 8.667 * dnsoNetherQuartzFreq ' range=':= 4.33 * dnsoNetherQuartzFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 59 ' range=':= 49 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>

--- a/src/main/resources/config/modules/ElectriCraft.xml
+++ b/src/main/resources/config/modules/ElectriCraft.xml
@@ -361,7 +361,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.226 * _default_ * elcrCopperFreq ' range=':= 1.226 * _default_ * elcrCopperFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.035 * _default_ * elcrCopperSize ' range=':= 1.035 * _default_ * elcrCopperSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 48 ' range=':= 16 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 48 ' range=':= 16 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -405,7 +405,7 @@
                             <Setting name='CloudRadius' avg=':= 1.183 * _default_ * elcrCopperSize ' range=':= 1.183 * _default_ * elcrCopperSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.183 * _default_ * elcrCopperSize ' range=':= 1.183 * _default_ * elcrCopperSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.400 * _default_ * elcrCopperFreq ' range=':= 1.400 * _default_ * elcrCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 48 ' range=':= 16 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 48 ' range=':= 16 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -456,9 +456,9 @@
                             <OreBlock block='ElectriCraft:electricraft_block_ore' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3.000 * elcrCopperSize ' range=':= 3.000 * elcrCopperSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 4.000 * elcrCopperFreq ' range=':= 4.000 * elcrCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 48 ' range=':= 16 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.0 * elcrCopperSize ' range=':= 2.0 * elcrCopperSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 5.333 * elcrCopperFreq ' range=':= 2.67 * elcrCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 48 ' range=':= 16 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -483,7 +483,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.416 * _default_ * elcrTinFreq ' range=':= 1.416 * _default_ * elcrTinFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.060 * _default_ * elcrTinSize ' range=':= 1.060 * _default_ * elcrTinSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 60 ' range=':= 12 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 60 ' range=':= 12 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -527,7 +527,7 @@
                             <Setting name='CloudRadius' avg=':= 1.271 * _default_ * elcrTinSize ' range=':= 1.271 * _default_ * elcrTinSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.271 * _default_ * elcrTinSize ' range=':= 1.271 * _default_ * elcrTinSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.616 * _default_ * elcrTinFreq ' range=':= 1.616 * _default_ * elcrTinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 60 ' range=':= 12 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 60 ' range=':= 12 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -578,9 +578,9 @@
                             <OreBlock block='ElectriCraft:electricraft_block_ore:1' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.000 * elcrTinSize ' range=':= 4.000 * elcrTinSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 4.000 * elcrTinFreq ' range=':= 4.000 * elcrTinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 60 ' range=':= 12 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 5.333 * elcrTinSize ' range=':= 2.67 * elcrTinSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 5.333 * elcrTinFreq ' range=':= 2.67 * elcrTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 60 ' range=':= 12 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -605,7 +605,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.867 * _default_ * elcrSilverFreq ' range=':= 0.867 * _default_ * elcrSilverFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.976 * _default_ * elcrSilverSize ' range=':= 0.976 * _default_ * elcrSilverSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -649,7 +649,7 @@
                             <Setting name='CloudRadius' avg=':= 0.995 * _default_ * elcrSilverSize ' range=':= 0.995 * _default_ * elcrSilverSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.995 * _default_ * elcrSilverSize ' range=':= 0.995 * _default_ * elcrSilverSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.990 * _default_ * elcrSilverFreq ' range=':= 0.990 * _default_ * elcrSilverFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -700,9 +700,9 @@
                             <OreBlock block='ElectriCraft:electricraft_block_ore:2' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3.000 * elcrSilverSize ' range=':= 3.000 * elcrSilverSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2.000 * elcrSilverFreq ' range=':= 2.000 * elcrSilverFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.0 * elcrSilverSize ' range=':= 2.0 * elcrSilverSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2.667 * elcrSilverFreq ' range=':= 1.33 * elcrSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -727,7 +727,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.226 * _default_ * elcrNickelFreq ' range=':= 1.226 * _default_ * elcrNickelFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.035 * _default_ * elcrNickelSize ' range=':= 1.035 * _default_ * elcrNickelSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 32 ' range=':= 16 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 32 ' range=':= 16 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -771,7 +771,7 @@
                             <Setting name='CloudRadius' avg=':= 1.183 * _default_ * elcrNickelSize ' range=':= 1.183 * _default_ * elcrNickelSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.183 * _default_ * elcrNickelSize ' range=':= 1.183 * _default_ * elcrNickelSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.400 * _default_ * elcrNickelFreq ' range=':= 1.400 * _default_ * elcrNickelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 32 ' range=':= 16 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 32 ' range=':= 16 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -822,9 +822,9 @@
                             <OreBlock block='ElectriCraft:electricraft_block_ore:3' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.000 * elcrNickelSize ' range=':= 4.000 * elcrNickelSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 3.000 * elcrNickelFreq ' range=':= 3.000 * elcrNickelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 32 ' range=':= 16 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 5.333 * elcrNickelSize ' range=':= 2.67 * elcrNickelSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4.0 * elcrNickelFreq ' range=':= 2.0 * elcrNickelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 32 ' range=':= 16 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -849,7 +849,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.583 * _default_ * elcrAluminumFreq ' range=':= 1.583 * _default_ * elcrAluminumFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.080 * _default_ * elcrAluminumSize ' range=':= 1.080 * _default_ * elcrAluminumSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 94 ' range=':= 34 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 94 ' range=':= 34 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -893,7 +893,7 @@
                             <Setting name='CloudRadius' avg=':= 1.344 * _default_ * elcrAluminumSize ' range=':= 1.344 * _default_ * elcrAluminumSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.344 * _default_ * elcrAluminumSize ' range=':= 1.344 * _default_ * elcrAluminumSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.807 * _default_ * elcrAluminumFreq ' range=':= 1.807 * _default_ * elcrAluminumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 94 ' range=':= 34 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 94 ' range=':= 34 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -944,9 +944,9 @@
                             <OreBlock block='ElectriCraft:electricraft_block_ore:4' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.000 * elcrAluminumSize ' range=':= 4.000 * elcrAluminumSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 5.000 * elcrAluminumFreq ' range=':= 5.000 * elcrAluminumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 94 ' range=':= 34 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 5.333 * elcrAluminumSize ' range=':= 2.67 * elcrAluminumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 6.667 * elcrAluminumFreq ' range=':= 3.33 * elcrAluminumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 94 ' range=':= 34 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -971,7 +971,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.500 * _default_ * elcrPlatinumFreq ' range=':= 0.500 * _default_ * elcrPlatinumFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.891 * _default_ * elcrPlatinumSize ' range=':= 0.891 * _default_ * elcrPlatinumSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 11 ' range=':= 5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 11 ' range=':= 5 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1015,7 +1015,7 @@
                             <Setting name='CloudRadius' avg=':= 0.756 * _default_ * elcrPlatinumSize ' range=':= 0.756 * _default_ * elcrPlatinumSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.756 * _default_ * elcrPlatinumSize ' range=':= 0.756 * _default_ * elcrPlatinumSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.571 * _default_ * elcrPlatinumFreq ' range=':= 0.571 * _default_ * elcrPlatinumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 11 ' range=':= 5 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 11 ' range=':= 5 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1066,9 +1066,9 @@
                             <OreBlock block='ElectriCraft:electricraft_block_ore:5' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 2.000 * elcrPlatinumSize ' range=':= 2.000 * elcrPlatinumSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.000 * elcrPlatinumFreq ' range=':= 1.000 * elcrPlatinumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 11 ' range=':= 5 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.667 * elcrPlatinumSize ' range=':= 1.33 * elcrPlatinumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.333 * elcrPlatinumFreq ' range=':= 0.67 * elcrPlatinumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 11 ' range=':= 5 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>

--- a/src/main/resources/config/modules/EtFuturum.xml
+++ b/src/main/resources/config/modules/EtFuturum.xml
@@ -222,7 +222,7 @@
                             <Setting name='CloudRadius' avg=':= 1.465 * _default_ * etftGraniteSize ' range=':= 1.465 * _default_ * etftGraniteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.465 * _default_ * etftGraniteSize ' range=':= 1.465 * _default_ * etftGraniteSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 2.146 * _default_ * etftGraniteFreq ' range=':= 2.146 * _default_ * etftGraniteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 40 ' range=':= 40 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 40 ' range=':= 40 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -248,7 +248,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 3.214 * _default_ * etftGraniteFreq ' range=':= 3.214 * _default_ * etftGraniteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.215 * _default_ * etftGraniteSize ' range=':= 1.215 * _default_ * etftGraniteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 40 ' range=':= 40 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 40 ' range=':= 40 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -279,9 +279,9 @@
                             <OreBlock block='etfuturum:stone:1' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 16.500 * etftGraniteSize ' range=':= 16.500 * etftGraniteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 5.000 * etftGraniteFreq ' range=':= 5.000 * etftGraniteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 40 ' range=':= 40 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 22.0 * etftGraniteSize ' range=':= 11.0 * etftGraniteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 6.667 * etftGraniteFreq ' range=':= 3.33 * etftGraniteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 40 ' range=':= 40 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -309,7 +309,7 @@
                             <Setting name='CloudRadius' avg=':= 1.465 * _default_ * etftDioriteSize ' range=':= 1.465 * _default_ * etftDioriteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.465 * _default_ * etftDioriteSize ' range=':= 1.465 * _default_ * etftDioriteSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 2.146 * _default_ * etftDioriteFreq ' range=':= 2.146 * _default_ * etftDioriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 40 ' range=':= 40 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 40 ' range=':= 40 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -335,7 +335,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 3.214 * _default_ * etftDioriteFreq ' range=':= 3.214 * _default_ * etftDioriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.215 * _default_ * etftDioriteSize ' range=':= 1.215 * _default_ * etftDioriteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 40 ' range=':= 40 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 40 ' range=':= 40 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -366,9 +366,9 @@
                             <OreBlock block='etfuturum:stone:3' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 16.500 * etftDioriteSize ' range=':= 16.500 * etftDioriteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 5.000 * etftDioriteFreq ' range=':= 5.000 * etftDioriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 40 ' range=':= 40 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 22.0 * etftDioriteSize ' range=':= 11.0 * etftDioriteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 6.667 * etftDioriteFreq ' range=':= 3.33 * etftDioriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 40 ' range=':= 40 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -396,7 +396,7 @@
                             <Setting name='CloudRadius' avg=':= 1.465 * _default_ * etftAndesiteSize ' range=':= 1.465 * _default_ * etftAndesiteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.465 * _default_ * etftAndesiteSize ' range=':= 1.465 * _default_ * etftAndesiteSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 2.146 * _default_ * etftAndesiteFreq ' range=':= 2.146 * _default_ * etftAndesiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 40 ' range=':= 40 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 40 ' range=':= 40 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -422,7 +422,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 3.214 * _default_ * etftAndesiteFreq ' range=':= 3.214 * _default_ * etftAndesiteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.215 * _default_ * etftAndesiteSize ' range=':= 1.215 * _default_ * etftAndesiteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 40 ' range=':= 40 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 40 ' range=':= 40 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -453,9 +453,9 @@
                             <OreBlock block='etfuturum:stone:5' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 16.500 * etftAndesiteSize ' range=':= 16.500 * etftAndesiteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 5.000 * etftAndesiteFreq ' range=':= 5.000 * etftAndesiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 40 ' range=':= 40 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 22.0 * etftAndesiteSize ' range=':= 11.0 * etftAndesiteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 6.667 * etftAndesiteFreq ' range=':= 3.33 * etftAndesiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 40 ' range=':= 40 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>

--- a/src/main/resources/config/modules/Factorization.xml
+++ b/src/main/resources/config/modules/Factorization.xml
@@ -86,9 +86,9 @@
                     <DisplayName>Factorization Dark Iron</DisplayName>
                     <IfCondition condition=':= (?blockExists("factorization:DarkIronOre")) '>
 
-                    <Choice value='SparseVeins' displayValue='Sparse Veins'>
+                    <Choice value='VerticalVeins' displayValue='Vertical Veins'>
                         <Description>
-                            Large veins filled very lightly with ore.
+                            Single vertical veins that occur with no motherlodes.
                         </Description>
                     </Choice>
                     </IfCondition>
@@ -172,7 +172,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.811 * _default_ * fctrSilverFreq ' range=':= 0.811 * _default_ * fctrSilverFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.966 * _default_ * fctrSilverSize ' range=':= 0.966 * _default_ * fctrSilverSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 25 ' range=':= 10 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 25 ' range=':= 10 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -216,7 +216,7 @@
                             <Setting name='CloudRadius' avg=':= 0.962 * _default_ * fctrSilverSize ' range=':= 0.962 * _default_ * fctrSilverSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.962 * _default_ * fctrSilverSize ' range=':= 0.962 * _default_ * fctrSilverSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.926 * _default_ * fctrSilverFreq ' range=':= 0.926 * _default_ * fctrSilverFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 25 ' range=':= 10 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 25 ' range=':= 10 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -267,9 +267,9 @@
                             <OreBlock block='factorization:ResourceBlock' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3.500 * fctrSilverSize ' range=':= 3.500 * fctrSilverSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.500 * fctrSilverFreq ' range=':= 1.500 * fctrSilverFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 25 ' range=':= 10 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.667 * fctrSilverSize ' range=':= 2.33 * fctrSilverSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2.0 * fctrSilverFreq ' range=':= 1.0 * fctrSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 25 ' range=':= 10 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -281,20 +281,13 @@
 
                 <!-- Begin Dark Iron Generation -->
 
-                <!-- Starting SparseVeins Preset for Dark Iron. -->
+                <!-- Starting VerticalVeins Preset for Dark Iron. -->
                 <ConfigSection>
-                    <IfCondition condition=':= fctrDarkIronDist = "SparseVeins"'>
-                        <Veins name='fctrDarkIronVeins'  inherits='PresetSparseVeins' branchType='Bezier' drawWireframe='true' wireframeColor='0x60781CCB' drawBoundBox='false' boundBoxColor='0x60781CCB'>
+                    <IfCondition condition=':= fctrDarkIronDist = "VerticalVeins"'>
+                        <Veins name='fctrDarkIronVeins'  inherits='PresetVerticalVeins' branchType='Bezier' drawWireframe='true' wireframeColor='0x60781CCB' drawBoundBox='false' boundBoxColor='0x60781CCB'>
                             <Description>
-                                Large veins filled very lightly  with
-                                ore.  Because they contain  less ore
-                                per volume, these veins  are
-                                relatively wide and long.  Mining the
-                                ore from them is time  consuming
-                                compared to solid ore  veins.  They
-                                are also more  difficult to follow,
-                                since it is  harder to get an idea of
-                                their  direction while mining.
+                                Single vertical veins that occur  with
+                                no motherlodes.
                             </Description>
                             <OreBlock block='factorization:DarkIronOre' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
@@ -303,24 +296,24 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.433 * _default_ * fctrDarkIronFreq ' range=':= 0.433 * _default_ * fctrDarkIronFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * fctrDarkIronSize ' range=':= 0 * _default_ * fctrDarkIronSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 3 ' range=':= 2 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 3 ' range=':= 2 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='BranchLength' avg=':= 0.658 * _default_ ' range=':= 0.658 * _default_ ' type='normal' />
+                            <Setting name='BranchLength' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchHeightLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' scaleTo='base' />
                             <Setting name='SegmentForkFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentForkLengthMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentLength' avg=':= _default_ * fctrDarkIronSize ' range=':= _default_ * fctrDarkIronSize ' type='normal' />
                             <Setting name='SegmentAngle' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='SegmentPitch' avg=':= _default_ ' range=':= _default_ ' type='normal' />
-                            <Setting name='SegmentRadius' avg=':= 0.811 * _default_ * fctrDarkIronSize ' range=':= 0.811 * _default_ * fctrDarkIronSize ' type='normal' />
+                            <Setting name='SegmentRadius' avg=':= 0.658 * _default_ * fctrDarkIronSize ' range=':= 0.658 * _default_ * fctrDarkIronSize ' type='normal' />
                             <Setting name='OreDensity' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='OreRadiusMult' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </Veins>
                     </IfCondition>
                 </ConfigSection>
-                <!-- SparseVeins Preset for Dark Iron is complete. -->
+                <!-- VerticalVeins Preset for Dark Iron is complete. -->
 
 
                 <!-- Starting StrategicClouds Preset for Dark Iron. -->
@@ -349,7 +342,7 @@
                             <Setting name='CloudRadius' avg=':= 0.449 * _default_ * fctrDarkIronSize ' range=':= 0.449 * _default_ * fctrDarkIronSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.449 * _default_ * fctrDarkIronSize ' range=':= 0.449 * _default_ * fctrDarkIronSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.202 * _default_ * fctrDarkIronFreq ' range=':= 0.202 * _default_ * fctrDarkIronFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 3 ' range=':= 2 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 3 ' range=':= 2 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -402,9 +395,9 @@
                             <Replaces block='minecraft:dirt' weight='1.0' />
                             <Replaces block='minecraft:gravel' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 0.500 * fctrDarkIronSize ' range=':= 0.500 * fctrDarkIronSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 0.500 * fctrDarkIronFreq ' range=':= 0.500 * fctrDarkIronFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 3 ' range=':= 2 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 0.667 * fctrDarkIronSize ' range=':= 0.33 * fctrDarkIronSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 0.667 * fctrDarkIronFreq ' range=':= 0.33 * fctrDarkIronFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 3 ' range=':= 2 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>

--- a/src/main/resources/config/modules/FlaxbeardsSteamcraft.xml
+++ b/src/main/resources/config/modules/FlaxbeardsSteamcraft.xml
@@ -172,7 +172,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.251 * _default_ * flxbCopperFreq ' range=':= 1.251 * _default_ * flxbCopperFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.038 * _default_ * flxbCopperSize ' range=':= 1.038 * _default_ * flxbCopperSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 42.5 ' range=':= 37.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 42.5 ' range=':= 37.5 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -216,7 +216,7 @@
                             <Setting name='CloudRadius' avg=':= 1.195 * _default_ * flxbCopperSize ' range=':= 1.195 * _default_ * flxbCopperSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.195 * _default_ * flxbCopperSize ' range=':= 1.195 * _default_ * flxbCopperSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.429 * _default_ * flxbCopperFreq ' range=':= 1.429 * _default_ * flxbCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 42.5 ' range=':= 37.5 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 42.5 ' range=':= 37.5 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -267,9 +267,9 @@
                             <OreBlock block='Steamcraft:steamcraftOre' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 2.500 * flxbCopperSize ' range=':= 2.500 * flxbCopperSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 5.000 * flxbCopperFreq ' range=':= 5.000 * flxbCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 42.5 ' range=':= 37.5 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 3.333 * flxbCopperSize ' range=':= 1.67 * flxbCopperSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 6.667 * flxbCopperFreq ' range=':= 3.33 * flxbCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 42.5 ' range=':= 37.5 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -294,7 +294,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.936 * _default_ * flxbZincFreq ' range=':= 0.936 * _default_ * flxbZincFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.989 * _default_ * flxbZincSize ' range=':= 0.989 * _default_ * flxbZincSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 40 ' range=':= 35 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 40 ' range=':= 35 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -338,7 +338,7 @@
                             <Setting name='CloudRadius' avg=':= 1.034 * _default_ * flxbZincSize ' range=':= 1.034 * _default_ * flxbZincSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.034 * _default_ * flxbZincSize ' range=':= 1.034 * _default_ * flxbZincSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.069 * _default_ * flxbZincFreq ' range=':= 1.069 * _default_ * flxbZincFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 40 ' range=':= 35 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 40 ' range=':= 35 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -389,9 +389,9 @@
                             <OreBlock block='Steamcraft:steamcraftOre:1' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 2.000 * flxbZincSize ' range=':= 2.000 * flxbZincSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 3.500 * flxbZincFreq ' range=':= 3.500 * flxbZincFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 40 ' range=':= 35 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.667 * flxbZincSize ' range=':= 1.33 * flxbZincSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4.667 * flxbZincFreq ' range=':= 2.33 * flxbZincFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 40 ' range=':= 35 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>

--- a/src/main/resources/config/modules/Forestry.xml
+++ b/src/main/resources/config/modules/Forestry.xml
@@ -226,7 +226,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.599 * _default_ * frstApatiteFreq ' range=':= 2.599 * _default_ * frstApatiteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * frstApatiteSize ' range=':= 0 * _default_ * frstApatiteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 120 ' range=':= 64 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 120 ' range=':= 64 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -270,7 +270,7 @@
                             <Setting name='CloudRadius' avg=':= 1.101 * _default_ * frstApatiteSize ' range=':= 1.101 * _default_ * frstApatiteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.101 * _default_ * frstApatiteSize ' range=':= 1.101 * _default_ * frstApatiteSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.212 * _default_ * frstApatiteFreq ' range=':= 1.212 * _default_ * frstApatiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 120 ' range=':= 64 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 120 ' range=':= 64 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -321,9 +321,9 @@
                             <OreBlock block='Forestry:resources' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 18.000 * frstApatiteSize ' range=':= 18.000 * frstApatiteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 0.500 * frstApatiteFreq ' range=':= 0.500 * frstApatiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 120 ' range=':= 64 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 24.0 * frstApatiteSize ' range=':= 12.0 * frstApatiteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 0.667 * frstApatiteFreq ' range=':= 0.33 * frstApatiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 120 ' range=':= 64 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -348,7 +348,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.938 * _default_ * frstCopperFreq ' range=':= 1.938 * _default_ * frstCopperFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.117 * _default_ * frstCopperSize ' range=':= 1.117 * _default_ * frstCopperSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 106 ' range=':= 74 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 106 ' range=':= 74 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -392,7 +392,7 @@
                             <Setting name='CloudRadius' avg=':= 1.488 * _default_ * frstCopperSize ' range=':= 1.488 * _default_ * frstCopperSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.488 * _default_ * frstCopperSize ' range=':= 1.488 * _default_ * frstCopperSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 2.213 * _default_ * frstCopperFreq ' range=':= 2.213 * _default_ * frstCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 106 ' range=':= 74 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 106 ' range=':= 74 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -443,9 +443,9 @@
                             <OreBlock block='Forestry:resources:1' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3.000 * frstCopperSize ' range=':= 3.000 * frstCopperSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 10.000 * frstCopperFreq ' range=':= 10.000 * frstCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 106 ' range=':= 74 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.0 * frstCopperSize ' range=':= 2.0 * frstCopperSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 13.333 * frstCopperFreq ' range=':= 6.67 * frstCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 106 ' range=':= 74 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -470,7 +470,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.839 * _default_ * frstTinFreq ' range=':= 1.839 * _default_ * frstTinFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.107 * _default_ * frstTinSize ' range=':= 1.107 * _default_ * frstTinSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 98 ' range=':= 82 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 98 ' range=':= 82 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -514,7 +514,7 @@
                             <Setting name='CloudRadius' avg=':= 1.449 * _default_ * frstTinSize ' range=':= 1.449 * _default_ * frstTinSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.449 * _default_ * frstTinSize ' range=':= 1.449 * _default_ * frstTinSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 2.100 * _default_ * frstTinFreq ' range=':= 2.100 * _default_ * frstTinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 98 ' range=':= 82 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 98 ' range=':= 82 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -565,9 +565,9 @@
                             <OreBlock block='Forestry:resources:2' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3.000 * frstTinSize ' range=':= 3.000 * frstTinSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 9.000 * frstTinFreq ' range=':= 9.000 * frstTinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 98 ' range=':= 82 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.0 * frstTinSize ' range=':= 2.0 * frstTinSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 12.0 * frstTinFreq ' range=':= 6.0 * frstTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 98 ' range=':= 82 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>

--- a/src/main/resources/config/modules/FossilsandArchaeology.xml
+++ b/src/main/resources/config/modules/FossilsandArchaeology.xml
@@ -180,7 +180,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 7.552 * _default_ * fsarFossilsFreq ' range=':= 7.552 * _default_ * fsarFossilsFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * fsarFossilsSize ' range=':= 0 * _default_ * fsarFossilsSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 53 ' range=':= 47 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 53 ' range=':= 47 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -208,7 +208,7 @@
                             <BiomeType name='desert'  />
                             <Setting name='MotherlodeFrequency' avg=':= 7.552 * _default_ * fsarFossilsFreq ' range=':= 7.552 * _default_ * fsarFossilsFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * fsarFossilsSize ' range=':= 0 * _default_ * fsarFossilsSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 53 ' range=':= 47 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 53 ' range=':= 47 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -254,7 +254,7 @@
                             <Setting name='CloudRadius' avg=':= 1.877 * _default_ * fsarFossilsSize ' range=':= 1.877 * _default_ * fsarFossilsSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.877 * _default_ * fsarFossilsSize ' range=':= 1.877 * _default_ * fsarFossilsSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 3.523 * _default_ * fsarFossilsFreq ' range=':= 3.523 * _default_ * fsarFossilsFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 53 ' range=':= 47 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 53 ' range=':= 47 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -303,7 +303,7 @@
                             <Setting name='CloudRadius' avg=':= 1.877 * _default_ * fsarFossilsSize ' range=':= 1.877 * _default_ * fsarFossilsSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.877 * _default_ * fsarFossilsSize ' range=':= 1.877 * _default_ * fsarFossilsSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 3.523 * _default_ * fsarFossilsFreq ' range=':= 3.523 * _default_ * fsarFossilsFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 53 ' range=':= 47 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 53 ' range=':= 47 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -340,9 +340,9 @@
                             <OreBlock block='fossil:fossil' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.000 * fsarFossilsSize ' range=':= 4.000 * fsarFossilsSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 19.000 * fsarFossilsFreq ' range=':= 19.000 * fsarFossilsFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 53 ' range=':= 47 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 5.333 * fsarFossilsSize ' range=':= 2.67 * fsarFossilsSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 25.333 * fsarFossilsFreq ' range=':= 12.67 * fsarFossilsFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 53 ' range=':= 47 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -375,7 +375,7 @@
                             <BiomeType name='Frozen'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.450 * _default_ * fsarPermafrostFreq ' range=':= 2.450 * _default_ * fsarPermafrostFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * fsarPermafrostSize ' range=':= 0 * _default_ * fsarPermafrostSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 18 ' range=':= 12.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 18 ' range=':= 12.5 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -420,7 +420,7 @@
                             <Setting name='CloudRadius' avg=':= 1.069 * _default_ * fsarPermafrostSize ' range=':= 1.069 * _default_ * fsarPermafrostSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.069 * _default_ * fsarPermafrostSize ' range=':= 1.069 * _default_ * fsarPermafrostSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.143 * _default_ * fsarPermafrostFreq ' range=':= 1.143 * _default_ * fsarPermafrostFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 18 ' range=':= 12.5 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 18 ' range=':= 12.5 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -473,9 +473,9 @@
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
                             <BiomeType name='Frozen'  />
-                            <Setting name='Size' avg=':= 2.000 * fsarPermafrostSize ' range=':= 2.000 * fsarPermafrostSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 4.000 * fsarPermafrostFreq ' range=':= 4.000 * fsarPermafrostFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 18 ' range=':= 12.5 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.667 * fsarPermafrostSize ' range=':= 1.33 * fsarPermafrostSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 5.333 * fsarPermafrostFreq ' range=':= 2.67 * fsarPermafrostFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 18 ' range=':= 12.5 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>

--- a/src/main/resources/config/modules/Galacticraft.xml
+++ b/src/main/resources/config/modules/Galacticraft.xml
@@ -267,7 +267,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.294 * _default_ * glctCopperFreq ' range=':= 2.294 * _default_ * glctCopperFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.148 * _default_ * glctCopperSize ' range=':= 1.148 * _default_ * glctCopperSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 40 ' range=':= 35 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 40 ' range=':= 35 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -311,7 +311,7 @@
                             <Setting name='CloudRadius' avg=':= 1.618 * _default_ * glctCopperSize ' range=':= 1.618 * _default_ * glctCopperSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.618 * _default_ * glctCopperSize ' range=':= 1.618 * _default_ * glctCopperSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 2.619 * _default_ * glctCopperFreq ' range=':= 2.619 * _default_ * glctCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 40 ' range=':= 35 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 40 ' range=':= 35 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -362,9 +362,9 @@
                             <OreBlock block='GalacticraftCore:tile.gcBlockCore:5' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3.500 * glctCopperSize ' range=':= 3.500 * glctCopperSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 12.000 * glctCopperFreq ' range=':= 12.000 * glctCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 40 ' range=':= 35 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.667 * glctCopperSize ' range=':= 2.33 * glctCopperSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 16.0 * glctCopperFreq ' range=':= 8.0 * glctCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 40 ' range=':= 35 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -389,7 +389,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.196 * _default_ * glctTinFreq ' range=':= 2.196 * _default_ * glctTinFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.140 * _default_ * glctTinSize ' range=':= 1.140 * _default_ * glctTinSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 33 ' range=':= 27 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 33 ' range=':= 27 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -433,7 +433,7 @@
                             <Setting name='CloudRadius' avg=':= 1.583 * _default_ * glctTinSize ' range=':= 1.583 * _default_ * glctTinSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.583 * _default_ * glctTinSize ' range=':= 1.583 * _default_ * glctTinSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 2.507 * _default_ * glctTinFreq ' range=':= 2.507 * _default_ * glctTinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 33 ' range=':= 27 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 33 ' range=':= 27 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -484,9 +484,9 @@
                             <OreBlock block='GalacticraftCore:tile.gcBlockCore:6' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3.500 * glctTinSize ' range=':= 3.500 * glctTinSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 11.000 * glctTinFreq ' range=':= 11.000 * glctTinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 33 ' range=':= 27 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.667 * glctTinSize ' range=':= 2.33 * glctTinSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 14.667 * glctTinFreq ' range=':= 7.33 * glctTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 33 ' range=':= 27 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -511,7 +511,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.986 * _default_ * glctAluminumFreq ' range=':= 1.986 * _default_ * glctAluminumFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.121 * _default_ * glctAluminumSize ' range=':= 1.121 * _default_ * glctAluminumSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 25 ' range=':= 20 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 25 ' range=':= 20 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -555,7 +555,7 @@
                             <Setting name='CloudRadius' avg=':= 1.506 * _default_ * glctAluminumSize ' range=':= 1.506 * _default_ * glctAluminumSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.506 * _default_ * glctAluminumSize ' range=':= 1.506 * _default_ * glctAluminumSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 2.268 * _default_ * glctAluminumFreq ' range=':= 2.268 * _default_ * glctAluminumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 25 ' range=':= 20 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 25 ' range=':= 20 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -606,9 +606,9 @@
                             <OreBlock block='GalacticraftCore:tile.gcBlockCore:7' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3.500 * glctAluminumSize ' range=':= 3.500 * glctAluminumSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 9.000 * glctAluminumFreq ' range=':= 9.000 * glctAluminumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 25 ' range=':= 20 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.667 * glctAluminumSize ' range=':= 2.33 * glctAluminumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 12.0 * glctAluminumFreq ' range=':= 6.0 * glctAluminumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 25 ' range=':= 20 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -633,7 +633,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.811 * _default_ * glctSiliconFreq ' range=':= 0.811 * _default_ * glctSiliconFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.966 * _default_ * glctSiliconSize ' range=':= 0.966 * _default_ * glctSiliconSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 15 ' range=':= 10 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 15 ' range=':= 10 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -677,7 +677,7 @@
                             <Setting name='CloudRadius' avg=':= 0.962 * _default_ * glctSiliconSize ' range=':= 0.962 * _default_ * glctSiliconSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.962 * _default_ * glctSiliconSize ' range=':= 0.962 * _default_ * glctSiliconSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.926 * _default_ * glctSiliconFreq ' range=':= 0.926 * _default_ * glctSiliconFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 15 ' range=':= 10 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 15 ' range=':= 10 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -728,9 +728,9 @@
                             <OreBlock block='GalacticraftCore:tile.gcBlockCore:8' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3.500 * glctSiliconSize ' range=':= 3.500 * glctSiliconSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.500 * glctSiliconFreq ' range=':= 1.500 * glctSiliconFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 15 ' range=':= 10 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.667 * glctSiliconSize ' range=':= 2.33 * glctSiliconSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2.0 * glctSiliconFreq ' range=':= 1.0 * glctSiliconFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 15 ' range=':= 10 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>

--- a/src/main/resources/config/modules/GeoStrata.xml
+++ b/src/main/resources/config/modules/GeoStrata.xml
@@ -882,7 +882,7 @@
                             <Setting name='CloudRadius' avg=':= 1.809 * _default_ * gstaShaleSize ' range=':= 1.809 * _default_ * gstaShaleSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.809 * _default_ * gstaShaleSize ' range=':= 1.809 * _default_ * gstaShaleSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 3.273 * _default_ * gstaShaleFreq ' range=':= 3.273 * _default_ * gstaShaleFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 56 ' range=':= 8 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 56 ' range=':= 8 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -908,7 +908,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 4.904 * _default_ * gstaShaleFreq ' range=':= 4.904 * _default_ * gstaShaleFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.303 * _default_ * gstaShaleSize ' range=':= 1.303 * _default_ * gstaShaleSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 56 ' range=':= 8 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 56 ' range=':= 8 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -939,9 +939,9 @@
                             <OreBlock block='GeoStrata:geostrata_rock_shale_smooth' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 16.000 * gstaShaleSize ' range=':= 16.000 * gstaShaleSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 12.000 * gstaShaleFreq ' range=':= 12.000 * gstaShaleFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 56 ' range=':= 8 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 21.333 * gstaShaleSize ' range=':= 10.67 * gstaShaleSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 16.0 * gstaShaleFreq ' range=':= 8.0 * gstaShaleFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 56 ' range=':= 8 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -969,7 +969,7 @@
                             <Setting name='CloudRadius' avg=':= 1.809 * _default_ * gstaSandstoneSize ' range=':= 1.809 * _default_ * gstaSandstoneSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.809 * _default_ * gstaSandstoneSize ' range=':= 1.809 * _default_ * gstaSandstoneSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 3.273 * _default_ * gstaSandstoneFreq ' range=':= 3.273 * _default_ * gstaSandstoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 88 ' range=':= 40 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 88 ' range=':= 40 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -995,7 +995,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 4.904 * _default_ * gstaSandstoneFreq ' range=':= 4.904 * _default_ * gstaSandstoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.303 * _default_ * gstaSandstoneSize ' range=':= 1.303 * _default_ * gstaSandstoneSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 88 ' range=':= 40 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 88 ' range=':= 40 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1026,9 +1026,9 @@
                             <OreBlock block='GeoStrata:geostrata_rock_sandstone_smooth' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 16.000 * gstaSandstoneSize ' range=':= 16.000 * gstaSandstoneSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 12.000 * gstaSandstoneFreq ' range=':= 12.000 * gstaSandstoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 88 ' range=':= 40 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 21.333 * gstaSandstoneSize ' range=':= 10.67 * gstaSandstoneSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 16.0 * gstaSandstoneFreq ' range=':= 8.0 * gstaSandstoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 88 ' range=':= 40 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1056,7 +1056,7 @@
                             <Setting name='CloudRadius' avg=':= 1.809 * _default_ * gstaLimestoneSize ' range=':= 1.809 * _default_ * gstaLimestoneSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.809 * _default_ * gstaLimestoneSize ' range=':= 1.809 * _default_ * gstaLimestoneSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 3.273 * _default_ * gstaLimestoneFreq ' range=':= 3.273 * _default_ * gstaLimestoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 88 ' range=':= 40 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 88 ' range=':= 40 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1082,7 +1082,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 4.904 * _default_ * gstaLimestoneFreq ' range=':= 4.904 * _default_ * gstaLimestoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.303 * _default_ * gstaLimestoneSize ' range=':= 1.303 * _default_ * gstaLimestoneSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 88 ' range=':= 40 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 88 ' range=':= 40 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1113,9 +1113,9 @@
                             <OreBlock block='GeoStrata:geostrata_rock_limestone_smooth' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 16.000 * gstaLimestoneSize ' range=':= 16.000 * gstaLimestoneSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 12.000 * gstaLimestoneFreq ' range=':= 12.000 * gstaLimestoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 88 ' range=':= 40 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 21.333 * gstaLimestoneSize ' range=':= 10.67 * gstaLimestoneSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 16.0 * gstaLimestoneFreq ' range=':= 8.0 * gstaLimestoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 88 ' range=':= 40 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1143,7 +1143,7 @@
                             <Setting name='CloudRadius' avg=':= 1.592 * _default_ * gstaPumiceSize ' range=':= 1.592 * _default_ * gstaPumiceSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.592 * _default_ * gstaPumiceSize ' range=':= 1.592 * _default_ * gstaPumiceSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 2.535 * _default_ * gstaPumiceFreq ' range=':= 2.535 * _default_ * gstaPumiceFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 11 ' range=':= 5 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 11 ' range=':= 5 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1169,7 +1169,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 3.798 * _default_ * gstaPumiceFreq ' range=':= 3.798 * _default_ * gstaPumiceFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.249 * _default_ * gstaPumiceSize ' range=':= 1.249 * _default_ * gstaPumiceSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 11 ' range=':= 5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 11 ' range=':= 5 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1200,9 +1200,9 @@
                             <OreBlock block='GeoStrata:geostrata_rock_pumice_smooth' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 16.000 * gstaPumiceSize ' range=':= 16.000 * gstaPumiceSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 7.200 * gstaPumiceFreq ' range=':= 7.200 * gstaPumiceFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 11 ' range=':= 5 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 21.333 * gstaPumiceSize ' range=':= 10.67 * gstaPumiceSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 9.6 * gstaPumiceFreq ' range=':= 4.8 * gstaPumiceFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 11 ' range=':= 5 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1230,7 +1230,7 @@
                             <Setting name='CloudRadius' avg=':= 1.076 * _default_ * gstaOpalSize ' range=':= 1.076 * _default_ * gstaOpalSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.076 * _default_ * gstaOpalSize ' range=':= 1.076 * _default_ * gstaOpalSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.157 * _default_ * gstaOpalFreq ' range=':= 1.157 * _default_ * gstaOpalFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1256,7 +1256,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.734 * _default_ * gstaOpalFreq ' range=':= 1.734 * _default_ * gstaOpalFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.096 * _default_ * gstaOpalSize ' range=':= 1.096 * _default_ * gstaOpalSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1287,9 +1287,9 @@
                             <OreBlock block='GeoStrata:geostrata_rock_opal_smooth' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 16.000 * gstaOpalSize ' range=':= 16.000 * gstaOpalSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.500 * gstaOpalFreq ' range=':= 1.500 * gstaOpalFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 21.333 * gstaOpalSize ' range=':= 10.67 * gstaOpalSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2.0 * gstaOpalFreq ' range=':= 1.0 * gstaOpalFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1317,7 +1317,7 @@
                             <Setting name='CloudRadius' avg=':= 1.809 * _default_ * gstaSlateSize ' range=':= 1.809 * _default_ * gstaSlateSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.809 * _default_ * gstaSlateSize ' range=':= 1.809 * _default_ * gstaSlateSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 3.273 * _default_ * gstaSlateFreq ' range=':= 3.273 * _default_ * gstaSlateFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 40 ' range=':= 8 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 40 ' range=':= 8 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1343,7 +1343,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 4.904 * _default_ * gstaSlateFreq ' range=':= 4.904 * _default_ * gstaSlateFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.303 * _default_ * gstaSlateSize ' range=':= 1.303 * _default_ * gstaSlateSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 40 ' range=':= 8 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 40 ' range=':= 8 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1374,9 +1374,9 @@
                             <OreBlock block='GeoStrata:geostrata_rock_slate_smooth' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 16.000 * gstaSlateSize ' range=':= 16.000 * gstaSlateSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 12.000 * gstaSlateFreq ' range=':= 12.000 * gstaSlateFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 40 ' range=':= 8 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 21.333 * gstaSlateSize ' range=':= 10.67 * gstaSlateSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 16.0 * gstaSlateFreq ' range=':= 8.0 * gstaSlateFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 40 ' range=':= 8 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1404,7 +1404,7 @@
                             <Setting name='CloudRadius' avg=':= 1.711 * _default_ * gstaGneissSize ' range=':= 1.711 * _default_ * gstaGneissSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.711 * _default_ * gstaGneissSize ' range=':= 1.711 * _default_ * gstaGneissSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 2.928 * _default_ * gstaGneissFreq ' range=':= 2.928 * _default_ * gstaGneissFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 24 ' range=':= 8 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 24 ' range=':= 8 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1430,7 +1430,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 4.386 * _default_ * gstaGneissFreq ' range=':= 4.386 * _default_ * gstaGneissFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.279 * _default_ * gstaGneissSize ' range=':= 1.279 * _default_ * gstaGneissSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 24 ' range=':= 8 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 24 ' range=':= 8 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1461,9 +1461,9 @@
                             <OreBlock block='GeoStrata:geostrata_rock_gneiss_smooth' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 16.000 * gstaGneissSize ' range=':= 16.000 * gstaGneissSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 9.600 * gstaGneissFreq ' range=':= 9.600 * gstaGneissFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 24 ' range=':= 8 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 21.333 * gstaGneissSize ' range=':= 10.67 * gstaGneissSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 12.8 * gstaGneissFreq ' range=':= 6.4 * gstaGneissFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 24 ' range=':= 8 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1491,7 +1491,7 @@
                             <Setting name='CloudRadius' avg=':= 1.592 * _default_ * gstaPeridotiteSize ' range=':= 1.592 * _default_ * gstaPeridotiteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.592 * _default_ * gstaPeridotiteSize ' range=':= 1.592 * _default_ * gstaPeridotiteSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 2.535 * _default_ * gstaPeridotiteFreq ' range=':= 2.535 * _default_ * gstaPeridotiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 15 ' range=':= 9 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 15 ' range=':= 9 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1517,7 +1517,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 3.798 * _default_ * gstaPeridotiteFreq ' range=':= 3.798 * _default_ * gstaPeridotiteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.249 * _default_ * gstaPeridotiteSize ' range=':= 1.249 * _default_ * gstaPeridotiteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 15 ' range=':= 9 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 15 ' range=':= 9 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1548,9 +1548,9 @@
                             <OreBlock block='GeoStrata:geostrata_rock_peridotite_smooth' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 16.000 * gstaPeridotiteSize ' range=':= 16.000 * gstaPeridotiteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 7.200 * gstaPeridotiteFreq ' range=':= 7.200 * gstaPeridotiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 15 ' range=':= 9 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 21.333 * gstaPeridotiteSize ' range=':= 10.67 * gstaPeridotiteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 9.6 * gstaPeridotiteFreq ' range=':= 4.8 * gstaPeridotiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 15 ' range=':= 9 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1578,7 +1578,7 @@
                             <Setting name='CloudRadius' avg=':= 1.655 * _default_ * gstaGranuliteSize ' range=':= 1.655 * _default_ * gstaGranuliteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.655 * _default_ * gstaGranuliteSize ' range=':= 1.655 * _default_ * gstaGranuliteSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 2.739 * _default_ * gstaGranuliteFreq ' range=':= 2.739 * _default_ * gstaGranuliteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 24 ' range=':= 8 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 24 ' range=':= 8 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1604,7 +1604,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 4.103 * _default_ * gstaGranuliteFreq ' range=':= 4.103 * _default_ * gstaGranuliteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.265 * _default_ * gstaGranuliteSize ' range=':= 1.265 * _default_ * gstaGranuliteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 24 ' range=':= 8 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 24 ' range=':= 8 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1635,9 +1635,9 @@
                             <OreBlock block='GeoStrata:geostrata_rock_granulite_smooth' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 16.000 * gstaGranuliteSize ' range=':= 16.000 * gstaGranuliteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 8.400 * gstaGranuliteFreq ' range=':= 8.400 * gstaGranuliteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 24 ' range=':= 8 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 21.333 * gstaGranuliteSize ' range=':= 10.67 * gstaGranuliteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 11.2 * gstaGranuliteFreq ' range=':= 5.6 * gstaGranuliteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 24 ' range=':= 8 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1665,7 +1665,7 @@
                             <Setting name='CloudRadius' avg=':= 1.592 * _default_ * gstaMigmatiteSize ' range=':= 1.592 * _default_ * gstaMigmatiteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.592 * _default_ * gstaMigmatiteSize ' range=':= 1.592 * _default_ * gstaMigmatiteSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 2.535 * _default_ * gstaMigmatiteFreq ' range=':= 2.535 * _default_ * gstaMigmatiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 11 ' range=':= 5 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 11 ' range=':= 5 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1691,7 +1691,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 3.798 * _default_ * gstaMigmatiteFreq ' range=':= 3.798 * _default_ * gstaMigmatiteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.249 * _default_ * gstaMigmatiteSize ' range=':= 1.249 * _default_ * gstaMigmatiteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 11 ' range=':= 5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 11 ' range=':= 5 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1722,9 +1722,9 @@
                             <OreBlock block='GeoStrata:geostrata_rock_migmatite_smooth' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 16.000 * gstaMigmatiteSize ' range=':= 16.000 * gstaMigmatiteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 7.200 * gstaMigmatiteFreq ' range=':= 7.200 * gstaMigmatiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 11 ' range=':= 5 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 21.333 * gstaMigmatiteSize ' range=':= 10.67 * gstaMigmatiteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 9.6 * gstaMigmatiteFreq ' range=':= 4.8 * gstaMigmatiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 11 ' range=':= 5 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1752,7 +1752,7 @@
                             <Setting name='CloudRadius' avg=':= 1.711 * _default_ * gstaSchistSize ' range=':= 1.711 * _default_ * gstaSchistSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.711 * _default_ * gstaSchistSize ' range=':= 1.711 * _default_ * gstaSchistSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 2.928 * _default_ * gstaSchistFreq ' range=':= 2.928 * _default_ * gstaSchistFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 32 ' range=':= 16 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 32 ' range=':= 16 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1778,7 +1778,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 4.386 * _default_ * gstaSchistFreq ' range=':= 4.386 * _default_ * gstaSchistFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.279 * _default_ * gstaSchistSize ' range=':= 1.279 * _default_ * gstaSchistSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 32 ' range=':= 16 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 32 ' range=':= 16 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1809,9 +1809,9 @@
                             <OreBlock block='GeoStrata:geostrata_rock_schist_smooth' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 16.000 * gstaSchistSize ' range=':= 16.000 * gstaSchistSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 9.600 * gstaSchistFreq ' range=':= 9.600 * gstaSchistFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 32 ' range=':= 16 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 21.333 * gstaSchistSize ' range=':= 10.67 * gstaSchistSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 12.8 * gstaSchistFreq ' range=':= 6.4 * gstaSchistFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 32 ' range=':= 16 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1839,7 +1839,7 @@
                             <Setting name='CloudRadius' avg=':= 1.809 * _default_ * gstaBasaltSize ' range=':= 1.809 * _default_ * gstaBasaltSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.809 * _default_ * gstaBasaltSize ' range=':= 1.809 * _default_ * gstaBasaltSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 3.273 * _default_ * gstaBasaltFreq ' range=':= 3.273 * _default_ * gstaBasaltFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 88 ' range=':= 40 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 88 ' range=':= 40 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1865,7 +1865,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 4.904 * _default_ * gstaBasaltFreq ' range=':= 4.904 * _default_ * gstaBasaltFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.303 * _default_ * gstaBasaltSize ' range=':= 1.303 * _default_ * gstaBasaltSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 88 ' range=':= 40 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 88 ' range=':= 40 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1896,9 +1896,9 @@
                             <OreBlock block='GeoStrata:geostrata_rock_basalt_smooth' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 16.000 * gstaBasaltSize ' range=':= 16.000 * gstaBasaltSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 12.000 * gstaBasaltFreq ' range=':= 12.000 * gstaBasaltFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 88 ' range=':= 40 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 21.333 * gstaBasaltSize ' range=':= 10.67 * gstaBasaltSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 16.0 * gstaBasaltFreq ' range=':= 8.0 * gstaBasaltFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 88 ' range=':= 40 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1926,7 +1926,7 @@
                             <Setting name='CloudRadius' avg=':= 1.809 * _default_ * gstaOnyxSize ' range=':= 1.809 * _default_ * gstaOnyxSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.809 * _default_ * gstaOnyxSize ' range=':= 1.809 * _default_ * gstaOnyxSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 3.273 * _default_ * gstaOnyxFreq ' range=':= 3.273 * _default_ * gstaOnyxFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 15 ' range=':= 9 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 15 ' range=':= 9 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1952,7 +1952,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 4.904 * _default_ * gstaOnyxFreq ' range=':= 4.904 * _default_ * gstaOnyxFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.303 * _default_ * gstaOnyxSize ' range=':= 1.303 * _default_ * gstaOnyxSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 15 ' range=':= 9 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 15 ' range=':= 9 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1983,9 +1983,9 @@
                             <OreBlock block='GeoStrata:geostrata_rock_onyx_smooth' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 16.000 * gstaOnyxSize ' range=':= 16.000 * gstaOnyxSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 12.000 * gstaOnyxFreq ' range=':= 12.000 * gstaOnyxFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 15 ' range=':= 9 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 21.333 * gstaOnyxSize ' range=':= 10.67 * gstaOnyxSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 16.0 * gstaOnyxFreq ' range=':= 8.0 * gstaOnyxFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 15 ' range=':= 9 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -2013,7 +2013,7 @@
                             <Setting name='CloudRadius' avg=':= 1.521 * _default_ * gstaQuartzSize ' range=':= 1.521 * _default_ * gstaQuartzSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.521 * _default_ * gstaQuartzSize ' range=':= 1.521 * _default_ * gstaQuartzSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 2.315 * _default_ * gstaQuartzFreq ' range=':= 2.315 * _default_ * gstaQuartzFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 35 ' range=':= 29 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 35 ' range=':= 29 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2039,7 +2039,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 3.467 * _default_ * gstaQuartzFreq ' range=':= 3.467 * _default_ * gstaQuartzFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.230 * _default_ * gstaQuartzSize ' range=':= 1.230 * _default_ * gstaQuartzSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 35 ' range=':= 29 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 35 ' range=':= 29 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2070,9 +2070,9 @@
                             <OreBlock block='GeoStrata:geostrata_rock_quartz_smooth' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 16.000 * gstaQuartzSize ' range=':= 16.000 * gstaQuartzSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 6.000 * gstaQuartzFreq ' range=':= 6.000 * gstaQuartzFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 35 ' range=':= 29 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 21.333 * gstaQuartzSize ' range=':= 10.67 * gstaQuartzSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 8.0 * gstaQuartzFreq ' range=':= 4.0 * gstaQuartzFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 35 ' range=':= 29 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -2100,7 +2100,7 @@
                             <Setting name='CloudRadius' avg=':= 1.809 * _default_ * gstaMarbleSize ' range=':= 1.809 * _default_ * gstaMarbleSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.809 * _default_ * gstaMarbleSize ' range=':= 1.809 * _default_ * gstaMarbleSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 3.273 * _default_ * gstaMarbleFreq ' range=':= 3.273 * _default_ * gstaMarbleFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 40 ' range=':= 24 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 40 ' range=':= 24 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2126,7 +2126,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 4.904 * _default_ * gstaMarbleFreq ' range=':= 4.904 * _default_ * gstaMarbleFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.303 * _default_ * gstaMarbleSize ' range=':= 1.303 * _default_ * gstaMarbleSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 40 ' range=':= 24 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 40 ' range=':= 24 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2157,9 +2157,9 @@
                             <OreBlock block='GeoStrata:geostrata_rock_marble_smooth' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 16.000 * gstaMarbleSize ' range=':= 16.000 * gstaMarbleSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 12.000 * gstaMarbleFreq ' range=':= 12.000 * gstaMarbleFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 40 ' range=':= 24 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 21.333 * gstaMarbleSize ' range=':= 10.67 * gstaMarbleSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 16.0 * gstaMarbleFreq ' range=':= 8.0 * gstaMarbleFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 40 ' range=':= 24 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -2187,7 +2187,7 @@
                             <Setting name='CloudRadius' avg=':= 1.809 * _default_ * gstaGraniteSize ' range=':= 1.809 * _default_ * gstaGraniteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.809 * _default_ * gstaGraniteSize ' range=':= 1.809 * _default_ * gstaGraniteSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 3.273 * _default_ * gstaGraniteFreq ' range=':= 3.273 * _default_ * gstaGraniteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 32 ' range=':= 16 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 32 ' range=':= 16 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2213,7 +2213,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 4.904 * _default_ * gstaGraniteFreq ' range=':= 4.904 * _default_ * gstaGraniteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.303 * _default_ * gstaGraniteSize ' range=':= 1.303 * _default_ * gstaGraniteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 32 ' range=':= 16 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 32 ' range=':= 16 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2244,9 +2244,9 @@
                             <OreBlock block='GeoStrata:geostrata_rock_granite_smooth' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 16.000 * gstaGraniteSize ' range=':= 16.000 * gstaGraniteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 12.000 * gstaGraniteFreq ' range=':= 12.000 * gstaGraniteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 32 ' range=':= 16 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 21.333 * gstaGraniteSize ' range=':= 10.67 * gstaGraniteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 16.0 * gstaGraniteFreq ' range=':= 8.0 * gstaGraniteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 32 ' range=':= 16 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -2274,7 +2274,7 @@
                             <Setting name='CloudRadius' avg=':= 1.711 * _default_ * gstaHornfelSize ' range=':= 1.711 * _default_ * gstaHornfelSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.711 * _default_ * gstaHornfelSize ' range=':= 1.711 * _default_ * gstaHornfelSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 2.928 * _default_ * gstaHornfelFreq ' range=':= 2.928 * _default_ * gstaHornfelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 35 ' range=':= 29 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 35 ' range=':= 29 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2300,7 +2300,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 4.386 * _default_ * gstaHornfelFreq ' range=':= 4.386 * _default_ * gstaHornfelFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.279 * _default_ * gstaHornfelSize ' range=':= 1.279 * _default_ * gstaHornfelSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 35 ' range=':= 29 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 35 ' range=':= 29 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2331,9 +2331,9 @@
                             <OreBlock block='GeoStrata:geostrata_rock_hornfel_smooth' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 16.000 * gstaHornfelSize ' range=':= 16.000 * gstaHornfelSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 9.600 * gstaHornfelFreq ' range=':= 9.600 * gstaHornfelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 35 ' range=':= 29 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 21.333 * gstaHornfelSize ' range=':= 10.67 * gstaHornfelSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 12.8 * gstaHornfelFreq ' range=':= 6.4 * gstaHornfelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 35 ' range=':= 29 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>

--- a/src/main/resources/config/modules/ImmersiveEngineering.xml
+++ b/src/main/resources/config/modules/ImmersiveEngineering.xml
@@ -313,7 +313,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.416 * _default_ * iengCopperFreq ' range=':= 1.416 * _default_ * iengCopperFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.060 * _default_ * iengCopperSize ' range=':= 1.060 * _default_ * iengCopperSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 56 ' range=':= 16 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 56 ' range=':= 16 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -357,7 +357,7 @@
                             <Setting name='CloudRadius' avg=':= 1.271 * _default_ * iengCopperSize ' range=':= 1.271 * _default_ * iengCopperSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.271 * _default_ * iengCopperSize ' range=':= 1.271 * _default_ * iengCopperSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.616 * _default_ * iengCopperFreq ' range=':= 1.616 * _default_ * iengCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 56 ' range=':= 16 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 56 ' range=':= 16 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -408,9 +408,9 @@
                             <OreBlock block='ImmersiveEngineering:ore:0' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.000 * iengCopperSize ' range=':= 4.000 * iengCopperSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 4.000 * iengCopperFreq ' range=':= 4.000 * iengCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 56 ' range=':= 16 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 5.333 * iengCopperSize ' range=':= 2.67 * iengCopperSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 5.333 * iengCopperFreq ' range=':= 2.67 * iengCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 56 ' range=':= 16 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -435,7 +435,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.001 * _default_ * iengBauxiteFreq ' range=':= 1.001 * _default_ * iengBauxiteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.000 * _default_ * iengBauxiteSize ' range=':= 1.000 * _default_ * iengBauxiteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 62.5 ' range=':= 22.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 62.5 ' range=':= 22.5 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -479,7 +479,7 @@
                             <Setting name='CloudRadius' avg=':= 1.069 * _default_ * iengBauxiteSize ' range=':= 1.069 * _default_ * iengBauxiteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.069 * _default_ * iengBauxiteSize ' range=':= 1.069 * _default_ * iengBauxiteSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.143 * _default_ * iengBauxiteFreq ' range=':= 1.143 * _default_ * iengBauxiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 62.5 ' range=':= 22.5 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 62.5 ' range=':= 22.5 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -530,9 +530,9 @@
                             <OreBlock block='ImmersiveEngineering:ore:1' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 2.000 * iengBauxiteSize ' range=':= 2.000 * iengBauxiteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 4.000 * iengBauxiteFreq ' range=':= 4.000 * iengBauxiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 62.5 ' range=':= 22.5 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.667 * iengBauxiteSize ' range=':= 1.33 * iengBauxiteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 5.333 * iengBauxiteFreq ' range=':= 2.67 * iengBauxiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 62.5 ' range=':= 22.5 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -557,7 +557,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.867 * _default_ * iengLeadFreq ' range=':= 0.867 * _default_ * iengLeadFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.976 * _default_ * iengLeadSize ' range=':= 0.976 * _default_ * iengLeadSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 22 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 22 ' range=':= 14 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -601,7 +601,7 @@
                             <Setting name='CloudRadius' avg=':= 0.995 * _default_ * iengLeadSize ' range=':= 0.995 * _default_ * iengLeadSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.995 * _default_ * iengLeadSize ' range=':= 0.995 * _default_ * iengLeadSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.990 * _default_ * iengLeadFreq ' range=':= 0.990 * _default_ * iengLeadFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 22 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 22 ' range=':= 14 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -652,9 +652,9 @@
                             <OreBlock block='ImmersiveEngineering:ore:2' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3.000 * iengLeadSize ' range=':= 3.000 * iengLeadSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2.000 * iengLeadFreq ' range=':= 2.000 * iengLeadFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 22 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.0 * iengLeadSize ' range=':= 2.0 * iengLeadSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2.667 * iengLeadFreq ' range=':= 1.33 * iengLeadFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 22 ' range=':= 14 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -679,7 +679,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.001 * _default_ * iengSilverFreq ' range=':= 1.001 * _default_ * iengSilverFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.000 * _default_ * iengSilverSize ' range=':= 1.000 * _default_ * iengSilverSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 24 ' range=':= 16 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 24 ' range=':= 16 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -723,7 +723,7 @@
                             <Setting name='CloudRadius' avg=':= 1.069 * _default_ * iengSilverSize ' range=':= 1.069 * _default_ * iengSilverSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.069 * _default_ * iengSilverSize ' range=':= 1.069 * _default_ * iengSilverSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.143 * _default_ * iengSilverFreq ' range=':= 1.143 * _default_ * iengSilverFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 24 ' range=':= 16 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 24 ' range=':= 16 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -774,9 +774,9 @@
                             <OreBlock block='ImmersiveEngineering:ore:3' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.000 * iengSilverSize ' range=':= 4.000 * iengSilverSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2.000 * iengSilverFreq ' range=':= 2.000 * iengSilverFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 24 ' range=':= 16 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 5.333 * iengSilverSize ' range=':= 2.67 * iengSilverSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2.667 * iengSilverFreq ' range=':= 1.33 * iengSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 24 ' range=':= 16 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -801,7 +801,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.613 * _default_ * iengNickelFreq ' range=':= 0.613 * _default_ * iengNickelFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * iengNickelSize ' range=':= 0.922 * _default_ * iengNickelSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 16 ' range=':= 8 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 16 ' range=':= 8 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -845,7 +845,7 @@
                             <Setting name='CloudRadius' avg=':= 0.837 * _default_ * iengNickelSize ' range=':= 0.837 * _default_ * iengNickelSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.837 * _default_ * iengNickelSize ' range=':= 0.837 * _default_ * iengNickelSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.700 * _default_ * iengNickelFreq ' range=':= 0.700 * _default_ * iengNickelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 16 ' range=':= 8 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 16 ' range=':= 8 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -896,9 +896,9 @@
                             <OreBlock block='ImmersiveEngineering:ore:4' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3.000 * iengNickelSize ' range=':= 3.000 * iengNickelSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.000 * iengNickelFreq ' range=':= 1.000 * iengNickelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 16 ' range=':= 8 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.0 * iengNickelSize ' range=':= 2.0 * iengNickelSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.333 * iengNickelFreq ' range=':= 0.67 * iengNickelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 16 ' range=':= 8 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>

--- a/src/main/resources/config/modules/IndustrialCraft2.xml
+++ b/src/main/resources/config/modules/IndustrialCraft2.xml
@@ -265,7 +265,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.167 * _default_ * ic2CopperFreq ' range=':= 2.167 * _default_ * ic2CopperFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.138 * _default_ * ic2CopperSize ' range=':= 1.138 * _default_ * ic2CopperSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 40 ' range=':= 30 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 40 ' range=':= 30 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -309,7 +309,7 @@
                             <Setting name='CloudRadius' avg=':= 1.573 * _default_ * ic2CopperSize ' range=':= 1.573 * _default_ * ic2CopperSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.573 * _default_ * ic2CopperSize ' range=':= 1.573 * _default_ * ic2CopperSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 2.474 * _default_ * ic2CopperFreq ' range=':= 2.474 * _default_ * ic2CopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 40 ' range=':= 30 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 40 ' range=':= 30 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -360,9 +360,9 @@
                             <OreBlock block='IC2:blockOreCopper' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 5.000 * ic2CopperSize ' range=':= 5.000 * ic2CopperSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 7.500 * ic2CopperFreq ' range=':= 7.500 * ic2CopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 40 ' range=':= 30 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 6.667 * ic2CopperSize ' range=':= 3.33 * ic2CopperSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 10.0 * ic2CopperFreq ' range=':= 5.0 * ic2CopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 40 ' range=':= 30 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -387,7 +387,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.167 * _default_ * ic2TinFreq ' range=':= 2.167 * _default_ * ic2TinFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.138 * _default_ * ic2TinSize ' range=':= 1.138 * _default_ * ic2TinSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 20 ' range=':= 20 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 20 ' range=':= 20 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -431,7 +431,7 @@
                             <Setting name='CloudRadius' avg=':= 1.573 * _default_ * ic2TinSize ' range=':= 1.573 * _default_ * ic2TinSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.573 * _default_ * ic2TinSize ' range=':= 1.573 * _default_ * ic2TinSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 2.474 * _default_ * ic2TinFreq ' range=':= 2.474 * _default_ * ic2TinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 20 ' range=':= 20 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 20 ' range=':= 20 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -482,9 +482,9 @@
                             <OreBlock block='IC2:blockOreTin' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3.000 * ic2TinSize ' range=':= 3.000 * ic2TinSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 12.500 * ic2TinFreq ' range=':= 12.500 * ic2TinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 20 ' range=':= 20 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.0 * ic2TinSize ' range=':= 2.0 * ic2TinSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 16.667 * ic2TinFreq ' range=':= 8.33 * ic2TinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 20 ' range=':= 20 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -516,7 +516,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 3.355 * _default_ * ic2UraniumFreq ' range=':= 3.355 * _default_ * ic2UraniumFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * ic2UraniumSize ' range=':= 0 * _default_ * ic2UraniumSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 30 ' range=':= 30 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 30 ' range=':= 30 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -560,7 +560,7 @@
                             <Setting name='CloudRadius' avg=':= 1.251 * _default_ * ic2UraniumSize ' range=':= 1.251 * _default_ * ic2UraniumSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.251 * _default_ * ic2UraniumSize ' range=':= 1.251 * _default_ * ic2UraniumSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.565 * _default_ * ic2UraniumFreq ' range=':= 1.565 * _default_ * ic2UraniumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 30 ' range=':= 30 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 30 ' range=':= 30 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -611,9 +611,9 @@
                             <OreBlock block='IC2:blockOreUran' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 1.500 * ic2UraniumSize ' range=':= 1.500 * ic2UraniumSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 10.000 * ic2UraniumFreq ' range=':= 10.000 * ic2UraniumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 30 ' range=':= 30 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.0 * ic2UraniumSize ' range=':= 1.0 * ic2UraniumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 13.333 * ic2UraniumFreq ' range=':= 6.67 * ic2UraniumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 30 ' range=':= 30 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -638,7 +638,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.001 * _default_ * ic2LeadFreq ' range=':= 1.001 * _default_ * ic2LeadFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.000 * _default_ * ic2LeadSize ' range=':= 1.000 * _default_ * ic2LeadSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 30 ' range=':= 30 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 30 ' range=':= 30 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -682,7 +682,7 @@
                             <Setting name='CloudRadius' avg=':= 1.069 * _default_ * ic2LeadSize ' range=':= 1.069 * _default_ * ic2LeadSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.069 * _default_ * ic2LeadSize ' range=':= 1.069 * _default_ * ic2LeadSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.143 * _default_ * ic2LeadFreq ' range=':= 1.143 * _default_ * ic2LeadFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 30 ' range=':= 30 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 30 ' range=':= 30 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -733,9 +733,9 @@
                             <OreBlock block='IC2:blockOreLead' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 2.000 * ic2LeadSize ' range=':= 2.000 * ic2LeadSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 4.000 * ic2LeadFreq ' range=':= 4.000 * ic2LeadFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 30 ' range=':= 30 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.667 * ic2LeadSize ' range=':= 1.33 * ic2LeadSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 5.333 * ic2LeadFreq ' range=':= 2.67 * ic2LeadFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 30 ' range=':= 30 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>

--- a/src/main/resources/config/modules/MagnetiCraft.xml
+++ b/src/main/resources/config/modules/MagnetiCraft.xml
@@ -454,7 +454,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.583 * _default_ * mgntCopperFreq ' range=':= 1.583 * _default_ * mgntCopperFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.080 * _default_ * mgntCopperSize ' range=':= 1.080 * _default_ * mgntCopperSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 55 ' range=':= 25 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 55 ' range=':= 25 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -498,7 +498,7 @@
                             <Setting name='CloudRadius' avg=':= 1.344 * _default_ * mgntCopperSize ' range=':= 1.344 * _default_ * mgntCopperSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.344 * _default_ * mgntCopperSize ' range=':= 1.344 * _default_ * mgntCopperSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.807 * _default_ * mgntCopperFreq ' range=':= 1.807 * _default_ * mgntCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 55 ' range=':= 25 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 55 ' range=':= 25 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -549,9 +549,9 @@
                             <OreBlock block='Magneticraft:copper_ore' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.000 * mgntCopperSize ' range=':= 4.000 * mgntCopperSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 5.000 * mgntCopperFreq ' range=':= 5.000 * mgntCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 55 ' range=':= 25 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 5.333 * mgntCopperSize ' range=':= 2.67 * mgntCopperSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 6.667 * mgntCopperFreq ' range=':= 3.33 * mgntCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 55 ' range=':= 25 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -583,7 +583,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.500 * _default_ * mgntTungstenFreq ' range=':= 1.500 * _default_ * mgntTungstenFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * mgntTungstenSize ' range=':= 0 * _default_ * mgntTungstenSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 5 ' range=':= 5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 5 ' range=':= 5 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -627,7 +627,7 @@
                             <Setting name='CloudRadius' avg=':= 0.837 * _default_ * mgntTungstenSize ' range=':= 0.837 * _default_ * mgntTungstenSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.837 * _default_ * mgntTungstenSize ' range=':= 0.837 * _default_ * mgntTungstenSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.700 * _default_ * mgntTungstenFreq ' range=':= 0.700 * _default_ * mgntTungstenFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 5 ' range=':= 5 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 5 ' range=':= 5 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -678,9 +678,9 @@
                             <OreBlock block='Magneticraft:tungsten_ore' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3.000 * mgntTungstenSize ' range=':= 3.000 * mgntTungstenSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.000 * mgntTungstenFreq ' range=':= 1.000 * mgntTungstenFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 5 ' range=':= 5 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.0 * mgntTungstenSize ' range=':= 2.0 * mgntTungstenSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.333 * mgntTungstenFreq ' range=':= 0.67 * mgntTungstenFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 5 ' range=':= 5 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -705,7 +705,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.323 * _default_ * mgntSulfurFreq ' range=':= 1.323 * _default_ * mgntSulfurFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * mgntSulfurSize ' range=':= 0 * _default_ * mgntSulfurSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 6 ' range=':= 6 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 6 ' range=':= 6 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -759,7 +759,7 @@
                             <Setting name='CloudRadius' avg=':= 0.995 * _default_ * mgntSulfurSize ' range=':= 0.995 * _default_ * mgntSulfurSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.995 * _default_ * mgntSulfurSize ' range=':= 0.995 * _default_ * mgntSulfurSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.990 * _default_ * mgntSulfurFreq ' range=':= 0.990 * _default_ * mgntSulfurFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 6 ' range=':= 6 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 6 ' range=':= 6 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -810,9 +810,9 @@
                             <OreBlock block='Magneticraft:sulfur_ore' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.000 * mgntSulfurSize ' range=':= 4.000 * mgntSulfurSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.500 * mgntSulfurFreq ' range=':= 1.500 * mgntSulfurFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 6 ' range=':= 6 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 5.333 * mgntSulfurSize ' range=':= 2.67 * mgntSulfurSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2.0 * mgntSulfurFreq ' range=':= 1.0 * mgntSulfurFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 6 ' range=':= 6 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -844,7 +844,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.299 * _default_ * mgntUraniumFreq ' range=':= 1.299 * _default_ * mgntUraniumFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * mgntUraniumSize ' range=':= 0 * _default_ * mgntUraniumSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 40 ' range=':= 40 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 40 ' range=':= 40 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -888,7 +888,7 @@
                             <Setting name='CloudRadius' avg=':= 0.779 * _default_ * mgntUraniumSize ' range=':= 0.779 * _default_ * mgntUraniumSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.779 * _default_ * mgntUraniumSize ' range=':= 0.779 * _default_ * mgntUraniumSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.606 * _default_ * mgntUraniumFreq ' range=':= 0.606 * _default_ * mgntUraniumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 40 ' range=':= 40 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 40 ' range=':= 40 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -939,9 +939,9 @@
                             <OreBlock block='Magneticraft:uranium_ore' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 1.500 * mgntUraniumSize ' range=':= 1.500 * mgntUraniumSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.500 * mgntUraniumFreq ' range=':= 1.500 * mgntUraniumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 40 ' range=':= 40 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.0 * mgntUraniumSize ' range=':= 1.0 * mgntUraniumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2.0 * mgntUraniumFreq ' range=':= 1.0 * mgntUraniumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 40 ' range=':= 40 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -968,7 +968,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.212 * _default_ * mgntThoriumFreq ' range=':= 1.212 * _default_ * mgntThoriumFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.033 * _default_ * mgntThoriumSize ' range=':= 1.033 * _default_ * mgntThoriumSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 10 ' range=':= 10 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 10 ' range=':= 10 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1012,7 +1012,7 @@
                             <Setting name='CloudRadius' avg=':= 1.052 * _default_ * mgntThoriumSize ' range=':= 1.052 * _default_ * mgntThoriumSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.052 * _default_ * mgntThoriumSize ' range=':= 1.052 * _default_ * mgntThoriumSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.107 * _default_ * mgntThoriumFreq ' range=':= 1.107 * _default_ * mgntThoriumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 10 ' range=':= 10 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 10 ' range=':= 10 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1063,9 +1063,9 @@
                             <OreBlock block='Magneticraft:thorium_ore' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3.000 * mgntThoriumSize ' range=':= 3.000 * mgntThoriumSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2.500 * mgntThoriumFreq ' range=':= 2.500 * mgntThoriumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 10 ' range=':= 10 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.0 * mgntThoriumSize ' range=':= 2.0 * mgntThoriumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 3.333 * mgntThoriumFreq ' range=':= 1.67 * mgntThoriumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 10 ' range=':= 10 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1097,7 +1097,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 3.001 * _default_ * mgntSaltFreq ' range=':= 3.001 * _default_ * mgntSaltFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * mgntSaltSize ' range=':= 0 * _default_ * mgntSaltSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 40 ' range=':= 40 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 40 ' range=':= 40 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1141,7 +1141,7 @@
                             <Setting name='CloudRadius' avg=':= 1.183 * _default_ * mgntSaltSize ' range=':= 1.183 * _default_ * mgntSaltSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.183 * _default_ * mgntSaltSize ' range=':= 1.183 * _default_ * mgntSaltSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.400 * _default_ * mgntSaltFreq ' range=':= 1.400 * _default_ * mgntSaltFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 40 ' range=':= 40 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 40 ' range=':= 40 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1192,9 +1192,9 @@
                             <OreBlock block='Magneticraft:salt_ore' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3.000 * mgntSaltSize ' range=':= 3.000 * mgntSaltSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 4.000 * mgntSaltFreq ' range=':= 4.000 * mgntSaltFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 40 ' range=':= 40 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.0 * mgntSaltSize ' range=':= 2.0 * mgntSaltSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 5.333 * mgntSaltFreq ' range=':= 2.67 * mgntSaltFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 40 ' range=':= 40 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1219,7 +1219,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.867 * _default_ * mgntZincFreq ' range=':= 0.867 * _default_ * mgntZincFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.976 * _default_ * mgntZincSize ' range=':= 0.976 * _default_ * mgntZincSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 40 ' range=':= 40 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 40 ' range=':= 40 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1263,7 +1263,7 @@
                             <Setting name='CloudRadius' avg=':= 0.995 * _default_ * mgntZincSize ' range=':= 0.995 * _default_ * mgntZincSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.995 * _default_ * mgntZincSize ' range=':= 0.995 * _default_ * mgntZincSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.990 * _default_ * mgntZincFreq ' range=':= 0.990 * _default_ * mgntZincFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 40 ' range=':= 40 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 40 ' range=':= 40 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1314,9 +1314,9 @@
                             <OreBlock block='Magneticraft:zinc_ore' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3.000 * mgntZincSize ' range=':= 3.000 * mgntZincSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2.000 * mgntZincFreq ' range=':= 2.000 * mgntZincFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 40 ' range=':= 40 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.0 * mgntZincSize ' range=':= 2.0 * mgntZincSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2.667 * mgntZincFreq ' range=':= 1.33 * mgntZincFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 40 ' range=':= 40 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1344,7 +1344,7 @@
                             <Setting name='CloudRadius' avg=':= 1.367 * _default_ * mgntLimestoneSize ' range=':= 1.367 * _default_ * mgntLimestoneSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.367 * _default_ * mgntLimestoneSize ' range=':= 1.367 * _default_ * mgntLimestoneSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.868 * _default_ * mgntLimestoneFreq ' range=':= 1.868 * _default_ * mgntLimestoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 40 ' range=':= 24 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 40 ' range=':= 24 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1370,7 +1370,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.798 * _default_ * mgntLimestoneFreq ' range=':= 2.798 * _default_ * mgntLimestoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.187 * _default_ * mgntLimestoneSize ' range=':= 1.187 * _default_ * mgntLimestoneSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 40 ' range=':= 24 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 40 ' range=':= 24 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1401,9 +1401,9 @@
                             <OreBlock block='Magneticraft:limestone' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 25.000 * mgntLimestoneSize ' range=':= 25.000 * mgntLimestoneSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2.500 * mgntLimestoneFreq ' range=':= 2.500 * mgntLimestoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 40 ' range=':= 24 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 33.333 * mgntLimestoneSize ' range=':= 16.67 * mgntLimestoneSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 3.333 * mgntLimestoneFreq ' range=':= 1.67 * mgntLimestoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 40 ' range=':= 24 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>

--- a/src/main/resources/config/modules/Mariculture.xml
+++ b/src/main/resources/config/modules/Mariculture.xml
@@ -171,7 +171,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.002 * _default_ * mrclBauxiteFreq ' range=':= 2.002 * _default_ * mrclBauxiteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.123 * _default_ * mrclBauxiteSize ' range=':= 1.123 * _default_ * mrclBauxiteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 96 ' range=':= 32 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 96 ' range=':= 32 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -215,7 +215,7 @@
                             <Setting name='CloudRadius' avg=':= 1.512 * _default_ * mrclBauxiteSize ' range=':= 1.512 * _default_ * mrclBauxiteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.512 * _default_ * mrclBauxiteSize ' range=':= 1.512 * _default_ * mrclBauxiteSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 2.286 * _default_ * mrclBauxiteFreq ' range=':= 2.286 * _default_ * mrclBauxiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 96 ' range=':= 32 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 96 ' range=':= 32 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -266,9 +266,9 @@
                             <OreBlock block='Mariculture:rocks:2' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.000 * mrclBauxiteSize ' range=':= 4.000 * mrclBauxiteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 8.000 * mrclBauxiteFreq ' range=':= 8.000 * mrclBauxiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 96 ' range=':= 32 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 5.333 * mrclBauxiteSize ' range=':= 2.67 * mrclBauxiteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 10.667 * mrclBauxiteFreq ' range=':= 5.33 * mrclBauxiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 96 ' range=':= 32 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -293,7 +293,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.371 * _default_ * mrclCopperFreq ' range=':= 1.371 * _default_ * mrclCopperFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.054 * _default_ * mrclCopperSize ' range=':= 1.054 * _default_ * mrclCopperSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 32.5 ' range=':= 31.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 32.5 ' range=':= 31.5 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -337,7 +337,7 @@
                             <Setting name='CloudRadius' avg=':= 1.251 * _default_ * mrclCopperSize ' range=':= 1.251 * _default_ * mrclCopperSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.251 * _default_ * mrclCopperSize ' range=':= 1.251 * _default_ * mrclCopperSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.565 * _default_ * mrclCopperFreq ' range=':= 1.565 * _default_ * mrclCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 32.5 ' range=':= 31.5 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 32.5 ' range=':= 31.5 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -388,9 +388,9 @@
                             <OreBlock block='Mariculture:rocks:1' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 2.500 * mrclCopperSize ' range=':= 2.500 * mrclCopperSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 6.000 * mrclCopperFreq ' range=':= 6.000 * mrclCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 32.5 ' range=':= 31.5 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 3.333 * mrclCopperSize ' range=':= 1.67 * mrclCopperSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 8.0 * mrclCopperFreq ' range=':= 4.0 * mrclCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 32.5 ' range=':= 31.5 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>

--- a/src/main/resources/config/modules/Mekanism.xml
+++ b/src/main/resources/config/modules/Mekanism.xml
@@ -218,7 +218,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.734 * _default_ * mknsOsmiumFreq ' range=':= 1.734 * _default_ * mknsOsmiumFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.096 * _default_ * mknsOsmiumSize ' range=':= 1.096 * _default_ * mknsOsmiumSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 33 ' range=':= 27 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 33 ' range=':= 27 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -262,7 +262,7 @@
                             <Setting name='CloudRadius' avg=':= 1.407 * _default_ * mknsOsmiumSize ' range=':= 1.407 * _default_ * mknsOsmiumSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.407 * _default_ * mknsOsmiumSize ' range=':= 1.407 * _default_ * mknsOsmiumSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.979 * _default_ * mknsOsmiumFreq ' range=':= 1.979 * _default_ * mknsOsmiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 33 ' range=':= 27 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 33 ' range=':= 27 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -313,9 +313,9 @@
                             <OreBlock block='Mekanism:OreBlock' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.000 * mknsOsmiumSize ' range=':= 4.000 * mknsOsmiumSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 6.000 * mknsOsmiumFreq ' range=':= 6.000 * mknsOsmiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 33 ' range=':= 27 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 5.333 * mknsOsmiumSize ' range=':= 2.67 * mknsOsmiumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 8.0 * mknsOsmiumFreq ' range=':= 4.0 * mknsOsmiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 33 ' range=':= 27 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -340,7 +340,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.002 * _default_ * mknsCopperFreq ' range=':= 2.002 * _default_ * mknsCopperFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.123 * _default_ * mknsCopperSize ' range=':= 1.123 * _default_ * mknsCopperSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 33 ' range=':= 27 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 33 ' range=':= 27 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -384,7 +384,7 @@
                             <Setting name='CloudRadius' avg=':= 1.512 * _default_ * mknsCopperSize ' range=':= 1.512 * _default_ * mknsCopperSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.512 * _default_ * mknsCopperSize ' range=':= 1.512 * _default_ * mknsCopperSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 2.286 * _default_ * mknsCopperFreq ' range=':= 2.286 * _default_ * mknsCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 33 ' range=':= 27 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 33 ' range=':= 27 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -435,9 +435,9 @@
                             <OreBlock block='Mekanism:OreBlock:1' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.000 * mknsCopperSize ' range=':= 4.000 * mknsCopperSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 8.000 * mknsCopperFreq ' range=':= 8.000 * mknsCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 33 ' range=':= 27 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 5.333 * mknsCopperSize ' range=':= 2.67 * mknsCopperSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 10.667 * mknsCopperFreq ' range=':= 5.33 * mknsCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 33 ' range=':= 27 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -462,7 +462,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.873 * _default_ * mknsTinFreq ' range=':= 1.873 * _default_ * mknsTinFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.110 * _default_ * mknsTinSize ' range=':= 1.110 * _default_ * mknsTinSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 33 ' range=':= 27 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 33 ' range=':= 27 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -506,7 +506,7 @@
                             <Setting name='CloudRadius' avg=':= 1.462 * _default_ * mknsTinSize ' range=':= 1.462 * _default_ * mknsTinSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.462 * _default_ * mknsTinSize ' range=':= 1.462 * _default_ * mknsTinSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 2.138 * _default_ * mknsTinFreq ' range=':= 2.138 * _default_ * mknsTinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 33 ' range=':= 27 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 33 ' range=':= 27 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -557,9 +557,9 @@
                             <OreBlock block='Mekanism:OreBlock:2' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.000 * mknsTinSize ' range=':= 4.000 * mknsTinSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 7.000 * mknsTinFreq ' range=':= 7.000 * mknsTinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 33 ' range=':= 27 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 5.333 * mknsTinSize ' range=':= 2.67 * mknsTinSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 9.333 * mknsTinFreq ' range=':= 4.67 * mknsTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 33 ' range=':= 27 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>

--- a/src/main/resources/config/modules/Metallurgy4.xml
+++ b/src/main/resources/config/modules/Metallurgy4.xml
@@ -1725,7 +1725,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.733 * _default_ * mtlgSulfurFreq ' range=':= 1.733 * _default_ * mtlgSulfurFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * mtlgSulfurSize ' range=':= 0 * _default_ * mtlgSulfurSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1769,7 +1769,7 @@
                             <Setting name='CloudRadius' avg=':= 0.899 * _default_ * mtlgSulfurSize ' range=':= 0.899 * _default_ * mtlgSulfurSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.899 * _default_ * mtlgSulfurSize ' range=':= 0.899 * _default_ * mtlgSulfurSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.808 * _default_ * mtlgSulfurFreq ' range=':= 0.808 * _default_ * mtlgSulfurFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1820,9 +1820,9 @@
                             <OreBlock block='Metallurgy:utility.ore' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 2.000 * mtlgSulfurSize ' range=':= 2.000 * mtlgSulfurSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2.000 * mtlgSulfurFreq ' range=':= 2.000 * mtlgSulfurFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.667 * mtlgSulfurSize ' range=':= 1.33 * mtlgSulfurSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2.667 * mtlgSulfurFreq ' range=':= 1.33 * mtlgSulfurFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1854,7 +1854,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.733 * _default_ * mtlgPhosphoriteFreq ' range=':= 1.733 * _default_ * mtlgPhosphoriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * mtlgPhosphoriteSize ' range=':= 0 * _default_ * mtlgPhosphoriteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1898,7 +1898,7 @@
                             <Setting name='CloudRadius' avg=':= 0.899 * _default_ * mtlgPhosphoriteSize ' range=':= 0.899 * _default_ * mtlgPhosphoriteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.899 * _default_ * mtlgPhosphoriteSize ' range=':= 0.899 * _default_ * mtlgPhosphoriteSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.808 * _default_ * mtlgPhosphoriteFreq ' range=':= 0.808 * _default_ * mtlgPhosphoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1950,9 +1950,9 @@
                             <OreBlock block='Metallurgy:utility.ore:1' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 2.000 * mtlgPhosphoriteSize ' range=':= 2.000 * mtlgPhosphoriteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2.000 * mtlgPhosphoriteFreq ' range=':= 2.000 * mtlgPhosphoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.667 * mtlgPhosphoriteSize ' range=':= 1.33 * mtlgPhosphoriteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2.667 * mtlgPhosphoriteFreq ' range=':= 1.33 * mtlgPhosphoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1984,7 +1984,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.733 * _default_ * mtlgSaltpeterFreq ' range=':= 1.733 * _default_ * mtlgSaltpeterFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * mtlgSaltpeterSize ' range=':= 0 * _default_ * mtlgSaltpeterSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2028,7 +2028,7 @@
                             <Setting name='CloudRadius' avg=':= 0.899 * _default_ * mtlgSaltpeterSize ' range=':= 0.899 * _default_ * mtlgSaltpeterSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.899 * _default_ * mtlgSaltpeterSize ' range=':= 0.899 * _default_ * mtlgSaltpeterSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.808 * _default_ * mtlgSaltpeterFreq ' range=':= 0.808 * _default_ * mtlgSaltpeterFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2079,9 +2079,9 @@
                             <OreBlock block='Metallurgy:utility.ore:2' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 2.000 * mtlgSaltpeterSize ' range=':= 2.000 * mtlgSaltpeterSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2.000 * mtlgSaltpeterFreq ' range=':= 2.000 * mtlgSaltpeterFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.667 * mtlgSaltpeterSize ' range=':= 1.33 * mtlgSaltpeterSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2.667 * mtlgSaltpeterFreq ' range=':= 1.33 * mtlgSaltpeterFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -2113,7 +2113,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.733 * _default_ * mtlgMagnesiumFreq ' range=':= 1.733 * _default_ * mtlgMagnesiumFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * mtlgMagnesiumSize ' range=':= 0 * _default_ * mtlgMagnesiumSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2157,7 +2157,7 @@
                             <Setting name='CloudRadius' avg=':= 0.899 * _default_ * mtlgMagnesiumSize ' range=':= 0.899 * _default_ * mtlgMagnesiumSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.899 * _default_ * mtlgMagnesiumSize ' range=':= 0.899 * _default_ * mtlgMagnesiumSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.808 * _default_ * mtlgMagnesiumFreq ' range=':= 0.808 * _default_ * mtlgMagnesiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2208,9 +2208,9 @@
                             <OreBlock block='Metallurgy:utility.ore:3' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 2.000 * mtlgMagnesiumSize ' range=':= 2.000 * mtlgMagnesiumSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2.000 * mtlgMagnesiumFreq ' range=':= 2.000 * mtlgMagnesiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.667 * mtlgMagnesiumSize ' range=':= 1.33 * mtlgMagnesiumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2.667 * mtlgMagnesiumFreq ' range=':= 1.33 * mtlgMagnesiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -2242,7 +2242,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.733 * _default_ * mtlgBitumenFreq ' range=':= 1.733 * _default_ * mtlgBitumenFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * mtlgBitumenSize ' range=':= 0 * _default_ * mtlgBitumenSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2286,7 +2286,7 @@
                             <Setting name='CloudRadius' avg=':= 0.899 * _default_ * mtlgBitumenSize ' range=':= 0.899 * _default_ * mtlgBitumenSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.899 * _default_ * mtlgBitumenSize ' range=':= 0.899 * _default_ * mtlgBitumenSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.808 * _default_ * mtlgBitumenFreq ' range=':= 0.808 * _default_ * mtlgBitumenFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2337,9 +2337,9 @@
                             <OreBlock block='Metallurgy:utility.ore:4' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 2.000 * mtlgBitumenSize ' range=':= 2.000 * mtlgBitumenSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2.000 * mtlgBitumenFreq ' range=':= 2.000 * mtlgBitumenFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.667 * mtlgBitumenSize ' range=':= 1.33 * mtlgBitumenSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2.667 * mtlgBitumenFreq ' range=':= 1.33 * mtlgBitumenFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -2371,7 +2371,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.733 * _default_ * mtlgPotashFreq ' range=':= 1.733 * _default_ * mtlgPotashFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * mtlgPotashSize ' range=':= 0 * _default_ * mtlgPotashSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2415,7 +2415,7 @@
                             <Setting name='CloudRadius' avg=':= 0.899 * _default_ * mtlgPotashSize ' range=':= 0.899 * _default_ * mtlgPotashSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.899 * _default_ * mtlgPotashSize ' range=':= 0.899 * _default_ * mtlgPotashSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.808 * _default_ * mtlgPotashFreq ' range=':= 0.808 * _default_ * mtlgPotashFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2466,9 +2466,9 @@
                             <OreBlock block='Metallurgy:utility.ore:5' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 2.000 * mtlgPotashSize ' range=':= 2.000 * mtlgPotashSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2.000 * mtlgPotashFreq ' range=':= 2.000 * mtlgPotashFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.667 * mtlgPotashSize ' range=':= 1.33 * mtlgPotashSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2.667 * mtlgPotashFreq ' range=':= 1.33 * mtlgPotashFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -2493,7 +2493,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.501 * _default_ * mtlgCopperFreq ' range=':= 1.501 * _default_ * mtlgCopperFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.070 * _default_ * mtlgCopperSize ' range=':= 1.070 * _default_ * mtlgCopperSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2537,7 +2537,7 @@
                             <Setting name='CloudRadius' avg=':= 1.309 * _default_ * mtlgCopperSize ' range=':= 1.309 * _default_ * mtlgCopperSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.309 * _default_ * mtlgCopperSize ' range=':= 1.309 * _default_ * mtlgCopperSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.714 * _default_ * mtlgCopperFreq ' range=':= 1.714 * _default_ * mtlgCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2588,9 +2588,9 @@
                             <OreBlock block='Metallurgy:base.ore' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3.000 * mtlgCopperSize ' range=':= 3.000 * mtlgCopperSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 6.000 * mtlgCopperFreq ' range=':= 6.000 * mtlgCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.0 * mtlgCopperSize ' range=':= 2.0 * mtlgCopperSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 8.0 * mtlgCopperFreq ' range=':= 4.0 * mtlgCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -2615,7 +2615,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.480 * _default_ * mtlgTinFreq ' range=':= 1.480 * _default_ * mtlgTinFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.068 * _default_ * mtlgTinSize ' range=':= 1.068 * _default_ * mtlgTinSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2659,7 +2659,7 @@
                             <Setting name='CloudRadius' avg=':= 1.300 * _default_ * mtlgTinSize ' range=':= 1.300 * _default_ * mtlgTinSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.300 * _default_ * mtlgTinSize ' range=':= 1.300 * _default_ * mtlgTinSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.690 * _default_ * mtlgTinFreq ' range=':= 1.690 * _default_ * mtlgTinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2710,9 +2710,9 @@
                             <OreBlock block='Metallurgy:base.ore:1' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 5.000 * mtlgTinSize ' range=':= 5.000 * mtlgTinSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 3.500 * mtlgTinFreq ' range=':= 3.500 * mtlgTinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 6.667 * mtlgTinSize ' range=':= 3.33 * mtlgTinSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4.667 * mtlgTinFreq ' range=':= 2.33 * mtlgTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -2737,7 +2737,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.791 * _default_ * mtlgManganeseFreq ' range=':= 0.791 * _default_ * mtlgManganeseFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.962 * _default_ * mtlgManganeseSize ' range=':= 0.962 * _default_ * mtlgManganeseSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2781,7 +2781,7 @@
                             <Setting name='CloudRadius' avg=':= 0.951 * _default_ * mtlgManganeseSize ' range=':= 0.951 * _default_ * mtlgManganeseSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.951 * _default_ * mtlgManganeseSize ' range=':= 0.951 * _default_ * mtlgManganeseSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.904 * _default_ * mtlgManganeseFreq ' range=':= 0.904 * _default_ * mtlgManganeseFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2832,9 +2832,9 @@
                             <OreBlock block='Metallurgy:base.ore:2' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 2.000 * mtlgManganeseSize ' range=':= 2.000 * mtlgManganeseSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2.500 * mtlgManganeseFreq ' range=':= 2.500 * mtlgManganeseFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.667 * mtlgManganeseSize ' range=':= 1.33 * mtlgManganeseSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 3.333 * mtlgManganeseFreq ' range=':= 1.67 * mtlgManganeseFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -2859,7 +2859,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * mtlgZincFreq ' range=':= 0.969 * _default_ * mtlgZincFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.995 * _default_ * mtlgZincSize ' range=':= 0.995 * _default_ * mtlgZincSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2903,7 +2903,7 @@
                             <Setting name='CloudRadius' avg=':= 1.052 * _default_ * mtlgZincSize ' range=':= 1.052 * _default_ * mtlgZincSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.052 * _default_ * mtlgZincSize ' range=':= 1.052 * _default_ * mtlgZincSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.107 * _default_ * mtlgZincFreq ' range=':= 1.107 * _default_ * mtlgZincFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2954,9 +2954,9 @@
                             <OreBlock block='Metallurgy:precious.ore' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 2.500 * mtlgZincSize ' range=':= 2.500 * mtlgZincSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 3.000 * mtlgZincFreq ' range=':= 3.000 * mtlgZincFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 3.333 * mtlgZincSize ' range=':= 1.67 * mtlgZincSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4.0 * mtlgZincFreq ' range=':= 2.0 * mtlgZincFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -2981,7 +2981,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * mtlgSilverFreq ' range=':= 0.969 * _default_ * mtlgSilverFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.995 * _default_ * mtlgSilverSize ' range=':= 0.995 * _default_ * mtlgSilverSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3025,7 +3025,7 @@
                             <Setting name='CloudRadius' avg=':= 1.052 * _default_ * mtlgSilverSize ' range=':= 1.052 * _default_ * mtlgSilverSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.052 * _default_ * mtlgSilverSize ' range=':= 1.052 * _default_ * mtlgSilverSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.107 * _default_ * mtlgSilverFreq ' range=':= 1.107 * _default_ * mtlgSilverFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3076,9 +3076,9 @@
                             <OreBlock block='Metallurgy:precious.ore:1' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 2.500 * mtlgSilverSize ' range=':= 2.500 * mtlgSilverSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 3.000 * mtlgSilverFreq ' range=':= 3.000 * mtlgSilverFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 3.333 * mtlgSilverSize ' range=':= 1.67 * mtlgSilverSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4.0 * mtlgSilverFreq ' range=':= 2.0 * mtlgSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -3103,7 +3103,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.531 * _default_ * mtlgPlatinumFreq ' range=':= 0.531 * _default_ * mtlgPlatinumFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.900 * _default_ * mtlgPlatinumSize ' range=':= 0.900 * _default_ * mtlgPlatinumSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3147,7 +3147,7 @@
                             <Setting name='CloudRadius' avg=':= 0.779 * _default_ * mtlgPlatinumSize ' range=':= 0.779 * _default_ * mtlgPlatinumSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.779 * _default_ * mtlgPlatinumSize ' range=':= 0.779 * _default_ * mtlgPlatinumSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.606 * _default_ * mtlgPlatinumFreq ' range=':= 0.606 * _default_ * mtlgPlatinumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3198,9 +3198,9 @@
                             <OreBlock block='Metallurgy:precious.ore:2' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 1.500 * mtlgPlatinumSize ' range=':= 1.500 * mtlgPlatinumSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.500 * mtlgPlatinumFreq ' range=':= 1.500 * mtlgPlatinumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.0 * mtlgPlatinumSize ' range=':= 1.0 * mtlgPlatinumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2.0 * mtlgPlatinumFreq ' range=':= 1.0 * mtlgPlatinumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -3225,7 +3225,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * mtlgPromethiumFreq ' range=':= 0.969 * _default_ * mtlgPromethiumFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.995 * _default_ * mtlgPromethiumSize ' range=':= 0.995 * _default_ * mtlgPromethiumSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3269,7 +3269,7 @@
                             <Setting name='CloudRadius' avg=':= 1.052 * _default_ * mtlgPromethiumSize ' range=':= 1.052 * _default_ * mtlgPromethiumSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.052 * _default_ * mtlgPromethiumSize ' range=':= 1.052 * _default_ * mtlgPromethiumSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.107 * _default_ * mtlgPromethiumFreq ' range=':= 1.107 * _default_ * mtlgPromethiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3321,9 +3321,9 @@
                             <OreBlock block='Metallurgy:fantasy.ore' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3.000 * mtlgPromethiumSize ' range=':= 3.000 * mtlgPromethiumSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2.500 * mtlgPromethiumFreq ' range=':= 2.500 * mtlgPromethiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.0 * mtlgPromethiumSize ' range=':= 2.0 * mtlgPromethiumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 3.333 * mtlgPromethiumFreq ' range=':= 1.67 * mtlgPromethiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -3348,7 +3348,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.791 * _default_ * mtlgDeepIronFreq ' range=':= 0.791 * _default_ * mtlgDeepIronFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.962 * _default_ * mtlgDeepIronSize ' range=':= 0.962 * _default_ * mtlgDeepIronSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3392,7 +3392,7 @@
                             <Setting name='CloudRadius' avg=':= 0.951 * _default_ * mtlgDeepIronSize ' range=':= 0.951 * _default_ * mtlgDeepIronSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.951 * _default_ * mtlgDeepIronSize ' range=':= 0.951 * _default_ * mtlgDeepIronSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.904 * _default_ * mtlgDeepIronFreq ' range=':= 0.904 * _default_ * mtlgDeepIronFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3443,9 +3443,9 @@
                             <OreBlock block='Metallurgy:fantasy.ore:1' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 2.000 * mtlgDeepIronSize ' range=':= 2.000 * mtlgDeepIronSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2.500 * mtlgDeepIronFreq ' range=':= 2.500 * mtlgDeepIronFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.667 * mtlgDeepIronSize ' range=':= 1.33 * mtlgDeepIronSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 3.333 * mtlgDeepIronFreq ' range=':= 1.67 * mtlgDeepIronFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -3470,7 +3470,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.791 * _default_ * mtlgInfuscoliumFreq ' range=':= 0.791 * _default_ * mtlgInfuscoliumFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.962 * _default_ * mtlgInfuscoliumSize ' range=':= 0.962 * _default_ * mtlgInfuscoliumSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3514,7 +3514,7 @@
                             <Setting name='CloudRadius' avg=':= 0.951 * _default_ * mtlgInfuscoliumSize ' range=':= 0.951 * _default_ * mtlgInfuscoliumSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.951 * _default_ * mtlgInfuscoliumSize ' range=':= 0.951 * _default_ * mtlgInfuscoliumSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.904 * _default_ * mtlgInfuscoliumFreq ' range=':= 0.904 * _default_ * mtlgInfuscoliumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3566,9 +3566,9 @@
                             <OreBlock block='Metallurgy:fantasy.ore:2' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 2.000 * mtlgInfuscoliumSize ' range=':= 2.000 * mtlgInfuscoliumSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2.500 * mtlgInfuscoliumFreq ' range=':= 2.500 * mtlgInfuscoliumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.667 * mtlgInfuscoliumSize ' range=':= 1.33 * mtlgInfuscoliumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 3.333 * mtlgInfuscoliumFreq ' range=':= 1.67 * mtlgInfuscoliumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -3593,7 +3593,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.613 * _default_ * mtlgOureclaseFreq ' range=':= 0.613 * _default_ * mtlgOureclaseFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * mtlgOureclaseSize ' range=':= 0.922 * _default_ * mtlgOureclaseSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3637,7 +3637,7 @@
                             <Setting name='CloudRadius' avg=':= 0.837 * _default_ * mtlgOureclaseSize ' range=':= 0.837 * _default_ * mtlgOureclaseSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.837 * _default_ * mtlgOureclaseSize ' range=':= 0.837 * _default_ * mtlgOureclaseSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.700 * _default_ * mtlgOureclaseFreq ' range=':= 0.700 * _default_ * mtlgOureclaseFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3688,9 +3688,9 @@
                             <OreBlock block='Metallurgy:fantasy.ore:4' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 1.500 * mtlgOureclaseSize ' range=':= 1.500 * mtlgOureclaseSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2.000 * mtlgOureclaseFreq ' range=':= 2.000 * mtlgOureclaseFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.0 * mtlgOureclaseSize ' range=':= 1.0 * mtlgOureclaseSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2.667 * mtlgOureclaseFreq ' range=':= 1.33 * mtlgOureclaseFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -3715,7 +3715,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.613 * _default_ * mtlgAstralSilverFreq ' range=':= 0.613 * _default_ * mtlgAstralSilverFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * mtlgAstralSilverSize ' range=':= 0.922 * _default_ * mtlgAstralSilverSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3761,7 +3761,7 @@
                             <Setting name='CloudRadius' avg=':= 0.837 * _default_ * mtlgAstralSilverSize ' range=':= 0.837 * _default_ * mtlgAstralSilverSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.837 * _default_ * mtlgAstralSilverSize ' range=':= 0.837 * _default_ * mtlgAstralSilverSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.700 * _default_ * mtlgAstralSilverFreq ' range=':= 0.700 * _default_ * mtlgAstralSilverFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3813,9 +3813,9 @@
                             <OreBlock block='Metallurgy:fantasy.ore:5' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 1.500 * mtlgAstralSilverSize ' range=':= 1.500 * mtlgAstralSilverSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2.000 * mtlgAstralSilverFreq ' range=':= 2.000 * mtlgAstralSilverFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.0 * mtlgAstralSilverSize ' range=':= 1.0 * mtlgAstralSilverSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2.667 * mtlgAstralSilverFreq ' range=':= 1.33 * mtlgAstralSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -3840,7 +3840,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.531 * _default_ * mtlgCarmotFreq ' range=':= 0.531 * _default_ * mtlgCarmotFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.900 * _default_ * mtlgCarmotSize ' range=':= 0.900 * _default_ * mtlgCarmotSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3884,7 +3884,7 @@
                             <Setting name='CloudRadius' avg=':= 0.779 * _default_ * mtlgCarmotSize ' range=':= 0.779 * _default_ * mtlgCarmotSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.779 * _default_ * mtlgCarmotSize ' range=':= 0.779 * _default_ * mtlgCarmotSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.606 * _default_ * mtlgCarmotFreq ' range=':= 0.606 * _default_ * mtlgCarmotFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3935,9 +3935,9 @@
                             <OreBlock block='Metallurgy:fantasy.ore:6' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 1.500 * mtlgCarmotSize ' range=':= 1.500 * mtlgCarmotSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.500 * mtlgCarmotFreq ' range=':= 1.500 * mtlgCarmotFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.0 * mtlgCarmotSize ' range=':= 1.0 * mtlgCarmotSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2.0 * mtlgCarmotFreq ' range=':= 1.0 * mtlgCarmotFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -3962,7 +3962,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.531 * _default_ * mtlgMithrilFreq ' range=':= 0.531 * _default_ * mtlgMithrilFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.900 * _default_ * mtlgMithrilSize ' range=':= 0.900 * _default_ * mtlgMithrilSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4006,7 +4006,7 @@
                             <Setting name='CloudRadius' avg=':= 0.779 * _default_ * mtlgMithrilSize ' range=':= 0.779 * _default_ * mtlgMithrilSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.779 * _default_ * mtlgMithrilSize ' range=':= 0.779 * _default_ * mtlgMithrilSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.606 * _default_ * mtlgMithrilFreq ' range=':= 0.606 * _default_ * mtlgMithrilFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4057,9 +4057,9 @@
                             <OreBlock block='Metallurgy:fantasy.ore:7' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 1.500 * mtlgMithrilSize ' range=':= 1.500 * mtlgMithrilSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.500 * mtlgMithrilFreq ' range=':= 1.500 * mtlgMithrilFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.0 * mtlgMithrilSize ' range=':= 1.0 * mtlgMithrilSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2.0 * mtlgMithrilFreq ' range=':= 1.0 * mtlgMithrilFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -4084,7 +4084,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.433 * _default_ * mtlgRubraciumFreq ' range=':= 0.433 * _default_ * mtlgRubraciumFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.870 * _default_ * mtlgRubraciumSize ' range=':= 0.870 * _default_ * mtlgRubraciumSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4128,7 +4128,7 @@
                             <Setting name='CloudRadius' avg=':= 0.703 * _default_ * mtlgRubraciumSize ' range=':= 0.703 * _default_ * mtlgRubraciumSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.703 * _default_ * mtlgRubraciumSize ' range=':= 0.703 * _default_ * mtlgRubraciumSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.495 * _default_ * mtlgRubraciumFreq ' range=':= 0.495 * _default_ * mtlgRubraciumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4179,9 +4179,9 @@
                             <OreBlock block='Metallurgy:fantasy.ore:8' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 1.500 * mtlgRubraciumSize ' range=':= 1.500 * mtlgRubraciumSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.000 * mtlgRubraciumFreq ' range=':= 1.000 * mtlgRubraciumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.0 * mtlgRubraciumSize ' range=':= 1.0 * mtlgRubraciumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.333 * mtlgRubraciumFreq ' range=':= 0.67 * mtlgRubraciumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -4206,7 +4206,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.500 * _default_ * mtlgOrichalcumFreq ' range=':= 0.500 * _default_ * mtlgOrichalcumFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.891 * _default_ * mtlgOrichalcumSize ' range=':= 0.891 * _default_ * mtlgOrichalcumSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4250,7 +4250,7 @@
                             <Setting name='CloudRadius' avg=':= 0.756 * _default_ * mtlgOrichalcumSize ' range=':= 0.756 * _default_ * mtlgOrichalcumSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.756 * _default_ * mtlgOrichalcumSize ' range=':= 0.756 * _default_ * mtlgOrichalcumSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.571 * _default_ * mtlgOrichalcumFreq ' range=':= 0.571 * _default_ * mtlgOrichalcumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4302,9 +4302,9 @@
                             <OreBlock block='Metallurgy:fantasy.ore:11' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 2.000 * mtlgOrichalcumSize ' range=':= 2.000 * mtlgOrichalcumSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.000 * mtlgOrichalcumFreq ' range=':= 1.000 * mtlgOrichalcumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.667 * mtlgOrichalcumSize ' range=':= 1.33 * mtlgOrichalcumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.333 * mtlgOrichalcumFreq ' range=':= 0.67 * mtlgOrichalcumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -4329,7 +4329,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.433 * _default_ * mtlgAdamantineFreq ' range=':= 0.433 * _default_ * mtlgAdamantineFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.870 * _default_ * mtlgAdamantineSize ' range=':= 0.870 * _default_ * mtlgAdamantineSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4373,7 +4373,7 @@
                             <Setting name='CloudRadius' avg=':= 0.703 * _default_ * mtlgAdamantineSize ' range=':= 0.703 * _default_ * mtlgAdamantineSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.703 * _default_ * mtlgAdamantineSize ' range=':= 0.703 * _default_ * mtlgAdamantineSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.495 * _default_ * mtlgAdamantineFreq ' range=':= 0.495 * _default_ * mtlgAdamantineFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4425,9 +4425,9 @@
                             <OreBlock block='Metallurgy:fantasy.ore:13' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 1.500 * mtlgAdamantineSize ' range=':= 1.500 * mtlgAdamantineSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.000 * mtlgAdamantineFreq ' range=':= 1.000 * mtlgAdamantineFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.0 * mtlgAdamantineSize ' range=':= 1.0 * mtlgAdamantineSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.333 * mtlgAdamantineFreq ' range=':= 0.67 * mtlgAdamantineFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -4452,7 +4452,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.433 * _default_ * mtlgAtlarusFreq ' range=':= 0.433 * _default_ * mtlgAtlarusFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.870 * _default_ * mtlgAtlarusSize ' range=':= 0.870 * _default_ * mtlgAtlarusSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4496,7 +4496,7 @@
                             <Setting name='CloudRadius' avg=':= 0.703 * _default_ * mtlgAtlarusSize ' range=':= 0.703 * _default_ * mtlgAtlarusSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.703 * _default_ * mtlgAtlarusSize ' range=':= 0.703 * _default_ * mtlgAtlarusSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.495 * _default_ * mtlgAtlarusFreq ' range=':= 0.495 * _default_ * mtlgAtlarusFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4547,9 +4547,9 @@
                             <OreBlock block='Metallurgy:fantasy.ore:14' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 1.500 * mtlgAtlarusSize ' range=':= 1.500 * mtlgAtlarusSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.000 * mtlgAtlarusFreq ' range=':= 1.000 * mtlgAtlarusFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.0 * mtlgAtlarusSize ' range=':= 1.0 * mtlgAtlarusSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.333 * mtlgAtlarusFreq ' range=':= 0.67 * mtlgAtlarusFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -4615,7 +4615,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.300 * _default_ * mtlgIgnatiusFreq ' range=':= 1.300 * _default_ * mtlgIgnatiusFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.045 * _default_ * mtlgIgnatiusSize ' range=':= 1.045 * _default_ * mtlgIgnatiusSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4659,7 +4659,7 @@
                             <Setting name='CloudRadius' avg=':= 1.218 * _default_ * mtlgIgnatiusSize ' range=':= 1.218 * _default_ * mtlgIgnatiusSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.218 * _default_ * mtlgIgnatiusSize ' range=':= 1.218 * _default_ * mtlgIgnatiusSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.485 * _default_ * mtlgIgnatiusFreq ' range=':= 1.485 * _default_ * mtlgIgnatiusFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4710,9 +4710,9 @@
                             <OreBlock block='Metallurgy:nether.ore' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3.000 * mtlgIgnatiusSize ' range=':= 3.000 * mtlgIgnatiusSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 4.500 * mtlgIgnatiusFreq ' range=':= 4.500 * mtlgIgnatiusFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.0 * mtlgIgnatiusSize ' range=':= 2.0 * mtlgIgnatiusSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 6.0 * mtlgIgnatiusFreq ' range=':= 3.0 * mtlgIgnatiusFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -4737,7 +4737,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.147 * _default_ * mtlgShadowIronFreq ' range=':= 1.147 * _default_ * mtlgShadowIronFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.023 * _default_ * mtlgShadowIronSize ' range=':= 1.023 * _default_ * mtlgShadowIronSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4781,7 +4781,7 @@
                             <Setting name='CloudRadius' avg=':= 1.144 * _default_ * mtlgShadowIronSize ' range=':= 1.144 * _default_ * mtlgShadowIronSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.144 * _default_ * mtlgShadowIronSize ' range=':= 1.144 * _default_ * mtlgShadowIronSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.309 * _default_ * mtlgShadowIronFreq ' range=':= 1.309 * _default_ * mtlgShadowIronFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4833,9 +4833,9 @@
                             <OreBlock block='Metallurgy:nether.ore:1' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3.000 * mtlgShadowIronSize ' range=':= 3.000 * mtlgShadowIronSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 3.500 * mtlgShadowIronFreq ' range=':= 3.500 * mtlgShadowIronFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.0 * mtlgShadowIronSize ' range=':= 2.0 * mtlgShadowIronSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4.667 * mtlgShadowIronFreq ' range=':= 2.33 * mtlgShadowIronFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -4860,7 +4860,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.062 * _default_ * mtlgLemuriteFreq ' range=':= 1.062 * _default_ * mtlgLemuriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.010 * _default_ * mtlgLemuriteSize ' range=':= 1.010 * _default_ * mtlgLemuriteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4904,7 +4904,7 @@
                             <Setting name='CloudRadius' avg=':= 1.101 * _default_ * mtlgLemuriteSize ' range=':= 1.101 * _default_ * mtlgLemuriteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.101 * _default_ * mtlgLemuriteSize ' range=':= 1.101 * _default_ * mtlgLemuriteSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.212 * _default_ * mtlgLemuriteFreq ' range=':= 1.212 * _default_ * mtlgLemuriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4955,9 +4955,9 @@
                             <OreBlock block='Metallurgy:nether.ore:2' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3.000 * mtlgLemuriteSize ' range=':= 3.000 * mtlgLemuriteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 3.000 * mtlgLemuriteFreq ' range=':= 3.000 * mtlgLemuriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.0 * mtlgLemuriteSize ' range=':= 2.0 * mtlgLemuriteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4.0 * mtlgLemuriteFreq ' range=':= 2.0 * mtlgLemuriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -4982,7 +4982,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * mtlgMidasiumFreq ' range=':= 0.969 * _default_ * mtlgMidasiumFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.995 * _default_ * mtlgMidasiumSize ' range=':= 0.995 * _default_ * mtlgMidasiumSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -5026,7 +5026,7 @@
                             <Setting name='CloudRadius' avg=':= 1.052 * _default_ * mtlgMidasiumSize ' range=':= 1.052 * _default_ * mtlgMidasiumSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.052 * _default_ * mtlgMidasiumSize ' range=':= 1.052 * _default_ * mtlgMidasiumSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.107 * _default_ * mtlgMidasiumFreq ' range=':= 1.107 * _default_ * mtlgMidasiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -5077,9 +5077,9 @@
                             <OreBlock block='Metallurgy:nether.ore:3' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3.000 * mtlgMidasiumSize ' range=':= 3.000 * mtlgMidasiumSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2.500 * mtlgMidasiumFreq ' range=':= 2.500 * mtlgMidasiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.0 * mtlgMidasiumSize ' range=':= 2.0 * mtlgMidasiumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 3.333 * mtlgMidasiumFreq ' range=':= 1.67 * mtlgMidasiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -5104,7 +5104,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.936 * _default_ * mtlgVyroxeresFreq ' range=':= 0.936 * _default_ * mtlgVyroxeresFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.989 * _default_ * mtlgVyroxeresSize ' range=':= 0.989 * _default_ * mtlgVyroxeresSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -5148,7 +5148,7 @@
                             <Setting name='CloudRadius' avg=':= 1.034 * _default_ * mtlgVyroxeresSize ' range=':= 1.034 * _default_ * mtlgVyroxeresSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.034 * _default_ * mtlgVyroxeresSize ' range=':= 1.034 * _default_ * mtlgVyroxeresSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.069 * _default_ * mtlgVyroxeresFreq ' range=':= 1.069 * _default_ * mtlgVyroxeresFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -5199,9 +5199,9 @@
                             <OreBlock block='Metallurgy:nether.ore:4' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3.500 * mtlgVyroxeresSize ' range=':= 3.500 * mtlgVyroxeresSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2.000 * mtlgVyroxeresFreq ' range=':= 2.000 * mtlgVyroxeresFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.667 * mtlgVyroxeresSize ' range=':= 2.33 * mtlgVyroxeresSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2.667 * mtlgVyroxeresFreq ' range=':= 1.33 * mtlgVyroxeresFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -5226,7 +5226,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.708 * _default_ * mtlgCeruclaseFreq ' range=':= 0.708 * _default_ * mtlgCeruclaseFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.944 * _default_ * mtlgCeruclaseSize ' range=':= 0.944 * _default_ * mtlgCeruclaseSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -5270,7 +5270,7 @@
                             <Setting name='CloudRadius' avg=':= 0.899 * _default_ * mtlgCeruclaseSize ' range=':= 0.899 * _default_ * mtlgCeruclaseSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.899 * _default_ * mtlgCeruclaseSize ' range=':= 0.899 * _default_ * mtlgCeruclaseSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.808 * _default_ * mtlgCeruclaseFreq ' range=':= 0.808 * _default_ * mtlgCeruclaseFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -5321,9 +5321,9 @@
                             <OreBlock block='Metallurgy:nether.ore:5' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 2.000 * mtlgCeruclaseSize ' range=':= 2.000 * mtlgCeruclaseSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2.000 * mtlgCeruclaseFreq ' range=':= 2.000 * mtlgCeruclaseFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.667 * mtlgCeruclaseSize ' range=':= 1.33 * mtlgCeruclaseSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2.667 * mtlgCeruclaseFreq ' range=':= 1.33 * mtlgCeruclaseFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -5348,7 +5348,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.613 * _default_ * mtlgAlduoriteFreq ' range=':= 0.613 * _default_ * mtlgAlduoriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * mtlgAlduoriteSize ' range=':= 0.922 * _default_ * mtlgAlduoriteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -5392,7 +5392,7 @@
                             <Setting name='CloudRadius' avg=':= 0.837 * _default_ * mtlgAlduoriteSize ' range=':= 0.837 * _default_ * mtlgAlduoriteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.837 * _default_ * mtlgAlduoriteSize ' range=':= 0.837 * _default_ * mtlgAlduoriteSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.700 * _default_ * mtlgAlduoriteFreq ' range=':= 0.700 * _default_ * mtlgAlduoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -5443,9 +5443,9 @@
                             <OreBlock block='Metallurgy:nether.ore:6' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 2.000 * mtlgAlduoriteSize ' range=':= 2.000 * mtlgAlduoriteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.500 * mtlgAlduoriteFreq ' range=':= 1.500 * mtlgAlduoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.667 * mtlgAlduoriteSize ' range=':= 1.33 * mtlgAlduoriteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2.0 * mtlgAlduoriteFreq ' range=':= 1.0 * mtlgAlduoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -5470,7 +5470,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.613 * _default_ * mtlgKalendriteFreq ' range=':= 0.613 * _default_ * mtlgKalendriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * mtlgKalendriteSize ' range=':= 0.922 * _default_ * mtlgKalendriteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -5514,7 +5514,7 @@
                             <Setting name='CloudRadius' avg=':= 0.837 * _default_ * mtlgKalendriteSize ' range=':= 0.837 * _default_ * mtlgKalendriteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.837 * _default_ * mtlgKalendriteSize ' range=':= 0.837 * _default_ * mtlgKalendriteSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.700 * _default_ * mtlgKalendriteFreq ' range=':= 0.700 * _default_ * mtlgKalendriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -5566,9 +5566,9 @@
                             <OreBlock block='Metallurgy:nether.ore:7' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 2.000 * mtlgKalendriteSize ' range=':= 2.000 * mtlgKalendriteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.500 * mtlgKalendriteFreq ' range=':= 1.500 * mtlgKalendriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.667 * mtlgKalendriteSize ' range=':= 1.33 * mtlgKalendriteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2.0 * mtlgKalendriteFreq ' range=':= 1.0 * mtlgKalendriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -5593,7 +5593,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.433 * _default_ * mtlgVulcaniteFreq ' range=':= 0.433 * _default_ * mtlgVulcaniteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.870 * _default_ * mtlgVulcaniteSize ' range=':= 0.870 * _default_ * mtlgVulcaniteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -5637,7 +5637,7 @@
                             <Setting name='CloudRadius' avg=':= 0.703 * _default_ * mtlgVulcaniteSize ' range=':= 0.703 * _default_ * mtlgVulcaniteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.703 * _default_ * mtlgVulcaniteSize ' range=':= 0.703 * _default_ * mtlgVulcaniteSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.495 * _default_ * mtlgVulcaniteFreq ' range=':= 0.495 * _default_ * mtlgVulcaniteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -5688,9 +5688,9 @@
                             <OreBlock block='Metallurgy:nether.ore:8' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 1.500 * mtlgVulcaniteSize ' range=':= 1.500 * mtlgVulcaniteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.000 * mtlgVulcaniteFreq ' range=':= 1.000 * mtlgVulcaniteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.0 * mtlgVulcaniteSize ' range=':= 1.0 * mtlgVulcaniteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.333 * mtlgVulcaniteFreq ' range=':= 0.67 * mtlgVulcaniteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -5715,7 +5715,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.433 * _default_ * mtlgSanguiniteFreq ' range=':= 0.433 * _default_ * mtlgSanguiniteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.870 * _default_ * mtlgSanguiniteSize ' range=':= 0.870 * _default_ * mtlgSanguiniteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -5759,7 +5759,7 @@
                             <Setting name='CloudRadius' avg=':= 0.703 * _default_ * mtlgSanguiniteSize ' range=':= 0.703 * _default_ * mtlgSanguiniteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.703 * _default_ * mtlgSanguiniteSize ' range=':= 0.703 * _default_ * mtlgSanguiniteSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.495 * _default_ * mtlgSanguiniteFreq ' range=':= 0.495 * _default_ * mtlgSanguiniteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -5811,9 +5811,9 @@
                             <OreBlock block='Metallurgy:nether.ore:9' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 1.500 * mtlgSanguiniteSize ' range=':= 1.500 * mtlgSanguiniteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.000 * mtlgSanguiniteFreq ' range=':= 1.000 * mtlgSanguiniteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.0 * mtlgSanguiniteSize ' range=':= 1.0 * mtlgSanguiniteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.333 * mtlgSanguiniteFreq ' range=':= 0.67 * mtlgSanguiniteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -5871,7 +5871,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.867 * _default_ * mtlgEximiteFreq ' range=':= 0.867 * _default_ * mtlgEximiteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.976 * _default_ * mtlgEximiteSize ' range=':= 0.976 * _default_ * mtlgEximiteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -5915,7 +5915,7 @@
                             <Setting name='CloudRadius' avg=':= 0.995 * _default_ * mtlgEximiteSize ' range=':= 0.995 * _default_ * mtlgEximiteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.995 * _default_ * mtlgEximiteSize ' range=':= 0.995 * _default_ * mtlgEximiteSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.990 * _default_ * mtlgEximiteFreq ' range=':= 0.990 * _default_ * mtlgEximiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -5966,9 +5966,9 @@
                             <OreBlock block='Metallurgy:ender.ore' weight='1.0' />
                             <Replaces block='minecraft:end_stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 2.000 * mtlgEximiteSize ' range=':= 2.000 * mtlgEximiteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 3.000 * mtlgEximiteFreq ' range=':= 3.000 * mtlgEximiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.667 * mtlgEximiteSize ' range=':= 1.33 * mtlgEximiteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4.0 * mtlgEximiteFreq ' range=':= 2.0 * mtlgEximiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -5993,7 +5993,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.531 * _default_ * mtlgMeutoiteFreq ' range=':= 0.531 * _default_ * mtlgMeutoiteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.900 * _default_ * mtlgMeutoiteSize ' range=':= 0.900 * _default_ * mtlgMeutoiteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -6037,7 +6037,7 @@
                             <Setting name='CloudRadius' avg=':= 0.779 * _default_ * mtlgMeutoiteSize ' range=':= 0.779 * _default_ * mtlgMeutoiteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.779 * _default_ * mtlgMeutoiteSize ' range=':= 0.779 * _default_ * mtlgMeutoiteSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.606 * _default_ * mtlgMeutoiteFreq ' range=':= 0.606 * _default_ * mtlgMeutoiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -6088,9 +6088,9 @@
                             <OreBlock block='Metallurgy:ender.ore:1' weight='1.0' />
                             <Replaces block='minecraft:end_stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 1.500 * mtlgMeutoiteSize ' range=':= 1.500 * mtlgMeutoiteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.500 * mtlgMeutoiteFreq ' range=':= 1.500 * mtlgMeutoiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.0 * mtlgMeutoiteSize ' range=':= 1.0 * mtlgMeutoiteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2.0 * mtlgMeutoiteFreq ' range=':= 1.0 * mtlgMeutoiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>

--- a/src/main/resources/config/modules/MineChem.xml
+++ b/src/main/resources/config/modules/MineChem.xml
@@ -125,7 +125,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.500 * _default_ * mchmUraniumFreq ' range=':= 0.500 * _default_ * mchmUraniumFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.891 * _default_ * mchmUraniumSize ' range=':= 0.891 * _default_ * mchmUraniumSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 17.5 ' range=':= 12.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 17.5 ' range=':= 12.5 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -169,7 +169,7 @@
                             <Setting name='CloudRadius' avg=':= 0.756 * _default_ * mchmUraniumSize ' range=':= 0.756 * _default_ * mchmUraniumSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.756 * _default_ * mchmUraniumSize ' range=':= 0.756 * _default_ * mchmUraniumSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.571 * _default_ * mchmUraniumFreq ' range=':= 0.571 * _default_ * mchmUraniumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 17.5 ' range=':= 12.5 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 17.5 ' range=':= 12.5 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -220,9 +220,9 @@
                             <OreBlock block='minechem:tile.oreUranium' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 2.000 * mchmUraniumSize ' range=':= 2.000 * mchmUraniumSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.000 * mchmUraniumFreq ' range=':= 1.000 * mchmUraniumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 17.5 ' range=':= 12.5 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.667 * mchmUraniumSize ' range=':= 1.33 * mchmUraniumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.333 * mchmUraniumFreq ' range=':= 0.67 * mchmUraniumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 17.5 ' range=':= 12.5 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>

--- a/src/main/resources/config/modules/MinecraftComesAlive.xml
+++ b/src/main/resources/config/modules/MinecraftComesAlive.xml
@@ -127,7 +127,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * mccaRoseGoldFreq ' range=':= 0.969 * _default_ * mccaRoseGoldFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.995 * _default_ * mccaRoseGoldSize ' range=':= 0.995 * _default_ * mccaRoseGoldSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 26 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 26 ' range=':= 14 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -171,7 +171,7 @@
                             <Setting name='CloudRadius' avg=':= 1.052 * _default_ * mccaRoseGoldSize ' range=':= 1.052 * _default_ * mccaRoseGoldSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.052 * _default_ * mccaRoseGoldSize ' range=':= 1.052 * _default_ * mccaRoseGoldSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.107 * _default_ * mccaRoseGoldFreq ' range=':= 1.107 * _default_ * mccaRoseGoldFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 26 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 26 ' range=':= 14 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -222,9 +222,9 @@
                             <OreBlock block='MCA:tile.roseGoldOre' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3.000 * mccaRoseGoldSize ' range=':= 3.000 * mccaRoseGoldSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2.500 * mccaRoseGoldFreq ' range=':= 2.500 * mccaRoseGoldFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 26 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.0 * mccaRoseGoldSize ' range=':= 2.0 * mccaRoseGoldSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 3.333 * mccaRoseGoldFreq ' range=':= 1.67 * mccaRoseGoldFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 26 ' range=':= 14 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>

--- a/src/main/resources/config/modules/NetherOres.xml
+++ b/src/main/resources/config/modules/NetherOres.xml
@@ -1594,7 +1594,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 4.900 * _default_ * nthoCoalFreq ' range=':= 4.900 * _default_ * nthoCoalFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoCoalSize ' range=':= 0 * _default_ * nthoCoalSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1638,7 +1638,7 @@
                             <Setting name='CloudRadius' avg=':= 1.512 * _default_ * nthoCoalSize ' range=':= 1.512 * _default_ * nthoCoalSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.512 * _default_ * nthoCoalSize ' range=':= 1.512 * _default_ * nthoCoalSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 2.286 * _default_ * nthoCoalFreq ' range=':= 2.286 * _default_ * nthoCoalFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1689,9 +1689,9 @@
                             <OreBlock block='NetherOres:tile.netherores.ore.0' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 8.000 * nthoCoalSize ' range=':= 8.000 * nthoCoalSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 4.000 * nthoCoalFreq ' range=':= 4.000 * nthoCoalFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 10.667 * nthoCoalSize ' range=':= 5.33 * nthoCoalSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 5.333 * nthoCoalFreq ' range=':= 2.67 * nthoCoalFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1716,7 +1716,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.935 * _default_ * nthoDiamondFreq ' range=':= 0.935 * _default_ * nthoDiamondFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoDiamondSize ' range=':= 0 * _default_ * nthoDiamondSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1770,7 +1770,7 @@
                             <Setting name='CloudRadius' avg=':= 0.837 * _default_ * nthoDiamondSize ' range=':= 0.837 * _default_ * nthoDiamondSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.837 * _default_ * nthoDiamondSize ' range=':= 0.837 * _default_ * nthoDiamondSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.700 * _default_ * nthoDiamondFreq ' range=':= 0.700 * _default_ * nthoDiamondFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1821,9 +1821,9 @@
                             <OreBlock block='NetherOres:tile.netherores.ore.0:1' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 1.500 * nthoDiamondSize ' range=':= 1.500 * nthoDiamondSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2.000 * nthoDiamondFreq ' range=':= 2.000 * nthoDiamondFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.0 * nthoDiamondSize ' range=':= 1.0 * nthoDiamondSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2.667 * nthoDiamondFreq ' range=':= 1.33 * nthoDiamondFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1848,7 +1848,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.226 * _default_ * nthoGoldFreq ' range=':= 1.226 * _default_ * nthoGoldFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.035 * _default_ * nthoGoldSize ' range=':= 1.035 * _default_ * nthoGoldSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1892,7 +1892,7 @@
                             <Setting name='CloudRadius' avg=':= 1.183 * _default_ * nthoGoldSize ' range=':= 1.183 * _default_ * nthoGoldSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.183 * _default_ * nthoGoldSize ' range=':= 1.183 * _default_ * nthoGoldSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.400 * _default_ * nthoGoldFreq ' range=':= 1.400 * _default_ * nthoGoldFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1943,9 +1943,9 @@
                             <OreBlock block='NetherOres:tile.netherores.ore.0:2' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3.000 * nthoGoldSize ' range=':= 3.000 * nthoGoldSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 4.000 * nthoGoldFreq ' range=':= 4.000 * nthoGoldFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.0 * nthoGoldSize ' range=':= 2.0 * nthoGoldSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 5.333 * nthoGoldFreq ' range=':= 2.67 * nthoGoldFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1970,7 +1970,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.416 * _default_ * nthoIronFreq ' range=':= 1.416 * _default_ * nthoIronFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.060 * _default_ * nthoIronSize ' range=':= 1.060 * _default_ * nthoIronSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2014,7 +2014,7 @@
                             <Setting name='CloudRadius' avg=':= 1.271 * _default_ * nthoIronSize ' range=':= 1.271 * _default_ * nthoIronSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.271 * _default_ * nthoIronSize ' range=':= 1.271 * _default_ * nthoIronSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.616 * _default_ * nthoIronFreq ' range=':= 1.616 * _default_ * nthoIronFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2065,9 +2065,9 @@
                             <OreBlock block='NetherOres:tile.netherores.ore.0:3' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.000 * nthoIronSize ' range=':= 4.000 * nthoIronSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 4.000 * nthoIronFreq ' range=':= 4.000 * nthoIronFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 5.333 * nthoIronSize ' range=':= 2.67 * nthoIronSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 5.333 * nthoIronFreq ' range=':= 2.67 * nthoIronFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -2092,7 +2092,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.929 * _default_ * nthoLapisLazuliFreq ' range=':= 1.929 * _default_ * nthoLapisLazuliFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoLapisLazuliSize ' range=':= 0 * _default_ * nthoLapisLazuliSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= -_default_ ' range=':= -_default_ ' type='normal' />
@@ -2137,7 +2137,7 @@
                             <Setting name='CloudRadius' avg=':= 1.101 * _default_ * nthoLapisLazuliSize ' range=':= 1.101 * _default_ * nthoLapisLazuliSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.101 * _default_ * nthoLapisLazuliSize ' range=':= 1.101 * _default_ * nthoLapisLazuliSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.212 * _default_ * nthoLapisLazuliFreq ' range=':= 1.212 * _default_ * nthoLapisLazuliFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2189,9 +2189,9 @@
                             <OreBlock block='NetherOres:tile.netherores.ore.0:4' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3.000 * nthoLapisLazuliSize ' range=':= 3.000 * nthoLapisLazuliSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 3.000 * nthoLapisLazuliFreq ' range=':= 3.000 * nthoLapisLazuliFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.0 * nthoLapisLazuliSize ' range=':= 2.0 * nthoLapisLazuliSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4.0 * nthoLapisLazuliFreq ' range=':= 2.0 * nthoLapisLazuliFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -2216,7 +2216,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.227 * _default_ * nthoRedstoneFreq ' range=':= 2.227 * _default_ * nthoRedstoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoRedstoneSize ' range=':= 0 * _default_ * nthoRedstoneSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= -_default_ ' range=':= -_default_ ' type='normal' />
@@ -2260,7 +2260,7 @@
                             <Setting name='CloudRadius' avg=':= 1.183 * _default_ * nthoRedstoneSize ' range=':= 1.183 * _default_ * nthoRedstoneSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.183 * _default_ * nthoRedstoneSize ' range=':= 1.183 * _default_ * nthoRedstoneSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.400 * _default_ * nthoRedstoneFreq ' range=':= 1.400 * _default_ * nthoRedstoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2311,9 +2311,9 @@
                             <OreBlock block='NetherOres:tile.netherores.ore.0:5' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.000 * nthoRedstoneSize ' range=':= 4.000 * nthoRedstoneSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 3.000 * nthoRedstoneFreq ' range=':= 3.000 * nthoRedstoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 5.333 * nthoRedstoneSize ' range=':= 2.67 * nthoRedstoneSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4.0 * nthoRedstoneFreq ' range=':= 2.0 * nthoRedstoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -2338,7 +2338,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.416 * _default_ * nthoCopperFreq ' range=':= 1.416 * _default_ * nthoCopperFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.060 * _default_ * nthoCopperSize ' range=':= 1.060 * _default_ * nthoCopperSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2382,7 +2382,7 @@
                             <Setting name='CloudRadius' avg=':= 1.271 * _default_ * nthoCopperSize ' range=':= 1.271 * _default_ * nthoCopperSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.271 * _default_ * nthoCopperSize ' range=':= 1.271 * _default_ * nthoCopperSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.616 * _default_ * nthoCopperFreq ' range=':= 1.616 * _default_ * nthoCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2433,9 +2433,9 @@
                             <OreBlock block='NetherOres:tile.netherores.ore.0:6' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.000 * nthoCopperSize ' range=':= 4.000 * nthoCopperSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 4.000 * nthoCopperFreq ' range=':= 4.000 * nthoCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 5.333 * nthoCopperSize ' range=':= 2.67 * nthoCopperSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 5.333 * nthoCopperFreq ' range=':= 2.67 * nthoCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -2460,7 +2460,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.416 * _default_ * nthoTinFreq ' range=':= 1.416 * _default_ * nthoTinFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.060 * _default_ * nthoTinSize ' range=':= 1.060 * _default_ * nthoTinSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2504,7 +2504,7 @@
                             <Setting name='CloudRadius' avg=':= 1.271 * _default_ * nthoTinSize ' range=':= 1.271 * _default_ * nthoTinSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.271 * _default_ * nthoTinSize ' range=':= 1.271 * _default_ * nthoTinSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.616 * _default_ * nthoTinFreq ' range=':= 1.616 * _default_ * nthoTinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2555,9 +2555,9 @@
                             <OreBlock block='NetherOres:tile.netherores.ore.0:7' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.000 * nthoTinSize ' range=':= 4.000 * nthoTinSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 4.000 * nthoTinFreq ' range=':= 4.000 * nthoTinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 5.333 * nthoTinSize ' range=':= 2.67 * nthoTinSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 5.333 * nthoTinFreq ' range=':= 2.67 * nthoTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -2582,7 +2582,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.661 * _default_ * nthoEmeraldFreq ' range=':= 0.661 * _default_ * nthoEmeraldFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoEmeraldSize ' range=':= 0 * _default_ * nthoEmeraldSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2636,7 +2636,7 @@
                             <Setting name='CloudRadius' avg=':= 0.703 * _default_ * nthoEmeraldSize ' range=':= 0.703 * _default_ * nthoEmeraldSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.703 * _default_ * nthoEmeraldSize ' range=':= 0.703 * _default_ * nthoEmeraldSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.495 * _default_ * nthoEmeraldFreq ' range=':= 0.495 * _default_ * nthoEmeraldFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2687,9 +2687,9 @@
                             <OreBlock block='NetherOres:tile.netherores.ore.0:8' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 1.000 * nthoEmeraldSize ' range=':= 1.000 * nthoEmeraldSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.500 * nthoEmeraldFreq ' range=':= 1.500 * nthoEmeraldFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 1.333 * nthoEmeraldSize ' range=':= 0.67 * nthoEmeraldSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2.0 * nthoEmeraldFreq ' range=':= 1.0 * nthoEmeraldFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -2714,7 +2714,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.867 * _default_ * nthoSilverFreq ' range=':= 0.867 * _default_ * nthoSilverFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.976 * _default_ * nthoSilverSize ' range=':= 0.976 * _default_ * nthoSilverSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2758,7 +2758,7 @@
                             <Setting name='CloudRadius' avg=':= 0.995 * _default_ * nthoSilverSize ' range=':= 0.995 * _default_ * nthoSilverSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.995 * _default_ * nthoSilverSize ' range=':= 0.995 * _default_ * nthoSilverSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.990 * _default_ * nthoSilverFreq ' range=':= 0.990 * _default_ * nthoSilverFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2809,9 +2809,9 @@
                             <OreBlock block='NetherOres:tile.netherores.ore.0:9' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 2.000 * nthoSilverSize ' range=':= 2.000 * nthoSilverSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 3.000 * nthoSilverFreq ' range=':= 3.000 * nthoSilverFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.667 * nthoSilverSize ' range=':= 1.33 * nthoSilverSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4.0 * nthoSilverFreq ' range=':= 2.0 * nthoSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -2836,7 +2836,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.062 * _default_ * nthoLeadFreq ' range=':= 1.062 * _default_ * nthoLeadFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.010 * _default_ * nthoLeadSize ' range=':= 1.010 * _default_ * nthoLeadSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2880,7 +2880,7 @@
                             <Setting name='CloudRadius' avg=':= 1.101 * _default_ * nthoLeadSize ' range=':= 1.101 * _default_ * nthoLeadSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.101 * _default_ * nthoLeadSize ' range=':= 1.101 * _default_ * nthoLeadSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.212 * _default_ * nthoLeadFreq ' range=':= 1.212 * _default_ * nthoLeadFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2931,9 +2931,9 @@
                             <OreBlock block='NetherOres:tile.netherores.ore.0:10' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3.000 * nthoLeadSize ' range=':= 3.000 * nthoLeadSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 3.000 * nthoLeadFreq ' range=':= 3.000 * nthoLeadFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.0 * nthoLeadSize ' range=':= 2.0 * nthoLeadSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4.0 * nthoLeadFreq ' range=':= 2.0 * nthoLeadFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -2965,7 +2965,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.061 * _default_ * nthoUraniumFreq ' range=':= 1.061 * _default_ * nthoUraniumFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoUraniumSize ' range=':= 0 * _default_ * nthoUraniumSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3009,7 +3009,7 @@
                             <Setting name='CloudRadius' avg=':= 0.703 * _default_ * nthoUraniumSize ' range=':= 0.703 * _default_ * nthoUraniumSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.703 * _default_ * nthoUraniumSize ' range=':= 0.703 * _default_ * nthoUraniumSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.495 * _default_ * nthoUraniumFreq ' range=':= 0.495 * _default_ * nthoUraniumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3060,9 +3060,9 @@
                             <OreBlock block='NetherOres:tile.netherores.ore.0:11' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 1.000 * nthoUraniumSize ' range=':= 1.000 * nthoUraniumSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.500 * nthoUraniumFreq ' range=':= 1.500 * nthoUraniumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 1.333 * nthoUraniumSize ' range=':= 0.67 * nthoUraniumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2.0 * nthoUraniumFreq ' range=':= 1.0 * nthoUraniumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -3087,7 +3087,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.818 * _default_ * nthoNikoliteFreq ' range=':= 1.818 * _default_ * nthoNikoliteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoNikoliteSize ' range=':= 0 * _default_ * nthoNikoliteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= -_default_ ' range=':= -_default_ ' type='normal' />
@@ -3131,7 +3131,7 @@
                             <Setting name='CloudRadius' avg=':= 1.069 * _default_ * nthoNikoliteSize ' range=':= 1.069 * _default_ * nthoNikoliteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.069 * _default_ * nthoNikoliteSize ' range=':= 1.069 * _default_ * nthoNikoliteSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.143 * _default_ * nthoNikoliteFreq ' range=':= 1.143 * _default_ * nthoNikoliteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3182,9 +3182,9 @@
                             <OreBlock block='NetherOres:tile.netherores.ore.0:12' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 2.000 * nthoNikoliteSize ' range=':= 2.000 * nthoNikoliteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 4.000 * nthoNikoliteFreq ' range=':= 4.000 * nthoNikoliteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.667 * nthoNikoliteSize ' range=':= 1.33 * nthoNikoliteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 5.333 * nthoNikoliteFreq ' range=':= 2.67 * nthoNikoliteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -3209,7 +3209,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.145 * _default_ * nthoRubyFreq ' range=':= 1.145 * _default_ * nthoRubyFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoRubySize ' range=':= 0 * _default_ * nthoRubySize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3263,7 +3263,7 @@
                             <Setting name='CloudRadius' avg=':= 0.926 * _default_ * nthoRubySize ' range=':= 0.926 * _default_ * nthoRubySize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.926 * _default_ * nthoRubySize ' range=':= 0.926 * _default_ * nthoRubySize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.857 * _default_ * nthoRubyFreq ' range=':= 0.857 * _default_ * nthoRubyFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3314,9 +3314,9 @@
                             <OreBlock block='NetherOres:tile.netherores.ore.0:13' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 1.500 * nthoRubySize ' range=':= 1.500 * nthoRubySize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 3.000 * nthoRubyFreq ' range=':= 3.000 * nthoRubyFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.0 * nthoRubySize ' range=':= 1.0 * nthoRubySize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4.0 * nthoRubyFreq ' range=':= 2.0 * nthoRubyFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -3341,7 +3341,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.145 * _default_ * nthoPeridotFreq ' range=':= 1.145 * _default_ * nthoPeridotFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoPeridotSize ' range=':= 0 * _default_ * nthoPeridotSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3395,7 +3395,7 @@
                             <Setting name='CloudRadius' avg=':= 0.926 * _default_ * nthoPeridotSize ' range=':= 0.926 * _default_ * nthoPeridotSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.926 * _default_ * nthoPeridotSize ' range=':= 0.926 * _default_ * nthoPeridotSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.857 * _default_ * nthoPeridotFreq ' range=':= 0.857 * _default_ * nthoPeridotFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3446,9 +3446,9 @@
                             <OreBlock block='NetherOres:tile.netherores.ore.0:14' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 1.500 * nthoPeridotSize ' range=':= 1.500 * nthoPeridotSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 3.000 * nthoPeridotFreq ' range=':= 3.000 * nthoPeridotFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.0 * nthoPeridotSize ' range=':= 1.0 * nthoPeridotSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4.0 * nthoPeridotFreq ' range=':= 2.0 * nthoPeridotFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -3473,7 +3473,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.145 * _default_ * nthoSapphireFreq ' range=':= 1.145 * _default_ * nthoSapphireFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoSapphireSize ' range=':= 0 * _default_ * nthoSapphireSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3527,7 +3527,7 @@
                             <Setting name='CloudRadius' avg=':= 0.926 * _default_ * nthoSapphireSize ' range=':= 0.926 * _default_ * nthoSapphireSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.926 * _default_ * nthoSapphireSize ' range=':= 0.926 * _default_ * nthoSapphireSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.857 * _default_ * nthoSapphireFreq ' range=':= 0.857 * _default_ * nthoSapphireFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3578,9 +3578,9 @@
                             <OreBlock block='NetherOres:tile.netherores.ore.0:15' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 1.500 * nthoSapphireSize ' range=':= 1.500 * nthoSapphireSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 3.000 * nthoSapphireFreq ' range=':= 3.000 * nthoSapphireFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.0 * nthoSapphireSize ' range=':= 1.0 * nthoSapphireSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4.0 * nthoSapphireFreq ' range=':= 2.0 * nthoSapphireFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -3605,7 +3605,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.306 * _default_ * nthoPlatinumFreq ' range=':= 0.306 * _default_ * nthoPlatinumFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.821 * _default_ * nthoPlatinumSize ' range=':= 0.821 * _default_ * nthoPlatinumSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3649,7 +3649,7 @@
                             <Setting name='CloudRadius' avg=':= 0.592 * _default_ * nthoPlatinumSize ' range=':= 0.592 * _default_ * nthoPlatinumSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.592 * _default_ * nthoPlatinumSize ' range=':= 0.592 * _default_ * nthoPlatinumSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.350 * _default_ * nthoPlatinumFreq ' range=':= 0.350 * _default_ * nthoPlatinumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3700,9 +3700,9 @@
                             <OreBlock block='NetherOres:tile.netherores.ore.1' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 1.500 * nthoPlatinumSize ' range=':= 1.500 * nthoPlatinumSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 0.500 * nthoPlatinumFreq ' range=':= 0.500 * nthoPlatinumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.0 * nthoPlatinumSize ' range=':= 1.0 * nthoPlatinumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 0.667 * nthoPlatinumFreq ' range=':= 0.33 * nthoPlatinumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -3727,7 +3727,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.867 * _default_ * nthoNickelFreq ' range=':= 0.867 * _default_ * nthoNickelFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.976 * _default_ * nthoNickelSize ' range=':= 0.976 * _default_ * nthoNickelSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3771,7 +3771,7 @@
                             <Setting name='CloudRadius' avg=':= 0.995 * _default_ * nthoNickelSize ' range=':= 0.995 * _default_ * nthoNickelSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.995 * _default_ * nthoNickelSize ' range=':= 0.995 * _default_ * nthoNickelSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.990 * _default_ * nthoNickelFreq ' range=':= 0.990 * _default_ * nthoNickelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3822,9 +3822,9 @@
                             <OreBlock block='NetherOres:tile.netherores.ore.1:1' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3.000 * nthoNickelSize ' range=':= 3.000 * nthoNickelSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2.000 * nthoNickelFreq ' range=':= 2.000 * nthoNickelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.0 * nthoNickelSize ' range=':= 2.0 * nthoNickelSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2.667 * nthoNickelFreq ' range=':= 1.33 * nthoNickelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -3849,7 +3849,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.613 * _default_ * nthoSteelFreq ' range=':= 0.613 * _default_ * nthoSteelFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * nthoSteelSize ' range=':= 0.922 * _default_ * nthoSteelSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3893,7 +3893,7 @@
                             <Setting name='CloudRadius' avg=':= 0.837 * _default_ * nthoSteelSize ' range=':= 0.837 * _default_ * nthoSteelSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.837 * _default_ * nthoSteelSize ' range=':= 0.837 * _default_ * nthoSteelSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.700 * _default_ * nthoSteelFreq ' range=':= 0.700 * _default_ * nthoSteelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3944,9 +3944,9 @@
                             <OreBlock block='NetherOres:tile.netherores.ore.1:2' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 2.000 * nthoSteelSize ' range=':= 2.000 * nthoSteelSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.500 * nthoSteelFreq ' range=':= 1.500 * nthoSteelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.667 * nthoSteelSize ' range=':= 1.33 * nthoSteelSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2.0 * nthoSteelFreq ' range=':= 1.0 * nthoSteelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -3973,7 +3973,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.313 * _default_ * nthoIridiumFreq ' range=':= 0.313 * _default_ * nthoIridiumFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.824 * _default_ * nthoIridiumSize ' range=':= 0.824 * _default_ * nthoIridiumSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4017,7 +4017,7 @@
                             <Setting name='CloudRadius' avg=':= 0.535 * _default_ * nthoIridiumSize ' range=':= 0.535 * _default_ * nthoIridiumSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.535 * _default_ * nthoIridiumSize ' range=':= 0.535 * _default_ * nthoIridiumSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.286 * _default_ * nthoIridiumFreq ' range=':= 0.286 * _default_ * nthoIridiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4068,9 +4068,9 @@
                             <OreBlock block='NetherOres:tile.netherores.ore.1:3' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 1.000 * nthoIridiumSize ' range=':= 1.000 * nthoIridiumSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 0.500 * nthoIridiumFreq ' range=':= 0.500 * nthoIridiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 1.333 * nthoIridiumSize ' range=':= 0.67 * nthoIridiumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 0.667 * nthoIridiumFreq ' range=':= 0.33 * nthoIridiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -4095,7 +4095,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.324 * _default_ * nthoOsmiumFreq ' range=':= 1.324 * _default_ * nthoOsmiumFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.048 * _default_ * nthoOsmiumSize ' range=':= 1.048 * _default_ * nthoOsmiumSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4139,7 +4139,7 @@
                             <Setting name='CloudRadius' avg=':= 1.230 * _default_ * nthoOsmiumSize ' range=':= 1.230 * _default_ * nthoOsmiumSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.230 * _default_ * nthoOsmiumSize ' range=':= 1.230 * _default_ * nthoOsmiumSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.512 * _default_ * nthoOsmiumFreq ' range=':= 1.512 * _default_ * nthoOsmiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4190,9 +4190,9 @@
                             <OreBlock block='NetherOres:tile.netherores.ore.1:4' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3.500 * nthoOsmiumSize ' range=':= 3.500 * nthoOsmiumSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 4.000 * nthoOsmiumFreq ' range=':= 4.000 * nthoOsmiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.667 * nthoOsmiumSize ' range=':= 2.33 * nthoOsmiumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 5.333 * nthoOsmiumFreq ' range=':= 2.67 * nthoOsmiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -4217,7 +4217,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 3.240 * _default_ * nthoSulfurFreq ' range=':= 3.240 * _default_ * nthoSulfurFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoSulfurSize ' range=':= 0 * _default_ * nthoSulfurSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4271,7 +4271,7 @@
                             <Setting name='CloudRadius' avg=':= 1.557 * _default_ * nthoSulfurSize ' range=':= 1.557 * _default_ * nthoSulfurSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.557 * _default_ * nthoSulfurSize ' range=':= 1.557 * _default_ * nthoSulfurSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 2.424 * _default_ * nthoSulfurFreq ' range=':= 2.424 * _default_ * nthoSulfurFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4322,9 +4322,9 @@
                             <OreBlock block='NetherOres:tile.netherores.ore.1:5' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 6.000 * nthoSulfurSize ' range=':= 6.000 * nthoSulfurSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 6.000 * nthoSulfurFreq ' range=':= 6.000 * nthoSulfurFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 8.0 * nthoSulfurSize ' range=':= 4.0 * nthoSulfurSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 8.0 * nthoSulfurFreq ' range=':= 4.0 * nthoSulfurFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -4349,7 +4349,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.433 * _default_ * nthoTitaniumFreq ' range=':= 0.433 * _default_ * nthoTitaniumFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.870 * _default_ * nthoTitaniumSize ' range=':= 0.870 * _default_ * nthoTitaniumSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4393,7 +4393,7 @@
                             <Setting name='CloudRadius' avg=':= 0.703 * _default_ * nthoTitaniumSize ' range=':= 0.703 * _default_ * nthoTitaniumSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.703 * _default_ * nthoTitaniumSize ' range=':= 0.703 * _default_ * nthoTitaniumSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.495 * _default_ * nthoTitaniumFreq ' range=':= 0.495 * _default_ * nthoTitaniumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4444,9 +4444,9 @@
                             <OreBlock block='NetherOres:tile.netherores.ore.1:6' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 1.000 * nthoTitaniumSize ' range=':= 1.000 * nthoTitaniumSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.500 * nthoTitaniumFreq ' range=':= 1.500 * nthoTitaniumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 1.333 * nthoTitaniumSize ' range=':= 0.67 * nthoTitaniumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2.0 * nthoTitaniumFreq ' range=':= 1.0 * nthoTitaniumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -4471,7 +4471,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.062 * _default_ * nthoMithrilFreq ' range=':= 1.062 * _default_ * nthoMithrilFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.010 * _default_ * nthoMithrilSize ' range=':= 1.010 * _default_ * nthoMithrilSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4515,7 +4515,7 @@
                             <Setting name='CloudRadius' avg=':= 1.101 * _default_ * nthoMithrilSize ' range=':= 1.101 * _default_ * nthoMithrilSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.101 * _default_ * nthoMithrilSize ' range=':= 1.101 * _default_ * nthoMithrilSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.212 * _default_ * nthoMithrilFreq ' range=':= 1.212 * _default_ * nthoMithrilFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4566,9 +4566,9 @@
                             <OreBlock block='NetherOres:tile.netherores.ore.1:7' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3.000 * nthoMithrilSize ' range=':= 3.000 * nthoMithrilSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 3.000 * nthoMithrilFreq ' range=':= 3.000 * nthoMithrilFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.0 * nthoMithrilSize ' range=':= 2.0 * nthoMithrilSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4.0 * nthoMithrilFreq ' range=':= 2.0 * nthoMithrilFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -4593,7 +4593,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.791 * _default_ * nthoAdamantiumFreq ' range=':= 0.791 * _default_ * nthoAdamantiumFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.962 * _default_ * nthoAdamantiumSize ' range=':= 0.962 * _default_ * nthoAdamantiumSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4637,7 +4637,7 @@
                             <Setting name='CloudRadius' avg=':= 0.951 * _default_ * nthoAdamantiumSize ' range=':= 0.951 * _default_ * nthoAdamantiumSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.951 * _default_ * nthoAdamantiumSize ' range=':= 0.951 * _default_ * nthoAdamantiumSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.904 * _default_ * nthoAdamantiumFreq ' range=':= 0.904 * _default_ * nthoAdamantiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4689,9 +4689,9 @@
                             <OreBlock block='NetherOres:tile.netherores.ore.1:8' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 2.000 * nthoAdamantiumSize ' range=':= 2.000 * nthoAdamantiumSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2.500 * nthoAdamantiumFreq ' range=':= 2.500 * nthoAdamantiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.667 * nthoAdamantiumSize ' range=':= 1.33 * nthoAdamantiumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 3.333 * nthoAdamantiumFreq ' range=':= 1.67 * nthoAdamantiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -4716,7 +4716,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.613 * _default_ * nthoRutileFreq ' range=':= 0.613 * _default_ * nthoRutileFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * nthoRutileSize ' range=':= 0.922 * _default_ * nthoRutileSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4760,7 +4760,7 @@
                             <Setting name='CloudRadius' avg=':= 0.837 * _default_ * nthoRutileSize ' range=':= 0.837 * _default_ * nthoRutileSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.837 * _default_ * nthoRutileSize ' range=':= 0.837 * _default_ * nthoRutileSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.700 * _default_ * nthoRutileFreq ' range=':= 0.700 * _default_ * nthoRutileFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4811,9 +4811,9 @@
                             <OreBlock block='NetherOres:tile.netherores.ore.1:9' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 2.000 * nthoRutileSize ' range=':= 2.000 * nthoRutileSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.500 * nthoRutileFreq ' range=':= 1.500 * nthoRutileFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.667 * nthoRutileSize ' range=':= 1.33 * nthoRutileSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2.0 * nthoRutileFreq ' range=':= 1.0 * nthoRutileFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -4838,7 +4838,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.416 * _default_ * nthoTungstenFreq ' range=':= 1.416 * _default_ * nthoTungstenFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.060 * _default_ * nthoTungstenSize ' range=':= 1.060 * _default_ * nthoTungstenSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4882,7 +4882,7 @@
                             <Setting name='CloudRadius' avg=':= 1.271 * _default_ * nthoTungstenSize ' range=':= 1.271 * _default_ * nthoTungstenSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.271 * _default_ * nthoTungstenSize ' range=':= 1.271 * _default_ * nthoTungstenSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.616 * _default_ * nthoTungstenFreq ' range=':= 1.616 * _default_ * nthoTungstenFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -4933,9 +4933,9 @@
                             <OreBlock block='NetherOres:tile.netherores.ore.1:10' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.000 * nthoTungstenSize ' range=':= 4.000 * nthoTungstenSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 4.000 * nthoTungstenFreq ' range=':= 4.000 * nthoTungstenFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 5.333 * nthoTungstenSize ' range=':= 2.67 * nthoTungstenSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 5.333 * nthoTungstenFreq ' range=':= 2.67 * nthoTungstenFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -4967,7 +4967,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.372 * _default_ * nthoAmberFreq ' range=':= 2.372 * _default_ * nthoAmberFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoAmberSize ' range=':= 0 * _default_ * nthoAmberSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -5011,7 +5011,7 @@
                             <Setting name='CloudRadius' avg=':= 1.052 * _default_ * nthoAmberSize ' range=':= 1.052 * _default_ * nthoAmberSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.052 * _default_ * nthoAmberSize ' range=':= 1.052 * _default_ * nthoAmberSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.107 * _default_ * nthoAmberFreq ' range=':= 1.107 * _default_ * nthoAmberFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -5062,9 +5062,9 @@
                             <OreBlock block='NetherOres:tile.netherores.ore.1:11' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3.000 * nthoAmberSize ' range=':= 3.000 * nthoAmberSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2.500 * nthoAmberFreq ' range=':= 2.500 * nthoAmberFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.0 * nthoAmberSize ' range=':= 2.0 * nthoAmberSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 3.333 * nthoAmberFreq ' range=':= 1.67 * nthoAmberFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -5089,7 +5089,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.416 * _default_ * nthoTennantiteFreq ' range=':= 1.416 * _default_ * nthoTennantiteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.060 * _default_ * nthoTennantiteSize ' range=':= 1.060 * _default_ * nthoTennantiteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -5133,7 +5133,7 @@
                             <Setting name='CloudRadius' avg=':= 1.271 * _default_ * nthoTennantiteSize ' range=':= 1.271 * _default_ * nthoTennantiteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.271 * _default_ * nthoTennantiteSize ' range=':= 1.271 * _default_ * nthoTennantiteSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.616 * _default_ * nthoTennantiteFreq ' range=':= 1.616 * _default_ * nthoTennantiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -5185,9 +5185,9 @@
                             <OreBlock block='NetherOres:tile.netherores.ore.1:12' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.000 * nthoTennantiteSize ' range=':= 4.000 * nthoTennantiteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 4.000 * nthoTennantiteFreq ' range=':= 4.000 * nthoTennantiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 5.333 * nthoTennantiteSize ' range=':= 2.67 * nthoTennantiteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 5.333 * nthoTennantiteFreq ' range=':= 2.67 * nthoTennantiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -5219,7 +5219,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.166 * _default_ * nthoSaltFreq ' range=':= 2.166 * _default_ * nthoSaltFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoSaltSize ' range=':= 0 * _default_ * nthoSaltSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -5263,7 +5263,7 @@
                             <Setting name='CloudRadius' avg=':= 1.005 * _default_ * nthoSaltSize ' range=':= 1.005 * _default_ * nthoSaltSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.005 * _default_ * nthoSaltSize ' range=':= 1.005 * _default_ * nthoSaltSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.010 * _default_ * nthoSaltFreq ' range=':= 1.010 * _default_ * nthoSaltFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -5314,9 +5314,9 @@
                             <OreBlock block='NetherOres:tile.netherores.ore.1:13' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 2.500 * nthoSaltSize ' range=':= 2.500 * nthoSaltSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2.500 * nthoSaltFreq ' range=':= 2.500 * nthoSaltFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 3.333 * nthoSaltSize ' range=':= 1.67 * nthoSaltSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 3.333 * nthoSaltFreq ' range=':= 1.67 * nthoSaltFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -5348,7 +5348,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.122 * _default_ * nthoSaltpeterFreq ' range=':= 2.122 * _default_ * nthoSaltpeterFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoSaltpeterSize ' range=':= 0 * _default_ * nthoSaltpeterSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -5392,7 +5392,7 @@
                             <Setting name='CloudRadius' avg=':= 0.995 * _default_ * nthoSaltpeterSize ' range=':= 0.995 * _default_ * nthoSaltpeterSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.995 * _default_ * nthoSaltpeterSize ' range=':= 0.995 * _default_ * nthoSaltpeterSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.990 * _default_ * nthoSaltpeterFreq ' range=':= 0.990 * _default_ * nthoSaltpeterFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -5443,9 +5443,9 @@
                             <OreBlock block='NetherOres:tile.netherores.ore.1:14' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 2.000 * nthoSaltpeterSize ' range=':= 2.000 * nthoSaltpeterSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 3.000 * nthoSaltpeterFreq ' range=':= 3.000 * nthoSaltpeterFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.667 * nthoSaltpeterSize ' range=':= 1.33 * nthoSaltpeterSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4.0 * nthoSaltpeterFreq ' range=':= 2.0 * nthoSaltpeterFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -5477,7 +5477,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.937 * _default_ * nthoMagnesiumFreq ' range=':= 1.937 * _default_ * nthoMagnesiumFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nthoMagnesiumSize ' range=':= 0 * _default_ * nthoMagnesiumSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -5521,7 +5521,7 @@
                             <Setting name='CloudRadius' avg=':= 0.951 * _default_ * nthoMagnesiumSize ' range=':= 0.951 * _default_ * nthoMagnesiumSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.951 * _default_ * nthoMagnesiumSize ' range=':= 0.951 * _default_ * nthoMagnesiumSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.904 * _default_ * nthoMagnesiumFreq ' range=':= 0.904 * _default_ * nthoMagnesiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -5572,9 +5572,9 @@
                             <OreBlock block='NetherOres:tile.netherores.ore.1:15' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 2.500 * nthoMagnesiumSize ' range=':= 2.500 * nthoMagnesiumSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2.000 * nthoMagnesiumFreq ' range=':= 2.000 * nthoMagnesiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 3.333 * nthoMagnesiumSize ' range=':= 1.67 * nthoMagnesiumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2.667 * nthoMagnesiumFreq ' range=':= 1.33 * nthoMagnesiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64.5 ' range=':= 63.5 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>

--- a/src/main/resources/config/modules/Netherrocks.xml
+++ b/src/main/resources/config/modules/Netherrocks.xml
@@ -358,7 +358,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.371 * _default_ * nthrFyriteFreq ' range=':= 1.371 * _default_ * nthrFyriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.054 * _default_ * nthrFyriteSize ' range=':= 1.054 * _default_ * nthrFyriteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -402,7 +402,7 @@
                             <Setting name='CloudRadius' avg=':= 1.251 * _default_ * nthrFyriteSize ' range=':= 1.251 * _default_ * nthrFyriteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.251 * _default_ * nthrFyriteSize ' range=':= 1.251 * _default_ * nthrFyriteSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.565 * _default_ * nthrFyriteFreq ' range=':= 1.565 * _default_ * nthrFyriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -453,9 +453,9 @@
                             <OreBlock block='netherrocks:fyrite_ore' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3.000 * nthrFyriteSize ' range=':= 3.000 * nthrFyriteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 5.000 * nthrFyriteFreq ' range=':= 5.000 * nthrFyriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.0 * nthrFyriteSize ' range=':= 2.0 * nthrFyriteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 6.667 * nthrFyriteFreq ' range=':= 3.33 * nthrFyriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -480,7 +480,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.480 * _default_ * nthrMalachiteFreq ' range=':= 1.480 * _default_ * nthrMalachiteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.068 * _default_ * nthrMalachiteSize ' range=':= 1.068 * _default_ * nthrMalachiteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -524,7 +524,7 @@
                             <Setting name='CloudRadius' avg=':= 1.300 * _default_ * nthrMalachiteSize ' range=':= 1.300 * _default_ * nthrMalachiteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.300 * _default_ * nthrMalachiteSize ' range=':= 1.300 * _default_ * nthrMalachiteSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.690 * _default_ * nthrMalachiteFreq ' range=':= 1.690 * _default_ * nthrMalachiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -575,9 +575,9 @@
                             <OreBlock block='netherrocks:malachite_ore' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3.500 * nthrMalachiteSize ' range=':= 3.500 * nthrMalachiteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 5.000 * nthrMalachiteFreq ' range=':= 5.000 * nthrMalachiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.667 * nthrMalachiteSize ' range=':= 2.33 * nthrMalachiteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 6.667 * nthrMalachiteFreq ' range=':= 3.33 * nthrMalachiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -602,7 +602,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.251 * _default_ * nthrAshtoneFreq ' range=':= 1.251 * _default_ * nthrAshtoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.038 * _default_ * nthrAshtoneSize ' range=':= 1.038 * _default_ * nthrAshtoneSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -646,7 +646,7 @@
                             <Setting name='CloudRadius' avg=':= 1.195 * _default_ * nthrAshtoneSize ' range=':= 1.195 * _default_ * nthrAshtoneSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.195 * _default_ * nthrAshtoneSize ' range=':= 1.195 * _default_ * nthrAshtoneSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.429 * _default_ * nthrAshtoneFreq ' range=':= 1.429 * _default_ * nthrAshtoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -697,9 +697,9 @@
                             <OreBlock block='netherrocks:ashstone_ore' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 2.500 * nthrAshtoneSize ' range=':= 2.500 * nthrAshtoneSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 5.000 * nthrAshtoneFreq ' range=':= 5.000 * nthrAshtoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 3.333 * nthrAshtoneSize ' range=':= 1.67 * nthrAshtoneSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 6.667 * nthrAshtoneFreq ' range=':= 3.33 * nthrAshtoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -722,8 +722,8 @@
                             <OreBlock block='netherrocks:illumenite_ore' weight='1.0' />
                             <Replaces block='minecraft:glowstone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 7.500 * nthrIllumeniteSize ' range=':= 7.500 * nthrIllumeniteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 175.000 * nthrIllumeniteFreq ' range=':= 175.000 * nthrIllumeniteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 10.0 * nthrIllumeniteSize ' range=':= 5.0 * nthrIllumeniteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 233.333 * nthrIllumeniteFreq ' range=':= 116.67 * nthrIllumeniteFreq ' type='normal' scaleTo='base' />
                             <Setting name='Height' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='base' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
@@ -749,7 +749,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * nthrDragonstoneFreq ' range=':= 0.969 * _default_ * nthrDragonstoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.995 * _default_ * nthrDragonstoneSize ' range=':= 0.995 * _default_ * nthrDragonstoneSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -793,7 +793,7 @@
                             <Setting name='CloudRadius' avg=':= 1.052 * _default_ * nthrDragonstoneSize ' range=':= 1.052 * _default_ * nthrDragonstoneSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.052 * _default_ * nthrDragonstoneSize ' range=':= 1.052 * _default_ * nthrDragonstoneSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.107 * _default_ * nthrDragonstoneFreq ' range=':= 1.107 * _default_ * nthrDragonstoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -845,9 +845,9 @@
                             <OreBlock block='netherrocks:dragonstone_ore' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 2.500 * nthrDragonstoneSize ' range=':= 2.500 * nthrDragonstoneSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 3.000 * nthrDragonstoneFreq ' range=':= 3.000 * nthrDragonstoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 3.333 * nthrDragonstoneSize ' range=':= 1.67 * nthrDragonstoneSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4.0 * nthrDragonstoneFreq ' range=':= 2.0 * nthrDragonstoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -872,7 +872,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.371 * _default_ * nthrArgoniteFreq ' range=':= 1.371 * _default_ * nthrArgoniteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.054 * _default_ * nthrArgoniteSize ' range=':= 1.054 * _default_ * nthrArgoniteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -916,7 +916,7 @@
                             <Setting name='CloudRadius' avg=':= 1.251 * _default_ * nthrArgoniteSize ' range=':= 1.251 * _default_ * nthrArgoniteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.251 * _default_ * nthrArgoniteSize ' range=':= 1.251 * _default_ * nthrArgoniteSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.565 * _default_ * nthrArgoniteFreq ' range=':= 1.565 * _default_ * nthrArgoniteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -967,9 +967,9 @@
                             <OreBlock block='netherrocks:argonite_ore' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3.000 * nthrArgoniteSize ' range=':= 3.000 * nthrArgoniteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 5.000 * nthrArgoniteFreq ' range=':= 5.000 * nthrArgoniteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.0 * nthrArgoniteSize ' range=':= 2.0 * nthrArgoniteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 6.667 * nthrArgoniteFreq ' range=':= 3.33 * nthrArgoniteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 128 ' range=':= 128 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>

--- a/src/main/resources/config/modules/Nuclearcraft.xml
+++ b/src/main/resources/config/modules/Nuclearcraft.xml
@@ -507,7 +507,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.937 * _default_ * nclcUraniumFreq ' range=':= 1.937 * _default_ * nclcUraniumFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nclcUraniumSize ' range=':= 0 * _default_ * nclcUraniumSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 20 ' range=':= 20 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 20 ' range=':= 20 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -551,7 +551,7 @@
                             <Setting name='CloudRadius' avg=':= 0.951 * _default_ * nclcUraniumSize ' range=':= 0.951 * _default_ * nclcUraniumSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.951 * _default_ * nclcUraniumSize ' range=':= 0.951 * _default_ * nclcUraniumSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.904 * _default_ * nclcUraniumFreq ' range=':= 0.904 * _default_ * nclcUraniumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 20 ' range=':= 20 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 20 ' range=':= 20 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -602,9 +602,9 @@
                             <OreBlock block='NuclearCraft:blockOre:4' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 2.500 * nclcUraniumSize ' range=':= 2.500 * nclcUraniumSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2.000 * nclcUraniumFreq ' range=':= 2.000 * nclcUraniumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 20 ' range=':= 20 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 3.333 * nclcUraniumSize ' range=':= 1.67 * nclcUraniumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2.667 * nclcUraniumFreq ' range=':= 1.33 * nclcUraniumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 20 ' range=':= 20 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -629,7 +629,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.324 * _default_ * nclcCopperFreq ' range=':= 1.324 * _default_ * nclcCopperFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.048 * _default_ * nclcCopperSize ' range=':= 1.048 * _default_ * nclcCopperSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 30 ' range=':= 30 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 30 ' range=':= 30 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -673,7 +673,7 @@
                             <Setting name='CloudRadius' avg=':= 1.230 * _default_ * nclcCopperSize ' range=':= 1.230 * _default_ * nclcCopperSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.230 * _default_ * nclcCopperSize ' range=':= 1.230 * _default_ * nclcCopperSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.512 * _default_ * nclcCopperFreq ' range=':= 1.512 * _default_ * nclcCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 30 ' range=':= 30 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 30 ' range=':= 30 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -724,9 +724,9 @@
                             <OreBlock block='NuclearCraft:blockOre' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.000 * nclcCopperSize ' range=':= 4.000 * nclcCopperSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 3.500 * nclcCopperFreq ' range=':= 3.500 * nclcCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 30 ' range=':= 30 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 5.333 * nclcCopperSize ' range=':= 2.67 * nclcCopperSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4.667 * nclcCopperFreq ' range=':= 2.33 * nclcCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 30 ' range=':= 30 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -751,7 +751,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.226 * _default_ * nclcTinFreq ' range=':= 1.226 * _default_ * nclcTinFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.035 * _default_ * nclcTinSize ' range=':= 1.035 * _default_ * nclcTinSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 30 ' range=':= 30 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 30 ' range=':= 30 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -795,7 +795,7 @@
                             <Setting name='CloudRadius' avg=':= 1.183 * _default_ * nclcTinSize ' range=':= 1.183 * _default_ * nclcTinSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.183 * _default_ * nclcTinSize ' range=':= 1.183 * _default_ * nclcTinSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.400 * _default_ * nclcTinFreq ' range=':= 1.400 * _default_ * nclcTinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 30 ' range=':= 30 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 30 ' range=':= 30 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -846,9 +846,9 @@
                             <OreBlock block='NuclearCraft:blockOre:1' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.000 * nclcTinSize ' range=':= 4.000 * nclcTinSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 3.000 * nclcTinFreq ' range=':= 3.000 * nclcTinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 30 ' range=':= 30 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 5.333 * nclcTinSize ' range=':= 2.67 * nclcTinSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4.0 * nclcTinFreq ' range=':= 2.0 * nclcTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 30 ' range=':= 30 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -873,7 +873,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.969 * _default_ * nclcLeadFreq ' range=':= 0.969 * _default_ * nclcLeadFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.995 * _default_ * nclcLeadSize ' range=':= 0.995 * _default_ * nclcLeadSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 20 ' range=':= 20 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 20 ' range=':= 20 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -917,7 +917,7 @@
                             <Setting name='CloudRadius' avg=':= 1.052 * _default_ * nclcLeadSize ' range=':= 1.052 * _default_ * nclcLeadSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.052 * _default_ * nclcLeadSize ' range=':= 1.052 * _default_ * nclcLeadSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.107 * _default_ * nclcLeadFreq ' range=':= 1.107 * _default_ * nclcLeadFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 20 ' range=':= 20 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 20 ' range=':= 20 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -968,9 +968,9 @@
                             <OreBlock block='NuclearCraft:blockOre:2' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 2.500 * nclcLeadSize ' range=':= 2.500 * nclcLeadSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 3.000 * nclcLeadFreq ' range=':= 3.000 * nclcLeadFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 20 ' range=':= 20 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 3.333 * nclcLeadSize ' range=':= 1.67 * nclcLeadSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4.0 * nclcLeadFreq ' range=':= 2.0 * nclcLeadFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 20 ' range=':= 20 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -995,7 +995,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.885 * _default_ * nclcSilverFreq ' range=':= 0.885 * _default_ * nclcSilverFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.980 * _default_ * nclcSilverSize ' range=':= 0.980 * _default_ * nclcSilverSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 20 ' range=':= 20 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 20 ' range=':= 20 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1039,7 +1039,7 @@
                             <Setting name='CloudRadius' avg=':= 1.005 * _default_ * nclcSilverSize ' range=':= 1.005 * _default_ * nclcSilverSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.005 * _default_ * nclcSilverSize ' range=':= 1.005 * _default_ * nclcSilverSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.010 * _default_ * nclcSilverFreq ' range=':= 1.010 * _default_ * nclcSilverFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 20 ' range=':= 20 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 20 ' range=':= 20 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1090,9 +1090,9 @@
                             <OreBlock block='NuclearCraft:blockOre:3' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 2.500 * nclcSilverSize ' range=':= 2.500 * nclcSilverSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2.500 * nclcSilverFreq ' range=':= 2.500 * nclcSilverFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 20 ' range=':= 20 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 3.333 * nclcSilverSize ' range=':= 1.67 * nclcSilverSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 3.333 * nclcSilverFreq ' range=':= 1.67 * nclcSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 20 ' range=':= 20 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1124,7 +1124,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.500 * _default_ * nclcLithiumFreq ' range=':= 1.500 * _default_ * nclcLithiumFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nclcLithiumSize ' range=':= 0 * _default_ * nclcLithiumSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 12.5 ' range=':= 12.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 12.5 ' range=':= 12.5 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1168,7 +1168,7 @@
                             <Setting name='CloudRadius' avg=':= 0.837 * _default_ * nclcLithiumSize ' range=':= 0.837 * _default_ * nclcLithiumSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.837 * _default_ * nclcLithiumSize ' range=':= 0.837 * _default_ * nclcLithiumSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.700 * _default_ * nclcLithiumFreq ' range=':= 0.700 * _default_ * nclcLithiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 12.5 ' range=':= 12.5 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 12.5 ' range=':= 12.5 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1219,9 +1219,9 @@
                             <OreBlock block='NuclearCraft:blockOre:7' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 2.000 * nclcLithiumSize ' range=':= 2.000 * nclcLithiumSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.500 * nclcLithiumFreq ' range=':= 1.500 * nclcLithiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 12.5 ' range=':= 12.5 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.667 * nclcLithiumSize ' range=':= 1.33 * nclcLithiumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2.0 * nclcLithiumFreq ' range=':= 1.0 * nclcLithiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 12.5 ' range=':= 12.5 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1253,7 +1253,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.500 * _default_ * nclcBoronFreq ' range=':= 1.500 * _default_ * nclcBoronFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nclcBoronSize ' range=':= 0 * _default_ * nclcBoronSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 10 ' range=':= 10 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 10 ' range=':= 10 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1297,7 +1297,7 @@
                             <Setting name='CloudRadius' avg=':= 0.837 * _default_ * nclcBoronSize ' range=':= 0.837 * _default_ * nclcBoronSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.837 * _default_ * nclcBoronSize ' range=':= 0.837 * _default_ * nclcBoronSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.700 * _default_ * nclcBoronFreq ' range=':= 0.700 * _default_ * nclcBoronFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 10 ' range=':= 10 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 10 ' range=':= 10 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1348,9 +1348,9 @@
                             <OreBlock block='NuclearCraft:blockOre:8' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 2.000 * nclcBoronSize ' range=':= 2.000 * nclcBoronSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.500 * nclcBoronFreq ' range=':= 1.500 * nclcBoronFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 10 ' range=':= 10 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.667 * nclcBoronSize ' range=':= 1.33 * nclcBoronSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2.0 * nclcBoronFreq ' range=':= 1.0 * nclcBoronFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 10 ' range=':= 10 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1382,7 +1382,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.937 * _default_ * nclcThoriumFreq ' range=':= 1.937 * _default_ * nclcThoriumFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nclcThoriumSize ' range=':= 0 * _default_ * nclcThoriumSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 20 ' range=':= 20 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 20 ' range=':= 20 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1426,7 +1426,7 @@
                             <Setting name='CloudRadius' avg=':= 0.951 * _default_ * nclcThoriumSize ' range=':= 0.951 * _default_ * nclcThoriumSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.951 * _default_ * nclcThoriumSize ' range=':= 0.951 * _default_ * nclcThoriumSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.904 * _default_ * nclcThoriumFreq ' range=':= 0.904 * _default_ * nclcThoriumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 20 ' range=':= 20 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 20 ' range=':= 20 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1477,9 +1477,9 @@
                             <OreBlock block='NuclearCraft:blockOre:5' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 2.500 * nclcThoriumSize ' range=':= 2.500 * nclcThoriumSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2.000 * nclcThoriumFreq ' range=':= 2.000 * nclcThoriumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 20 ' range=':= 20 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 3.333 * nclcThoriumSize ' range=':= 1.67 * nclcThoriumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2.667 * nclcThoriumFreq ' range=':= 1.33 * nclcThoriumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 20 ' range=':= 20 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1543,7 +1543,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.678 * _default_ * nclcPlutoniumFreq ' range=':= 1.678 * _default_ * nclcPlutoniumFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * nclcPlutoniumSize ' range=':= 0 * _default_ * nclcPlutoniumSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64 ' range=':= 64 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 64 ' range=':= 64 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1587,7 +1587,7 @@
                             <Setting name='CloudRadius' avg=':= 0.885 * _default_ * nclcPlutoniumSize ' range=':= 0.885 * _default_ * nclcPlutoniumSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.885 * _default_ * nclcPlutoniumSize ' range=':= 0.885 * _default_ * nclcPlutoniumSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.782 * _default_ * nclcPlutoniumFreq ' range=':= 0.782 * _default_ * nclcPlutoniumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64 ' range=':= 64 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64 ' range=':= 64 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1638,9 +1638,9 @@
                             <OreBlock block='NuclearCraft:blockOre:6' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 2.500 * nclcPlutoniumSize ' range=':= 2.500 * nclcPlutoniumSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.500 * nclcPlutoniumFreq ' range=':= 1.500 * nclcPlutoniumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64 ' range=':= 64 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 3.333 * nclcPlutoniumSize ' range=':= 1.67 * nclcPlutoniumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2.0 * nclcPlutoniumFreq ' range=':= 1.0 * nclcPlutoniumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64 ' range=':= 64 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>

--- a/src/main/resources/config/modules/PamsHarvestCraft.xml
+++ b/src/main/resources/config/modules/PamsHarvestCraft.xml
@@ -133,7 +133,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 5.305 * _default_ * hvstSaltFreq ' range=':= 5.305 * _default_ * hvstSaltFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * hvstSaltSize ' range=':= 0 * _default_ * hvstSaltSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -177,7 +177,7 @@
                             <Setting name='CloudRadius' avg=':= 1.573 * _default_ * hvstSaltSize ' range=':= 1.573 * _default_ * hvstSaltSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.573 * _default_ * hvstSaltSize ' range=':= 1.573 * _default_ * hvstSaltSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 2.474 * _default_ * hvstSaltFreq ' range=':= 2.474 * _default_ * hvstSaltFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -228,9 +228,9 @@
                             <OreBlock block='harvestcraft:salt' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 2.500 * hvstSaltSize ' range=':= 2.500 * hvstSaltSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 15.000 * hvstSaltFreq ' range=':= 15.000 * hvstSaltFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 3.333 * hvstSaltSize ' range=':= 1.67 * hvstSaltSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 20.0 * hvstSaltFreq ' range=':= 10.0 * hvstSaltFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 67 ' range=':= 61 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>

--- a/src/main/resources/config/modules/ProjectRed.xml
+++ b/src/main/resources/config/modules/ProjectRed.xml
@@ -455,7 +455,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.270 * _default_ * predRubyFreq ' range=':= 0.270 * _default_ * predRubyFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * predRubySize ' range=':= 0 * _default_ * predRubySize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 16 ' range=':= 4 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 16 ' range=':= 4 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -509,7 +509,7 @@
                             <Setting name='CloudRadius' avg=':= 0.449 * _default_ * predRubySize ' range=':= 0.449 * _default_ * predRubySize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.449 * _default_ * predRubySize ' range=':= 0.449 * _default_ * predRubySize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.202 * _default_ * predRubyFreq ' range=':= 0.202 * _default_ * predRubyFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 16 ' range=':= 4 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 16 ' range=':= 4 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -560,9 +560,9 @@
                             <OreBlock block='ProjRed|Exploration:projectred.exploration.ore' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 0.500 * predRubySize ' range=':= 0.500 * predRubySize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 0.500 * predRubyFreq ' range=':= 0.500 * predRubyFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 16 ' range=':= 4 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 0.667 * predRubySize ' range=':= 0.33 * predRubySize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 0.667 * predRubyFreq ' range=':= 0.33 * predRubyFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 16 ' range=':= 4 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -587,7 +587,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.270 * _default_ * predSapphireFreq ' range=':= 0.270 * _default_ * predSapphireFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * predSapphireSize ' range=':= 0 * _default_ * predSapphireSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 16 ' range=':= 4 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 16 ' range=':= 4 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -641,7 +641,7 @@
                             <Setting name='CloudRadius' avg=':= 0.449 * _default_ * predSapphireSize ' range=':= 0.449 * _default_ * predSapphireSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.449 * _default_ * predSapphireSize ' range=':= 0.449 * _default_ * predSapphireSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.202 * _default_ * predSapphireFreq ' range=':= 0.202 * _default_ * predSapphireFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 16 ' range=':= 4 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 16 ' range=':= 4 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -692,9 +692,9 @@
                             <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:1' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 0.500 * predSapphireSize ' range=':= 0.500 * predSapphireSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 0.500 * predSapphireFreq ' range=':= 0.500 * predSapphireFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 16 ' range=':= 4 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 0.667 * predSapphireSize ' range=':= 0.33 * predSapphireSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 0.667 * predSapphireFreq ' range=':= 0.33 * predSapphireFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 16 ' range=':= 4 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -719,7 +719,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.270 * _default_ * predPeridotFreq ' range=':= 0.270 * _default_ * predPeridotFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * predPeridotSize ' range=':= 0 * _default_ * predPeridotSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 22 ' range=':= 6 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 22 ' range=':= 6 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -773,7 +773,7 @@
                             <Setting name='CloudRadius' avg=':= 0.449 * _default_ * predPeridotSize ' range=':= 0.449 * _default_ * predPeridotSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.449 * _default_ * predPeridotSize ' range=':= 0.449 * _default_ * predPeridotSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.202 * _default_ * predPeridotFreq ' range=':= 0.202 * _default_ * predPeridotFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 22 ' range=':= 6 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 22 ' range=':= 6 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -824,9 +824,9 @@
                             <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:2' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 0.500 * predPeridotSize ' range=':= 0.500 * predPeridotSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 0.500 * predPeridotFreq ' range=':= 0.500 * predPeridotFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 22 ' range=':= 6 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 0.667 * predPeridotSize ' range=':= 0.33 * predPeridotSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 0.667 * predPeridotFreq ' range=':= 0.33 * predPeridotFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 22 ' range=':= 6 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -851,7 +851,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.416 * _default_ * predCopperFreq ' range=':= 1.416 * _default_ * predCopperFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.060 * _default_ * predCopperSize ' range=':= 1.060 * _default_ * predCopperSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 35 ' range=':= 29 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 35 ' range=':= 29 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -895,7 +895,7 @@
                             <Setting name='CloudRadius' avg=':= 1.271 * _default_ * predCopperSize ' range=':= 1.271 * _default_ * predCopperSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.271 * _default_ * predCopperSize ' range=':= 1.271 * _default_ * predCopperSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.616 * _default_ * predCopperFreq ' range=':= 1.616 * _default_ * predCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 35 ' range=':= 29 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 35 ' range=':= 29 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -946,9 +946,9 @@
                             <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:3' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.000 * predCopperSize ' range=':= 4.000 * predCopperSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 4.000 * predCopperFreq ' range=':= 4.000 * predCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 35 ' range=':= 29 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 5.333 * predCopperSize ' range=':= 2.67 * predCopperSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 5.333 * predCopperFreq ' range=':= 2.67 * predCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 35 ' range=':= 29 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -973,7 +973,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.119 * _default_ * predTinFreq ' range=':= 1.119 * _default_ * predTinFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.019 * _default_ * predTinSize ' range=':= 1.019 * _default_ * predTinSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 27 ' range=':= 21 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 27 ' range=':= 21 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1017,7 +1017,7 @@
                             <Setting name='CloudRadius' avg=':= 1.130 * _default_ * predTinSize ' range=':= 1.130 * _default_ * predTinSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.130 * _default_ * predTinSize ' range=':= 1.130 * _default_ * predTinSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.278 * _default_ * predTinFreq ' range=':= 1.278 * _default_ * predTinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 27 ' range=':= 21 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 27 ' range=':= 21 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1068,9 +1068,9 @@
                             <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:4' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.000 * predTinSize ' range=':= 4.000 * predTinSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2.500 * predTinFreq ' range=':= 2.500 * predTinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 27 ' range=':= 21 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 5.333 * predTinSize ' range=':= 2.67 * predTinSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 3.333 * predTinFreq ' range=':= 1.67 * predTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 27 ' range=':= 21 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1095,7 +1095,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.354 * _default_ * predSilverFreq ' range=':= 0.354 * _default_ * predSilverFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.841 * _default_ * predSilverSize ' range=':= 0.841 * _default_ * predSilverSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1139,7 +1139,7 @@
                             <Setting name='CloudRadius' avg=':= 0.636 * _default_ * predSilverSize ' range=':= 0.636 * _default_ * predSilverSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.636 * _default_ * predSilverSize ' range=':= 0.636 * _default_ * predSilverSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.404 * _default_ * predSilverFreq ' range=':= 0.404 * _default_ * predSilverFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1190,9 +1190,9 @@
                             <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:5' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 2.000 * predSilverSize ' range=':= 2.000 * predSilverSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 0.500 * predSilverFreq ' range=':= 0.500 * predSilverFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.667 * predSilverSize ' range=':= 1.33 * predSilverSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 0.667 * predSilverFreq ' range=':= 0.33 * predSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 19 ' range=':= 13 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1217,7 +1217,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.286 * _default_ * predElectrotineFreq ' range=':= 1.286 * _default_ * predElectrotineFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * predElectrotineSize ' range=':= 0 * _default_ * predElectrotineSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 11 ' range=':= 5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 11 ' range=':= 5 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1261,7 +1261,7 @@
                             <Setting name='CloudRadius' avg=':= 0.899 * _default_ * predElectrotineSize ' range=':= 0.899 * _default_ * predElectrotineSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.899 * _default_ * predElectrotineSize ' range=':= 0.899 * _default_ * predElectrotineSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.808 * _default_ * predElectrotineFreq ' range=':= 0.808 * _default_ * predElectrotineFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 11 ' range=':= 5 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 11 ' range=':= 5 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1313,9 +1313,9 @@
                             <OreBlock block='ProjRed|Exploration:projectred.exploration.ore:6' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.000 * predElectrotineSize ' range=':= 4.000 * predElectrotineSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.000 * predElectrotineFreq ' range=':= 1.000 * predElectrotineFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 11 ' range=':= 5 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 5.333 * predElectrotineSize ' range=':= 2.67 * predElectrotineSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.333 * predElectrotineFreq ' range=':= 0.67 * predElectrotineFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 11 ' range=':= 5 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1343,7 +1343,7 @@
                             <Setting name='CloudRadius' avg=':= 0.687 * _default_ * predMarbleSize ' range=':= 0.687 * _default_ * predMarbleSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.687 * _default_ * predMarbleSize ' range=':= 0.687 * _default_ * predMarbleSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.472 * _default_ * predMarbleFreq ' range=':= 0.472 * _default_ * predMarbleFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 48 ' range=':= 16 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 48 ' range=':= 16 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1369,7 +1369,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.708 * _default_ * predMarbleFreq ' range=':= 0.708 * _default_ * predMarbleFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.944 * _default_ * predMarbleSize ' range=':= 0.944 * _default_ * predMarbleSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 48 ' range=':= 16 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 48 ' range=':= 16 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1400,9 +1400,9 @@
                             <OreBlock block='ProjRed|Exploration:projectred.exploration.stone' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 8.000 * predMarbleSize ' range=':= 8.000 * predMarbleSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 0.500 * predMarbleFreq ' range=':= 0.500 * predMarbleFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 48 ' range=':= 16 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 10.667 * predMarbleSize ' range=':= 5.33 * predMarbleSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 0.667 * predMarbleFreq ' range=':= 0.33 * predMarbleFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 48 ' range=':= 16 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>

--- a/src/main/resources/config/modules/RailCraft.xml
+++ b/src/main/resources/config/modules/RailCraft.xml
@@ -594,7 +594,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 9.801 * _default_ * rlcrPoorIronFreq ' range=':= 9.801 * _default_ * rlcrPoorIronFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * rlcrPoorIronSize ' range=':= 0 * _default_ * rlcrPoorIronSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 40 ' range=':= 4 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 40 ' range=':= 4 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -638,7 +638,7 @@
                             <Setting name='CloudRadius' avg=':= 2.138 * _default_ * rlcrPoorIronSize ' range=':= 2.138 * _default_ * rlcrPoorIronSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 2.138 * _default_ * rlcrPoorIronSize ' range=':= 2.138 * _default_ * rlcrPoorIronSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 4.571 * _default_ * rlcrPoorIronFreq ' range=':= 4.571 * _default_ * rlcrPoorIronFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 40 ' range=':= 4 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 40 ' range=':= 4 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -689,9 +689,9 @@
                             <OreBlock block='Railcraft:ore:7' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 8.000 * rlcrPoorIronSize ' range=':= 8.000 * rlcrPoorIronSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 16.000 * rlcrPoorIronFreq ' range=':= 16.000 * rlcrPoorIronFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 40 ' range=':= 4 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 10.667 * rlcrPoorIronSize ' range=':= 5.33 * rlcrPoorIronSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 21.333 * rlcrPoorIronFreq ' range=':= 10.67 * rlcrPoorIronFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 40 ' range=':= 4 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -723,7 +723,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.450 * _default_ * rlcrPoorGoldFreq ' range=':= 2.450 * _default_ * rlcrPoorGoldFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * rlcrPoorGoldSize ' range=':= 0 * _default_ * rlcrPoorGoldSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 15 ' range=':= 1 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 15 ' range=':= 1 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -767,7 +767,7 @@
                             <Setting name='CloudRadius' avg=':= 1.069 * _default_ * rlcrPoorGoldSize ' range=':= 1.069 * _default_ * rlcrPoorGoldSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.069 * _default_ * rlcrPoorGoldSize ' range=':= 1.069 * _default_ * rlcrPoorGoldSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.143 * _default_ * rlcrPoorGoldFreq ' range=':= 1.143 * _default_ * rlcrPoorGoldFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 15 ' range=':= 1 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 15 ' range=':= 1 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -818,9 +818,9 @@
                             <OreBlock block='Railcraft:ore:8' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 0.500 * rlcrPoorGoldSize ' range=':= 0.500 * rlcrPoorGoldSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 16.000 * rlcrPoorGoldFreq ' range=':= 16.000 * rlcrPoorGoldFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 15 ' range=':= 1 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 0.667 * rlcrPoorGoldSize ' range=':= 0.33 * rlcrPoorGoldSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 21.333 * rlcrPoorGoldFreq ' range=':= 10.67 * rlcrPoorGoldFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 15 ' range=':= 1 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -852,7 +852,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 6.930 * _default_ * rlcrPoorCopperFreq ' range=':= 6.930 * _default_ * rlcrPoorCopperFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * rlcrPoorCopperSize ' range=':= 0 * _default_ * rlcrPoorCopperSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 60 ' range=':= 3 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 60 ' range=':= 3 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -896,7 +896,7 @@
                             <Setting name='CloudRadius' avg=':= 1.798 * _default_ * rlcrPoorCopperSize ' range=':= 1.798 * _default_ * rlcrPoorCopperSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.798 * _default_ * rlcrPoorCopperSize ' range=':= 1.798 * _default_ * rlcrPoorCopperSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 3.232 * _default_ * rlcrPoorCopperFreq ' range=':= 3.232 * _default_ * rlcrPoorCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 60 ' range=':= 3 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 60 ' range=':= 3 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -948,9 +948,9 @@
                             <OreBlock block='Railcraft:ore:9' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.000 * rlcrPoorCopperSize ' range=':= 4.000 * rlcrPoorCopperSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 16.000 * rlcrPoorCopperFreq ' range=':= 16.000 * rlcrPoorCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 60 ' range=':= 3 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 5.333 * rlcrPoorCopperSize ' range=':= 2.67 * rlcrPoorCopperSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 21.333 * rlcrPoorCopperFreq ' range=':= 10.67 * rlcrPoorCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 60 ' range=':= 3 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -982,7 +982,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 3.465 * _default_ * rlcrPoorTinFreq ' range=':= 3.465 * _default_ * rlcrPoorTinFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * rlcrPoorTinSize ' range=':= 0 * _default_ * rlcrPoorTinSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 50 ' range=':= 2 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 50 ' range=':= 2 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1026,7 +1026,7 @@
                             <Setting name='CloudRadius' avg=':= 1.271 * _default_ * rlcrPoorTinSize ' range=':= 1.271 * _default_ * rlcrPoorTinSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.271 * _default_ * rlcrPoorTinSize ' range=':= 1.271 * _default_ * rlcrPoorTinSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.616 * _default_ * rlcrPoorTinFreq ' range=':= 1.616 * _default_ * rlcrPoorTinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 50 ' range=':= 2 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 50 ' range=':= 2 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1077,9 +1077,9 @@
                             <OreBlock block='Railcraft:ore:10' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 1.000 * rlcrPoorTinSize ' range=':= 1.000 * rlcrPoorTinSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 16.000 * rlcrPoorTinFreq ' range=':= 16.000 * rlcrPoorTinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 50 ' range=':= 2 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 1.333 * rlcrPoorTinSize ' range=':= 0.67 * rlcrPoorTinSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 21.333 * rlcrPoorTinFreq ' range=':= 10.67 * rlcrPoorTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 50 ' range=':= 2 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1111,7 +1111,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 6.002 * _default_ * rlcrPoorLeadFreq ' range=':= 6.002 * _default_ * rlcrPoorLeadFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * rlcrPoorLeadSize ' range=':= 0 * _default_ * rlcrPoorLeadSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 30 ' range=':= 3 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 30 ' range=':= 3 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1155,7 +1155,7 @@
                             <Setting name='CloudRadius' avg=':= 1.673 * _default_ * rlcrPoorLeadSize ' range=':= 1.673 * _default_ * rlcrPoorLeadSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.673 * _default_ * rlcrPoorLeadSize ' range=':= 1.673 * _default_ * rlcrPoorLeadSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 2.799 * _default_ * rlcrPoorLeadFreq ' range=':= 2.799 * _default_ * rlcrPoorLeadFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 30 ' range=':= 3 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 30 ' range=':= 3 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1206,9 +1206,9 @@
                             <OreBlock block='Railcraft:ore:11' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3.000 * rlcrPoorLeadSize ' range=':= 3.000 * rlcrPoorLeadSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 16.000 * rlcrPoorLeadFreq ' range=':= 16.000 * rlcrPoorLeadFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 30 ' range=':= 3 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.0 * rlcrPoorLeadSize ' range=':= 2.0 * rlcrPoorLeadSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 21.333 * rlcrPoorLeadFreq ' range=':= 10.67 * rlcrPoorLeadFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 30 ' range=':= 3 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1233,7 +1233,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.707 * _default_ * rlcrSulfurFreq ' range=':= 1.707 * _default_ * rlcrSulfurFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * rlcrSulfurSize ' range=':= 0 * _default_ * rlcrSulfurSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 11 ' range=':= 5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 11 ' range=':= 5 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1287,7 +1287,7 @@
                             <Setting name='CloudRadius' avg=':= 1.130 * _default_ * rlcrSulfurSize ' range=':= 1.130 * _default_ * rlcrSulfurSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.130 * _default_ * rlcrSulfurSize ' range=':= 1.130 * _default_ * rlcrSulfurSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.278 * _default_ * rlcrSulfurFreq ' range=':= 1.278 * _default_ * rlcrSulfurFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 11 ' range=':= 5 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 11 ' range=':= 5 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1338,9 +1338,9 @@
                             <OreBlock block='Railcraft:ore' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 5.000 * rlcrSulfurSize ' range=':= 5.000 * rlcrSulfurSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2.000 * rlcrSulfurFreq ' range=':= 2.000 * rlcrSulfurFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 11 ' range=':= 5 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 6.667 * rlcrSulfurSize ' range=':= 3.33 * rlcrSulfurSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2.667 * rlcrSulfurFreq ' range=':= 1.33 * rlcrSulfurFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 11 ' range=':= 5 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1373,7 +1373,7 @@
                             <BiomeType name='Desert'  minRainfall='0' maxRainfall='0.1' minTemperature='1.5' maxTemperature='2.0' />
                             <Setting name='MotherlodeFrequency' avg=':= 3.465 * _default_ * rlcrSaltpeterFreq ' range=':= 3.465 * _default_ * rlcrSaltpeterFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * rlcrSaltpeterSize ' range=':= 0 * _default_ * rlcrSaltpeterSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64 ' range=':= 5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 64 ' range=':= 5 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1418,7 +1418,7 @@
                             <Setting name='CloudRadius' avg=':= 1.271 * _default_ * rlcrSaltpeterSize ' range=':= 1.271 * _default_ * rlcrSaltpeterSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.271 * _default_ * rlcrSaltpeterSize ' range=':= 1.271 * _default_ * rlcrSaltpeterSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.616 * _default_ * rlcrSaltpeterFreq ' range=':= 1.616 * _default_ * rlcrSaltpeterFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64 ' range=':= 5 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64 ' range=':= 5 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1470,9 +1470,9 @@
                             <ReplacesOre block='sand' weight='1.0' />
                             <Replaces block='minecraft:sandstone' weight='1.0' />
                             <BiomeType name='Desert'  minRainfall='0' maxRainfall='0.1' minTemperature='1.5' maxTemperature='2.0' />
-                            <Setting name='Size' avg=':= 0.500 * rlcrSaltpeterSize ' range=':= 0.500 * rlcrSaltpeterSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 32.000 * rlcrSaltpeterFreq ' range=':= 32.000 * rlcrSaltpeterFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64 ' range=':= 5 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 0.667 * rlcrSaltpeterSize ' range=':= 0.33 * rlcrSaltpeterSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 42.667 * rlcrSaltpeterFreq ' range=':= 21.33 * rlcrSaltpeterFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64 ' range=':= 5 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1531,7 +1531,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.111 * _default_ * rlcrFirestoneFreq ' range=':= 0.111 * _default_ * rlcrFirestoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.693 * _default_ * rlcrFirestoneSize ' range=':= 0.693 * _default_ * rlcrFirestoneSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 16 ' range=':= 15 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 16 ' range=':= 15 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1575,7 +1575,7 @@
                             <Setting name='CloudRadius' avg=':= 0.318 * _default_ * rlcrFirestoneSize ' range=':= 0.318 * _default_ * rlcrFirestoneSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.318 * _default_ * rlcrFirestoneSize ' range=':= 0.318 * _default_ * rlcrFirestoneSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.101 * _default_ * rlcrFirestoneFreq ' range=':= 0.101 * _default_ * rlcrFirestoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 16 ' range=':= 15 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 16 ' range=':= 15 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1626,9 +1626,9 @@
                             <OreBlock block='Railcraft:ore:5' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 0.500 * rlcrFirestoneSize ' range=':= 0.500 * rlcrFirestoneSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 0.125 * rlcrFirestoneFreq ' range=':= 0.125 * rlcrFirestoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 16 ' range=':= 15 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 0.667 * rlcrFirestoneSize ' range=':= 0.33 * rlcrFirestoneSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 0.167 * rlcrFirestoneFreq ' range=':= 0.08 * rlcrFirestoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 16 ' range=':= 15 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>

--- a/src/main/resources/config/modules/ReactorCraft.xml
+++ b/src/main/resources/config/modules/ReactorCraft.xml
@@ -887,7 +887,7 @@
                             <BiomeType name='River'  />
                             <Setting name='MotherlodeFrequency' avg=':= 3.001 * _default_ * recrPitchblendeFreq ' range=':= 3.001 * _default_ * recrPitchblendeFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * recrPitchblendeSize ' range=':= 0 * _default_ * recrPitchblendeSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 16 ' range=':= 8 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 16 ' range=':= 8 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -933,7 +933,7 @@
                             <Setting name='CloudRadius' avg=':= 1.183 * _default_ * recrPitchblendeSize ' range=':= 1.183 * _default_ * recrPitchblendeSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.183 * _default_ * recrPitchblendeSize ' range=':= 1.183 * _default_ * recrPitchblendeSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.400 * _default_ * recrPitchblendeFreq ' range=':= 1.400 * _default_ * recrPitchblendeFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 16 ' range=':= 8 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 16 ' range=':= 8 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -987,9 +987,9 @@
                             <BiomeType name='Mushroom'  />
                             <BiomeType name='Ocean'  />
                             <BiomeType name='River'  />
-                            <Setting name='Size' avg=':= 8.000 * recrPitchblendeSize ' range=':= 8.000 * recrPitchblendeSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.500 * recrPitchblendeFreq ' range=':= 1.500 * recrPitchblendeFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 16 ' range=':= 8 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 10.667 * recrPitchblendeSize ' range=':= 5.33 * recrPitchblendeSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2.0 * recrPitchblendeFreq ' range=':= 1.0 * recrPitchblendeFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 16 ' range=':= 8 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1014,7 +1014,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.919 * _default_ * recrCadmiumFreq ' range=':= 0.919 * _default_ * recrCadmiumFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.986 * _default_ * recrCadmiumSize ' range=':= 0.986 * _default_ * recrCadmiumSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 22 ' range=':= 10 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 22 ' range=':= 10 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1058,7 +1058,7 @@
                             <Setting name='CloudRadius' avg=':= 1.025 * _default_ * recrCadmiumSize ' range=':= 1.025 * _default_ * recrCadmiumSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.025 * _default_ * recrCadmiumSize ' range=':= 1.025 * _default_ * recrCadmiumSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.050 * _default_ * recrCadmiumFreq ' range=':= 1.050 * _default_ * recrCadmiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 22 ' range=':= 10 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 22 ' range=':= 10 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1109,9 +1109,9 @@
                             <OreBlock block='ReactorCraft:reactorcraft_block_ore:2' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.500 * recrCadmiumSize ' range=':= 4.500 * recrCadmiumSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.500 * recrCadmiumFreq ' range=':= 1.500 * recrCadmiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 22 ' range=':= 10 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 6.0 * recrCadmiumSize ' range=':= 3.0 * recrCadmiumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2.0 * recrCadmiumFreq ' range=':= 1.0 * recrCadmiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 22 ' range=':= 10 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1136,7 +1136,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.662 * _default_ * recrIndiumFreq ' range=':= 0.662 * _default_ * recrIndiumFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.934 * _default_ * recrIndiumSize ' range=':= 0.934 * _default_ * recrIndiumSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 11 ' range=':= 5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 11 ' range=':= 5 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1180,7 +1180,7 @@
                             <Setting name='CloudRadius' avg=':= 0.869 * _default_ * recrIndiumSize ' range=':= 0.869 * _default_ * recrIndiumSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.869 * _default_ * recrIndiumSize ' range=':= 0.869 * _default_ * recrIndiumSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.756 * _default_ * recrIndiumFreq ' range=':= 0.756 * _default_ * recrIndiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 11 ' range=':= 5 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 11 ' range=':= 5 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1231,9 +1231,9 @@
                             <OreBlock block='ReactorCraft:reactorcraft_block_ore:3' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3.500 * recrIndiumSize ' range=':= 3.500 * recrIndiumSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.000 * recrIndiumFreq ' range=':= 1.000 * recrIndiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 11 ' range=':= 5 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.667 * recrIndiumSize ' range=':= 2.33 * recrIndiumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.333 * recrIndiumFreq ' range=':= 0.67 * recrIndiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 11 ' range=':= 5 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1258,7 +1258,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.751 * _default_ * recrSilverFreq ' range=':= 0.751 * _default_ * recrSilverFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.953 * _default_ * recrSilverSize ' range=':= 0.953 * _default_ * recrSilverSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 28 ' range=':= 12 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 28 ' range=':= 12 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1302,7 +1302,7 @@
                             <Setting name='CloudRadius' avg=':= 0.926 * _default_ * recrSilverSize ' range=':= 0.926 * _default_ * recrSilverSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.926 * _default_ * recrSilverSize ' range=':= 0.926 * _default_ * recrSilverSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.857 * _default_ * recrSilverFreq ' range=':= 0.857 * _default_ * recrSilverFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 28 ' range=':= 12 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 28 ' range=':= 12 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1353,9 +1353,9 @@
                             <OreBlock block='ReactorCraft:reactorcraft_block_ore:4' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.500 * recrSilverSize ' range=':= 4.500 * recrSilverSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.000 * recrSilverFreq ' range=':= 1.000 * recrSilverFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 28 ' range=':= 12 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 6.0 * recrSilverSize ' range=':= 3.0 * recrSilverSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.333 * recrSilverFreq ' range=':= 0.67 * recrSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 28 ' range=':= 12 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1387,7 +1387,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 3.001 * _default_ * recrCalciteFreq ' range=':= 3.001 * _default_ * recrCalciteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * recrCalciteSize ' range=':= 0 * _default_ * recrCalciteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1431,7 +1431,7 @@
                             <Setting name='CloudRadius' avg=':= 1.183 * _default_ * recrCalciteSize ' range=':= 1.183 * _default_ * recrCalciteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.183 * _default_ * recrCalciteSize ' range=':= 1.183 * _default_ * recrCalciteSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.400 * _default_ * recrCalciteFreq ' range=':= 1.400 * _default_ * recrCalciteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1482,9 +1482,9 @@
                             <OreBlock block='ReactorCraft:reactorcraft_block_ore:7' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 2.000 * recrCalciteSize ' range=':= 2.000 * recrCalciteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 6.000 * recrCalciteFreq ' range=':= 6.000 * recrCalciteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.667 * recrCalciteSize ' range=':= 1.33 * recrCalciteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 8.0 * recrCalciteFreq ' range=':= 4.0 * recrCalciteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1516,7 +1516,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 4.584 * _default_ * recrMagnetiteFreq ' range=':= 4.584 * _default_ * recrMagnetiteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * recrMagnetiteSize ' range=':= 0 * _default_ * recrMagnetiteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 94 ' range=':= 34 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 94 ' range=':= 34 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1560,7 +1560,7 @@
                             <Setting name='CloudRadius' avg=':= 1.462 * _default_ * recrMagnetiteSize ' range=':= 1.462 * _default_ * recrMagnetiteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.462 * _default_ * recrMagnetiteSize ' range=':= 1.462 * _default_ * recrMagnetiteSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 2.138 * _default_ * recrMagnetiteFreq ' range=':= 2.138 * _default_ * recrMagnetiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 94 ' range=':= 34 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 94 ' range=':= 34 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1611,9 +1611,9 @@
                             <OreBlock block='ReactorCraft:reactorcraft_block_ore:8' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 8.000 * recrMagnetiteSize ' range=':= 8.000 * recrMagnetiteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 3.500 * recrMagnetiteFreq ' range=':= 3.500 * recrMagnetiteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 94 ' range=':= 34 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 10.667 * recrMagnetiteSize ' range=':= 5.33 * recrMagnetiteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4.667 * recrMagnetiteFreq ' range=':= 2.33 * recrMagnetiteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 94 ' range=':= 34 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1638,7 +1638,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.613 * _default_ * recrBlueFluoriteFreq ' range=':= 0.613 * _default_ * recrBlueFluoriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * recrBlueFluoriteSize ' range=':= 0.922 * _default_ * recrBlueFluoriteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1684,7 +1684,7 @@
                             <Setting name='CloudRadius' avg=':= 0.837 * _default_ * recrBlueFluoriteSize ' range=':= 0.837 * _default_ * recrBlueFluoriteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.837 * _default_ * recrBlueFluoriteSize ' range=':= 0.837 * _default_ * recrBlueFluoriteSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.700 * _default_ * recrBlueFluoriteFreq ' range=':= 0.700 * _default_ * recrBlueFluoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1736,9 +1736,9 @@
                             <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.000 * recrBlueFluoriteSize ' range=':= 4.000 * recrBlueFluoriteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 0.750 * recrBlueFluoriteFreq ' range=':= 0.750 * recrBlueFluoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 5.333 * recrBlueFluoriteSize ' range=':= 2.67 * recrBlueFluoriteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.0 * recrBlueFluoriteFreq ' range=':= 0.5 * recrBlueFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1763,7 +1763,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.613 * _default_ * recrPinkFluoriteFreq ' range=':= 0.613 * _default_ * recrPinkFluoriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * recrPinkFluoriteSize ' range=':= 0.922 * _default_ * recrPinkFluoriteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1809,7 +1809,7 @@
                             <Setting name='CloudRadius' avg=':= 0.837 * _default_ * recrPinkFluoriteSize ' range=':= 0.837 * _default_ * recrPinkFluoriteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.837 * _default_ * recrPinkFluoriteSize ' range=':= 0.837 * _default_ * recrPinkFluoriteSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.700 * _default_ * recrPinkFluoriteFreq ' range=':= 0.700 * _default_ * recrPinkFluoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1861,9 +1861,9 @@
                             <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:1' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.000 * recrPinkFluoriteSize ' range=':= 4.000 * recrPinkFluoriteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 0.750 * recrPinkFluoriteFreq ' range=':= 0.750 * recrPinkFluoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 5.333 * recrPinkFluoriteSize ' range=':= 2.67 * recrPinkFluoriteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.0 * recrPinkFluoriteFreq ' range=':= 0.5 * recrPinkFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1888,7 +1888,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.613 * _default_ * recrOrangeFluoriteFreq ' range=':= 0.613 * _default_ * recrOrangeFluoriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * recrOrangeFluoriteSize ' range=':= 0.922 * _default_ * recrOrangeFluoriteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1934,7 +1934,7 @@
                             <Setting name='CloudRadius' avg=':= 0.837 * _default_ * recrOrangeFluoriteSize ' range=':= 0.837 * _default_ * recrOrangeFluoriteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.837 * _default_ * recrOrangeFluoriteSize ' range=':= 0.837 * _default_ * recrOrangeFluoriteSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.700 * _default_ * recrOrangeFluoriteFreq ' range=':= 0.700 * _default_ * recrOrangeFluoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1986,9 +1986,9 @@
                             <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:2' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.000 * recrOrangeFluoriteSize ' range=':= 4.000 * recrOrangeFluoriteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 0.750 * recrOrangeFluoriteFreq ' range=':= 0.750 * recrOrangeFluoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 5.333 * recrOrangeFluoriteSize ' range=':= 2.67 * recrOrangeFluoriteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.0 * recrOrangeFluoriteFreq ' range=':= 0.5 * recrOrangeFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -2014,7 +2014,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.613 * _default_ * recrMagentaFluoriteFreq ' range=':= 0.613 * _default_ * recrMagentaFluoriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * recrMagentaFluoriteSize ' range=':= 0.922 * _default_ * recrMagentaFluoriteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2060,7 +2060,7 @@
                             <Setting name='CloudRadius' avg=':= 0.837 * _default_ * recrMagentaFluoriteSize ' range=':= 0.837 * _default_ * recrMagentaFluoriteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.837 * _default_ * recrMagentaFluoriteSize ' range=':= 0.837 * _default_ * recrMagentaFluoriteSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.700 * _default_ * recrMagentaFluoriteFreq ' range=':= 0.700 * _default_ * recrMagentaFluoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2112,9 +2112,9 @@
                             <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:3' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.000 * recrMagentaFluoriteSize ' range=':= 4.000 * recrMagentaFluoriteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 0.750 * recrMagentaFluoriteFreq ' range=':= 0.750 * recrMagentaFluoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 5.333 * recrMagentaFluoriteSize ' range=':= 2.67 * recrMagentaFluoriteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.0 * recrMagentaFluoriteFreq ' range=':= 0.5 * recrMagentaFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -2139,7 +2139,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.613 * _default_ * recrGreenFluoriteFreq ' range=':= 0.613 * _default_ * recrGreenFluoriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * recrGreenFluoriteSize ' range=':= 0.922 * _default_ * recrGreenFluoriteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2185,7 +2185,7 @@
                             <Setting name='CloudRadius' avg=':= 0.837 * _default_ * recrGreenFluoriteSize ' range=':= 0.837 * _default_ * recrGreenFluoriteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.837 * _default_ * recrGreenFluoriteSize ' range=':= 0.837 * _default_ * recrGreenFluoriteSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.700 * _default_ * recrGreenFluoriteFreq ' range=':= 0.700 * _default_ * recrGreenFluoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2237,9 +2237,9 @@
                             <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:4' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.000 * recrGreenFluoriteSize ' range=':= 4.000 * recrGreenFluoriteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 0.750 * recrGreenFluoriteFreq ' range=':= 0.750 * recrGreenFluoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 5.333 * recrGreenFluoriteSize ' range=':= 2.67 * recrGreenFluoriteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.0 * recrGreenFluoriteFreq ' range=':= 0.5 * recrGreenFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -2264,7 +2264,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.613 * _default_ * recrRedFluoriteFreq ' range=':= 0.613 * _default_ * recrRedFluoriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * recrRedFluoriteSize ' range=':= 0.922 * _default_ * recrRedFluoriteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2308,7 +2308,7 @@
                             <Setting name='CloudRadius' avg=':= 0.837 * _default_ * recrRedFluoriteSize ' range=':= 0.837 * _default_ * recrRedFluoriteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.837 * _default_ * recrRedFluoriteSize ' range=':= 0.837 * _default_ * recrRedFluoriteSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.700 * _default_ * recrRedFluoriteFreq ' range=':= 0.700 * _default_ * recrRedFluoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2360,9 +2360,9 @@
                             <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:5' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.000 * recrRedFluoriteSize ' range=':= 4.000 * recrRedFluoriteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 0.750 * recrRedFluoriteFreq ' range=':= 0.750 * recrRedFluoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 5.333 * recrRedFluoriteSize ' range=':= 2.67 * recrRedFluoriteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.0 * recrRedFluoriteFreq ' range=':= 0.5 * recrRedFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -2387,7 +2387,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.613 * _default_ * recrWhiteFluoriteFreq ' range=':= 0.613 * _default_ * recrWhiteFluoriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * recrWhiteFluoriteSize ' range=':= 0.922 * _default_ * recrWhiteFluoriteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2433,7 +2433,7 @@
                             <Setting name='CloudRadius' avg=':= 0.837 * _default_ * recrWhiteFluoriteSize ' range=':= 0.837 * _default_ * recrWhiteFluoriteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.837 * _default_ * recrWhiteFluoriteSize ' range=':= 0.837 * _default_ * recrWhiteFluoriteSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.700 * _default_ * recrWhiteFluoriteFreq ' range=':= 0.700 * _default_ * recrWhiteFluoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2485,9 +2485,9 @@
                             <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:6' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.000 * recrWhiteFluoriteSize ' range=':= 4.000 * recrWhiteFluoriteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 0.750 * recrWhiteFluoriteFreq ' range=':= 0.750 * recrWhiteFluoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 5.333 * recrWhiteFluoriteSize ' range=':= 2.67 * recrWhiteFluoriteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.0 * recrWhiteFluoriteFreq ' range=':= 0.5 * recrWhiteFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -2512,7 +2512,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.613 * _default_ * recrYellowFluoriteFreq ' range=':= 0.613 * _default_ * recrYellowFluoriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * recrYellowFluoriteSize ' range=':= 0.922 * _default_ * recrYellowFluoriteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2558,7 +2558,7 @@
                             <Setting name='CloudRadius' avg=':= 0.837 * _default_ * recrYellowFluoriteSize ' range=':= 0.837 * _default_ * recrYellowFluoriteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.837 * _default_ * recrYellowFluoriteSize ' range=':= 0.837 * _default_ * recrYellowFluoriteSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.700 * _default_ * recrYellowFluoriteFreq ' range=':= 0.700 * _default_ * recrYellowFluoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2610,9 +2610,9 @@
                             <OreBlock block='ReactorCraft:reactorcraft_block_fluoriteore:7' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.000 * recrYellowFluoriteSize ' range=':= 4.000 * recrYellowFluoriteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 0.750 * recrYellowFluoriteFreq ' range=':= 0.750 * recrYellowFluoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 5.333 * recrYellowFluoriteSize ' range=':= 2.67 * recrYellowFluoriteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.0 * recrYellowFluoriteFreq ' range=':= 0.5 * recrYellowFluoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 46 ' range=':= 14 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -2678,7 +2678,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 3.001 * _default_ * recrAmmoniumChlorideFreq ' range=':= 3.001 * _default_ * recrAmmoniumChlorideFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * recrAmmoniumChlorideSize ' range=':= 0 * _default_ * recrAmmoniumChlorideSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 32 ' range=':= 0 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 32 ' range=':= 0 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2724,7 +2724,7 @@
                             <Setting name='CloudRadius' avg=':= 1.183 * _default_ * recrAmmoniumChlorideSize ' range=':= 1.183 * _default_ * recrAmmoniumChlorideSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.183 * _default_ * recrAmmoniumChlorideSize ' range=':= 1.183 * _default_ * recrAmmoniumChlorideSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.400 * _default_ * recrAmmoniumChlorideFreq ' range=':= 1.400 * _default_ * recrAmmoniumChlorideFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 32 ' range=':= 0 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 32 ' range=':= 0 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2776,9 +2776,9 @@
                             <OreBlock block='ReactorCraft:reactorcraft_block_ore:6' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.000 * recrAmmoniumChlorideSize ' range=':= 4.000 * recrAmmoniumChlorideSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 3.000 * recrAmmoniumChlorideFreq ' range=':= 3.000 * recrAmmoniumChlorideFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 32 ' range=':= 0 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 5.333 * recrAmmoniumChlorideSize ' range=':= 2.67 * recrAmmoniumChlorideSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4.0 * recrAmmoniumChlorideFreq ' range=':= 2.0 * recrAmmoniumChlorideFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 32 ' range=':= 0 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -2810,7 +2810,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.122 * _default_ * recrThoriteFreq ' range=':= 2.122 * _default_ * recrThoriteFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * recrThoriteSize ' range=':= 0 * _default_ * recrThoriteSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 18.5 ' range=':= 13.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 18.5 ' range=':= 13.5 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2854,7 +2854,7 @@
                             <Setting name='CloudRadius' avg=':= 0.995 * _default_ * recrThoriteSize ' range=':= 0.995 * _default_ * recrThoriteSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.995 * _default_ * recrThoriteSize ' range=':= 0.995 * _default_ * recrThoriteSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.990 * _default_ * recrThoriteFreq ' range=':= 0.990 * _default_ * recrThoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 18.5 ' range=':= 13.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 18.5 ' range=':= 13.5 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -2905,9 +2905,9 @@
                             <OreBlock block='ReactorCraft:reactorcraft_block_ore:9' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 12.000 * recrThoriteSize ' range=':= 12.000 * recrThoriteSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 0.500 * recrThoriteFreq ' range=':= 0.500 * recrThoriteFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 18.5 ' range=':= 13.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 16.0 * recrThoriteSize ' range=':= 8.0 * recrThoriteSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 0.667 * recrThoriteFreq ' range=':= 0.33 * recrThoriteFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 18.5 ' range=':= 13.5 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -2971,7 +2971,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 4.244 * _default_ * recrEndPitchblendeFreq ' range=':= 4.244 * _default_ * recrEndPitchblendeFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * recrEndPitchblendeSize ' range=':= 0 * _default_ * recrEndPitchblendeSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 34.5 ' range=':= 29.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 34.5 ' range=':= 29.5 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3017,7 +3017,7 @@
                             <Setting name='CloudRadius' avg=':= 1.407 * _default_ * recrEndPitchblendeSize ' range=':= 1.407 * _default_ * recrEndPitchblendeSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.407 * _default_ * recrEndPitchblendeSize ' range=':= 1.407 * _default_ * recrEndPitchblendeSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.979 * _default_ * recrEndPitchblendeFreq ' range=':= 1.979 * _default_ * recrEndPitchblendeFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 34.5 ' range=':= 29.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 34.5 ' range=':= 29.5 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -3069,9 +3069,9 @@
                             <OreBlock block='ReactorCraft:reactorcraft_block_ore:5' weight='1.0' />
                             <Replaces block='minecraft:end_stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 8.000 * recrEndPitchblendeSize ' range=':= 8.000 * recrEndPitchblendeSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 3.000 * recrEndPitchblendeFreq ' range=':= 3.000 * recrEndPitchblendeFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 34.5 ' range=':= 29.5 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 10.667 * recrEndPitchblendeSize ' range=':= 5.33 * recrEndPitchblendeSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4.0 * recrEndPitchblendeFreq ' range=':= 2.0 * recrEndPitchblendeFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 34.5 ' range=':= 29.5 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>

--- a/src/main/resources/config/modules/SimpleOres.xml
+++ b/src/main/resources/config/modules/SimpleOres.xml
@@ -312,7 +312,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.770 * _default_ * smpoCopperFreq ' range=':= 2.770 * _default_ * smpoCopperFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.185 * _default_ * smpoCopperSize ' range=':= 1.185 * _default_ * smpoCopperSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 48 ' range=':= 42 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 48 ' range=':= 42 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -356,7 +356,7 @@
                             <Setting name='CloudRadius' avg=':= 1.778 * _default_ * smpoCopperSize ' range=':= 1.778 * _default_ * smpoCopperSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.778 * _default_ * smpoCopperSize ' range=':= 1.778 * _default_ * smpoCopperSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 3.162 * _default_ * smpoCopperFreq ' range=':= 3.162 * _default_ * smpoCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 48 ' range=':= 42 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 48 ' range=':= 42 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -407,9 +407,9 @@
                             <OreBlock block='simpleores:copper_ore' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3.500 * smpoCopperSize ' range=':= 3.500 * smpoCopperSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 17.500 * smpoCopperFreq ' range=':= 17.500 * smpoCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 48 ' range=':= 42 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.667 * smpoCopperSize ' range=':= 2.33 * smpoCopperSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 23.333 * smpoCopperFreq ' range=':= 11.67 * smpoCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 48 ' range=':= 42 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -434,7 +434,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.564 * _default_ * smpoTinFreq ' range=':= 2.564 * _default_ * smpoTinFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.170 * _default_ * smpoTinSize ' range=':= 1.170 * _default_ * smpoTinSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 48 ' range=':= 42 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 48 ' range=':= 42 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -478,7 +478,7 @@
                             <Setting name='CloudRadius' avg=':= 1.711 * _default_ * smpoTinSize ' range=':= 1.711 * _default_ * smpoTinSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.711 * _default_ * smpoTinSize ' range=':= 1.711 * _default_ * smpoTinSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 2.928 * _default_ * smpoTinFreq ' range=':= 2.928 * _default_ * smpoTinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 48 ' range=':= 42 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 48 ' range=':= 42 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -529,9 +529,9 @@
                             <OreBlock block='simpleores:tin_ore' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3.500 * smpoTinSize ' range=':= 3.500 * smpoTinSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 15.000 * smpoTinFreq ' range=':= 15.000 * smpoTinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 48 ' range=':= 42 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.667 * smpoTinSize ' range=':= 2.33 * smpoTinSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 20.0 * smpoTinFreq ' range=':= 10.0 * smpoTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 48 ' range=':= 42 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -556,7 +556,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.001 * _default_ * smpoMythrilFreq ' range=':= 1.001 * _default_ * smpoMythrilFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.000 * _default_ * smpoMythrilSize ' range=':= 1.000 * _default_ * smpoMythrilSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 20 ' range=':= 15 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 20 ' range=':= 15 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -600,7 +600,7 @@
                             <Setting name='CloudRadius' avg=':= 1.069 * _default_ * smpoMythrilSize ' range=':= 1.069 * _default_ * smpoMythrilSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.069 * _default_ * smpoMythrilSize ' range=':= 1.069 * _default_ * smpoMythrilSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.143 * _default_ * smpoMythrilFreq ' range=':= 1.143 * _default_ * smpoMythrilFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 20 ' range=':= 15 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 20 ' range=':= 15 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -651,9 +651,9 @@
                             <OreBlock block='simpleores:mythril_ore' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 2.000 * smpoMythrilSize ' range=':= 2.000 * smpoMythrilSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 4.000 * smpoMythrilFreq ' range=':= 4.000 * smpoMythrilFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 20 ' range=':= 15 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.667 * smpoMythrilSize ' range=':= 1.33 * smpoMythrilSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 5.333 * smpoMythrilFreq ' range=':= 2.67 * smpoMythrilFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 20 ' range=':= 15 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -678,7 +678,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.708 * _default_ * smpoAdamantiumFreq ' range=':= 0.708 * _default_ * smpoAdamantiumFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.944 * _default_ * smpoAdamantiumSize ' range=':= 0.944 * _default_ * smpoAdamantiumSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 13 ' range=':= 7 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 13 ' range=':= 7 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -722,7 +722,7 @@
                             <Setting name='CloudRadius' avg=':= 0.899 * _default_ * smpoAdamantiumSize ' range=':= 0.899 * _default_ * smpoAdamantiumSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.899 * _default_ * smpoAdamantiumSize ' range=':= 0.899 * _default_ * smpoAdamantiumSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.808 * _default_ * smpoAdamantiumFreq ' range=':= 0.808 * _default_ * smpoAdamantiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 13 ' range=':= 7 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 13 ' range=':= 7 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -774,9 +774,9 @@
                             <OreBlock block='simpleores:adamantium_ore' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 2.000 * smpoAdamantiumSize ' range=':= 2.000 * smpoAdamantiumSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2.000 * smpoAdamantiumFreq ' range=':= 2.000 * smpoAdamantiumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 13 ' range=':= 7 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.667 * smpoAdamantiumSize ' range=':= 1.33 * smpoAdamantiumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2.667 * smpoAdamantiumFreq ' range=':= 1.33 * smpoAdamantiumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 13 ' range=':= 7 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -833,7 +833,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.597 * _default_ * smpoOnyxFreq ' range=':= 1.597 * _default_ * smpoOnyxFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * smpoOnyxSize ' range=':= 0 * _default_ * smpoOnyxSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 72 ' range=':= 56 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 72 ' range=':= 56 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -887,7 +887,7 @@
                             <Setting name='CloudRadius' avg=':= 1.093 * _default_ * smpoOnyxSize ' range=':= 1.093 * _default_ * smpoOnyxSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.093 * _default_ * smpoOnyxSize ' range=':= 1.093 * _default_ * smpoOnyxSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.195 * _default_ * smpoOnyxFreq ' range=':= 1.195 * _default_ * smpoOnyxFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 72 ' range=':= 56 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 72 ' range=':= 56 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -938,9 +938,9 @@
                             <OreBlock block='simpleores:onyx_ore' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3.500 * smpoOnyxSize ' range=':= 3.500 * smpoOnyxSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 2.500 * smpoOnyxFreq ' range=':= 2.500 * smpoOnyxFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 72 ' range=':= 56 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.667 * smpoOnyxSize ' range=':= 2.33 * smpoOnyxSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 3.333 * smpoOnyxFreq ' range=':= 1.67 * smpoOnyxFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 72 ' range=':= 56 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>

--- a/src/main/resources/config/modules/Thaumcraft4.xml
+++ b/src/main/resources/config/modules/Thaumcraft4.xml
@@ -465,7 +465,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.937 * _default_ * thm4AmberBearingStoneFreq ' range=':= 1.937 * _default_ * thm4AmberBearingStoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * thm4AmberBearingStoneSize ' range=':= 0 * _default_ * thm4AmberBearingStoneSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 12.5 ' range=':= 12.5 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 12.5 ' range=':= 12.5 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -511,7 +511,7 @@
                             <Setting name='CloudRadius' avg=':= 0.951 * _default_ * thm4AmberBearingStoneSize ' range=':= 0.951 * _default_ * thm4AmberBearingStoneSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.951 * _default_ * thm4AmberBearingStoneSize ' range=':= 0.951 * _default_ * thm4AmberBearingStoneSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.904 * _default_ * thm4AmberBearingStoneFreq ' range=':= 0.904 * _default_ * thm4AmberBearingStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 12.5 ' range=':= 12.5 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 12.5 ' range=':= 12.5 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -563,9 +563,9 @@
                             <OreBlock block='Thaumcraft:blockCustomOre:7' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 0.500 * thm4AmberBearingStoneSize ' range=':= 0.500 * thm4AmberBearingStoneSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 10.000 * thm4AmberBearingStoneFreq ' range=':= 10.000 * thm4AmberBearingStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 12.5 ' range=':= 12.5 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 0.667 * thm4AmberBearingStoneSize ' range=':= 0.33 * thm4AmberBearingStoneSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 13.333 * thm4AmberBearingStoneFreq ' range=':= 6.67 * thm4AmberBearingStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 12.5 ' range=':= 12.5 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -598,7 +598,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.838 * _default_ * thm4CinnabarFreq ' range=':= 1.838 * _default_ * thm4CinnabarFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * thm4CinnabarSize ' range=':= 0 * _default_ * thm4CinnabarSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 6.4 ' range=':= 6.4 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 6.4 ' range=':= 6.4 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -642,7 +642,7 @@
                             <Setting name='CloudRadius' avg=':= 0.926 * _default_ * thm4CinnabarSize ' range=':= 0.926 * _default_ * thm4CinnabarSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.926 * _default_ * thm4CinnabarSize ' range=':= 0.926 * _default_ * thm4CinnabarSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.857 * _default_ * thm4CinnabarFreq ' range=':= 0.857 * _default_ * thm4CinnabarFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 6.4 ' range=':= 6.4 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 6.4 ' range=':= 6.4 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -693,9 +693,9 @@
                             <OreBlock block='Thaumcraft:blockCustomOre' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 0.500 * thm4CinnabarSize ' range=':= 0.500 * thm4CinnabarSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 9.000 * thm4CinnabarFreq ' range=':= 9.000 * thm4CinnabarFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 6.4 ' range=':= 6.4 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 0.667 * thm4CinnabarSize ' range=':= 0.33 * thm4CinnabarSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 12.0 * thm4CinnabarFreq ' range=':= 6.0 * thm4CinnabarFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 6.4 ' range=':= 6.4 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -728,7 +728,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 3.001 * _default_ * thm4AirInfusedStoneFreq ' range=':= 3.001 * _default_ * thm4AirInfusedStoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * thm4AirInfusedStoneSize ' range=':= 0 * _default_ * thm4AirInfusedStoneSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 32 ' range=':= 27 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 32 ' range=':= 27 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -755,7 +755,7 @@
                             <BiomeType name='Plains'  />
                             <Setting name='MotherlodeFrequency' avg=':= 3.001 * _default_ * thm4AirInfusedStoneFreq ' range=':= 3.001 * _default_ * thm4AirInfusedStoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * thm4AirInfusedStoneSize ' range=':= 0 * _default_ * thm4AirInfusedStoneSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 32 ' range=':= 27 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 32 ' range=':= 27 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -803,7 +803,7 @@
                             <Setting name='CloudRadius' avg=':= 0.905 * _default_ * thm4AirInfusedStoneSize ' range=':= 0.905 * _default_ * thm4AirInfusedStoneSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.905 * _default_ * thm4AirInfusedStoneSize ' range=':= 0.905 * _default_ * thm4AirInfusedStoneSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.818 * _default_ * thm4AirInfusedStoneFreq ' range=':= 0.818 * _default_ * thm4AirInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 32 ' range=':= 27 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 32 ' range=':= 27 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -851,7 +851,7 @@
                             <Setting name='CloudRadius' avg=':= 0.905 * _default_ * thm4AirInfusedStoneSize ' range=':= 0.905 * _default_ * thm4AirInfusedStoneSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.905 * _default_ * thm4AirInfusedStoneSize ' range=':= 0.905 * _default_ * thm4AirInfusedStoneSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.818 * _default_ * thm4AirInfusedStoneFreq ' range=':= 0.818 * _default_ * thm4AirInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 32 ' range=':= 27 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 32 ' range=':= 27 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -889,9 +889,9 @@
                             <OreBlock block='Thaumcraft:blockCustomOre:1' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3.000 * thm4AirInfusedStoneSize ' range=':= 3.000 * thm4AirInfusedStoneSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 4.000 * thm4AirInfusedStoneFreq ' range=':= 4.000 * thm4AirInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 32 ' range=':= 27 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.0 * thm4AirInfusedStoneSize ' range=':= 2.0 * thm4AirInfusedStoneSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 5.333 * thm4AirInfusedStoneFreq ' range=':= 2.67 * thm4AirInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 32 ' range=':= 27 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -924,7 +924,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 3.001 * _default_ * thm4FireInfusedStoneFreq ' range=':= 3.001 * _default_ * thm4FireInfusedStoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * thm4FireInfusedStoneSize ' range=':= 0 * _default_ * thm4FireInfusedStoneSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 32 ' range=':= 27 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 32 ' range=':= 27 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -951,7 +951,7 @@
                             <BiomeType name='Desert'  />
                             <Setting name='MotherlodeFrequency' avg=':= 3.001 * _default_ * thm4FireInfusedStoneFreq ' range=':= 3.001 * _default_ * thm4FireInfusedStoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * thm4FireInfusedStoneSize ' range=':= 0 * _default_ * thm4FireInfusedStoneSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 32 ' range=':= 27 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 32 ' range=':= 27 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -999,7 +999,7 @@
                             <Setting name='CloudRadius' avg=':= 0.905 * _default_ * thm4FireInfusedStoneSize ' range=':= 0.905 * _default_ * thm4FireInfusedStoneSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.905 * _default_ * thm4FireInfusedStoneSize ' range=':= 0.905 * _default_ * thm4FireInfusedStoneSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.818 * _default_ * thm4FireInfusedStoneFreq ' range=':= 0.818 * _default_ * thm4FireInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 32 ' range=':= 27 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 32 ' range=':= 27 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1047,7 +1047,7 @@
                             <Setting name='CloudRadius' avg=':= 0.905 * _default_ * thm4FireInfusedStoneSize ' range=':= 0.905 * _default_ * thm4FireInfusedStoneSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.905 * _default_ * thm4FireInfusedStoneSize ' range=':= 0.905 * _default_ * thm4FireInfusedStoneSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.818 * _default_ * thm4FireInfusedStoneFreq ' range=':= 0.818 * _default_ * thm4FireInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 32 ' range=':= 27 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 32 ' range=':= 27 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1085,9 +1085,9 @@
                             <OreBlock block='Thaumcraft:blockCustomOre:2' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3.000 * thm4FireInfusedStoneSize ' range=':= 3.000 * thm4FireInfusedStoneSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 4.000 * thm4FireInfusedStoneFreq ' range=':= 4.000 * thm4FireInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 32 ' range=':= 27 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.0 * thm4FireInfusedStoneSize ' range=':= 2.0 * thm4FireInfusedStoneSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 5.333 * thm4FireInfusedStoneFreq ' range=':= 2.67 * thm4FireInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 32 ' range=':= 27 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1121,7 +1121,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 3.001 * _default_ * thm4WaterInfusedStoneFreq ' range=':= 3.001 * _default_ * thm4WaterInfusedStoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * thm4WaterInfusedStoneSize ' range=':= 0 * _default_ * thm4WaterInfusedStoneSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 32 ' range=':= 27 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 32 ' range=':= 27 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1149,7 +1149,7 @@
                             <BiomeType name='Swamp'  />
                             <Setting name='MotherlodeFrequency' avg=':= 3.001 * _default_ * thm4WaterInfusedStoneFreq ' range=':= 3.001 * _default_ * thm4WaterInfusedStoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * thm4WaterInfusedStoneSize ' range=':= 0 * _default_ * thm4WaterInfusedStoneSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 32 ' range=':= 27 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 32 ' range=':= 27 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1197,7 +1197,7 @@
                             <Setting name='CloudRadius' avg=':= 0.905 * _default_ * thm4WaterInfusedStoneSize ' range=':= 0.905 * _default_ * thm4WaterInfusedStoneSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.905 * _default_ * thm4WaterInfusedStoneSize ' range=':= 0.905 * _default_ * thm4WaterInfusedStoneSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.818 * _default_ * thm4WaterInfusedStoneFreq ' range=':= 0.818 * _default_ * thm4WaterInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 32 ' range=':= 27 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 32 ' range=':= 27 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1246,7 +1246,7 @@
                             <Setting name='CloudRadius' avg=':= 0.905 * _default_ * thm4WaterInfusedStoneSize ' range=':= 0.905 * _default_ * thm4WaterInfusedStoneSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.905 * _default_ * thm4WaterInfusedStoneSize ' range=':= 0.905 * _default_ * thm4WaterInfusedStoneSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.818 * _default_ * thm4WaterInfusedStoneFreq ' range=':= 0.818 * _default_ * thm4WaterInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 32 ' range=':= 27 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 32 ' range=':= 27 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1284,9 +1284,9 @@
                             <OreBlock block='Thaumcraft:blockCustomOre:3' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3.000 * thm4WaterInfusedStoneSize ' range=':= 3.000 * thm4WaterInfusedStoneSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 4.000 * thm4WaterInfusedStoneFreq ' range=':= 4.000 * thm4WaterInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 32 ' range=':= 27 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.0 * thm4WaterInfusedStoneSize ' range=':= 2.0 * thm4WaterInfusedStoneSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 5.333 * thm4WaterInfusedStoneFreq ' range=':= 2.67 * thm4WaterInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 32 ' range=':= 27 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1320,7 +1320,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 3.001 * _default_ * thm4EarthInfusedStoneFreq ' range=':= 3.001 * _default_ * thm4EarthInfusedStoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * thm4EarthInfusedStoneSize ' range=':= 0 * _default_ * thm4EarthInfusedStoneSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 32 ' range=':= 27 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 32 ' range=':= 27 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1347,7 +1347,7 @@
                             <BiomeType name='Forest'  />
                             <Setting name='MotherlodeFrequency' avg=':= 3.001 * _default_ * thm4EarthInfusedStoneFreq ' range=':= 3.001 * _default_ * thm4EarthInfusedStoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * thm4EarthInfusedStoneSize ' range=':= 0 * _default_ * thm4EarthInfusedStoneSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 32 ' range=':= 27 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 32 ' range=':= 27 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1395,7 +1395,7 @@
                             <Setting name='CloudRadius' avg=':= 0.905 * _default_ * thm4EarthInfusedStoneSize ' range=':= 0.905 * _default_ * thm4EarthInfusedStoneSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.905 * _default_ * thm4EarthInfusedStoneSize ' range=':= 0.905 * _default_ * thm4EarthInfusedStoneSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.818 * _default_ * thm4EarthInfusedStoneFreq ' range=':= 0.818 * _default_ * thm4EarthInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 32 ' range=':= 27 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 32 ' range=':= 27 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1443,7 +1443,7 @@
                             <Setting name='CloudRadius' avg=':= 0.905 * _default_ * thm4EarthInfusedStoneSize ' range=':= 0.905 * _default_ * thm4EarthInfusedStoneSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.905 * _default_ * thm4EarthInfusedStoneSize ' range=':= 0.905 * _default_ * thm4EarthInfusedStoneSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.818 * _default_ * thm4EarthInfusedStoneFreq ' range=':= 0.818 * _default_ * thm4EarthInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 32 ' range=':= 27 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 32 ' range=':= 27 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1481,9 +1481,9 @@
                             <OreBlock block='Thaumcraft:blockCustomOre:4' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3.000 * thm4EarthInfusedStoneSize ' range=':= 3.000 * thm4EarthInfusedStoneSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 4.000 * thm4EarthInfusedStoneFreq ' range=':= 4.000 * thm4EarthInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 32 ' range=':= 27 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.0 * thm4EarthInfusedStoneSize ' range=':= 2.0 * thm4EarthInfusedStoneSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 5.333 * thm4EarthInfusedStoneFreq ' range=':= 2.67 * thm4EarthInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 32 ' range=':= 27 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1517,7 +1517,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 3.001 * _default_ * thm4OrderInfusedStoneFreq ' range=':= 3.001 * _default_ * thm4OrderInfusedStoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * thm4OrderInfusedStoneSize ' range=':= 0 * _default_ * thm4OrderInfusedStoneSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 32 ' range=':= 27 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 32 ' range=':= 27 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1546,7 +1546,7 @@
                             <BiomeType name='Magical'  />
                             <Setting name='MotherlodeFrequency' avg=':= 3.001 * _default_ * thm4OrderInfusedStoneFreq ' range=':= 3.001 * _default_ * thm4OrderInfusedStoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * thm4OrderInfusedStoneSize ' range=':= 0 * _default_ * thm4OrderInfusedStoneSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 32 ' range=':= 27 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 32 ' range=':= 27 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1594,7 +1594,7 @@
                             <Setting name='CloudRadius' avg=':= 0.905 * _default_ * thm4OrderInfusedStoneSize ' range=':= 0.905 * _default_ * thm4OrderInfusedStoneSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.905 * _default_ * thm4OrderInfusedStoneSize ' range=':= 0.905 * _default_ * thm4OrderInfusedStoneSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.818 * _default_ * thm4OrderInfusedStoneFreq ' range=':= 0.818 * _default_ * thm4OrderInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 32 ' range=':= 27 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 32 ' range=':= 27 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1644,7 +1644,7 @@
                             <Setting name='CloudRadius' avg=':= 0.905 * _default_ * thm4OrderInfusedStoneSize ' range=':= 0.905 * _default_ * thm4OrderInfusedStoneSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.905 * _default_ * thm4OrderInfusedStoneSize ' range=':= 0.905 * _default_ * thm4OrderInfusedStoneSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.818 * _default_ * thm4OrderInfusedStoneFreq ' range=':= 0.818 * _default_ * thm4OrderInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 32 ' range=':= 27 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 32 ' range=':= 27 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1682,9 +1682,9 @@
                             <OreBlock block='Thaumcraft:blockCustomOre:5' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3.000 * thm4OrderInfusedStoneSize ' range=':= 3.000 * thm4OrderInfusedStoneSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 4.000 * thm4OrderInfusedStoneFreq ' range=':= 4.000 * thm4OrderInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 32 ' range=':= 27 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.0 * thm4OrderInfusedStoneSize ' range=':= 2.0 * thm4OrderInfusedStoneSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 5.333 * thm4OrderInfusedStoneFreq ' range=':= 2.67 * thm4OrderInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 32 ' range=':= 27 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1718,7 +1718,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 3.001 * _default_ * thm4EntropyInfusedStoneFreq ' range=':= 3.001 * _default_ * thm4EntropyInfusedStoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * thm4EntropyInfusedStoneSize ' range=':= 0 * _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 32 ' range=':= 27 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 32 ' range=':= 27 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1746,7 +1746,7 @@
                             <BiomeType name='Wasteland'  />
                             <Setting name='MotherlodeFrequency' avg=':= 3.001 * _default_ * thm4EntropyInfusedStoneFreq ' range=':= 3.001 * _default_ * thm4EntropyInfusedStoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0 * _default_ * thm4EntropyInfusedStoneSize ' range=':= 0 * _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 32 ' range=':= 27 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 32 ' range=':= 27 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1794,7 +1794,7 @@
                             <Setting name='CloudRadius' avg=':= 0.905 * _default_ * thm4EntropyInfusedStoneSize ' range=':= 0.905 * _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.905 * _default_ * thm4EntropyInfusedStoneSize ' range=':= 0.905 * _default_ * thm4EntropyInfusedStoneSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.818 * _default_ * thm4EntropyInfusedStoneFreq ' range=':= 0.818 * _default_ * thm4EntropyInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 32 ' range=':= 27 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 32 ' range=':= 27 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1843,7 +1843,7 @@
                             <Setting name='CloudRadius' avg=':= 0.905 * _default_ * thm4EntropyInfusedStoneSize ' range=':= 0.905 * _default_ * thm4EntropyInfusedStoneSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.905 * _default_ * thm4EntropyInfusedStoneSize ' range=':= 0.905 * _default_ * thm4EntropyInfusedStoneSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.818 * _default_ * thm4EntropyInfusedStoneFreq ' range=':= 0.818 * _default_ * thm4EntropyInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 32 ' range=':= 27 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 32 ' range=':= 27 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1882,9 +1882,9 @@
                             <OreBlock block='Thaumcraft:blockCustomOre:6' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3.000 * thm4EntropyInfusedStoneSize ' range=':= 3.000 * thm4EntropyInfusedStoneSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 4.000 * thm4EntropyInfusedStoneFreq ' range=':= 4.000 * thm4EntropyInfusedStoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 32 ' range=':= 27 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.0 * thm4EntropyInfusedStoneSize ' range=':= 2.0 * thm4EntropyInfusedStoneSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 5.333 * thm4EntropyInfusedStoneFreq ' range=':= 2.67 * thm4EntropyInfusedStoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 32 ' range=':= 27 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>

--- a/src/main/resources/config/modules/ThermalFoundation.xml
+++ b/src/main/resources/config/modules/ThermalFoundation.xml
@@ -362,7 +362,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.583 * _default_ * thfoCopperFreq ' range=':= 1.583 * _default_ * thfoCopperFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.080 * _default_ * thfoCopperSize ' range=':= 1.080 * _default_ * thfoCopperSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 68 ' range=':= 28 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 68 ' range=':= 28 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -406,7 +406,7 @@
                             <Setting name='CloudRadius' avg=':= 1.344 * _default_ * thfoCopperSize ' range=':= 1.344 * _default_ * thfoCopperSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.344 * _default_ * thfoCopperSize ' range=':= 1.344 * _default_ * thfoCopperSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.807 * _default_ * thfoCopperFreq ' range=':= 1.807 * _default_ * thfoCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 68 ' range=':= 28 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 68 ' range=':= 28 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -457,9 +457,9 @@
                             <OreBlock block='ThermalFoundation:Ore' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.000 * thfoCopperSize ' range=':= 4.000 * thfoCopperSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 5.000 * thfoCopperFreq ' range=':= 5.000 * thfoCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 68 ' range=':= 28 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 5.333 * thfoCopperSize ' range=':= 2.67 * thfoCopperSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 6.667 * thfoCopperFreq ' range=':= 3.33 * thfoCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 68 ' range=':= 28 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -484,7 +484,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.416 * _default_ * thfoTinFreq ' range=':= 1.416 * _default_ * thfoTinFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.060 * _default_ * thfoTinSize ' range=':= 1.060 * _default_ * thfoTinSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 38 ' range=':= 17 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 38 ' range=':= 17 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -528,7 +528,7 @@
                             <Setting name='CloudRadius' avg=':= 1.271 * _default_ * thfoTinSize ' range=':= 1.271 * _default_ * thfoTinSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.271 * _default_ * thfoTinSize ' range=':= 1.271 * _default_ * thfoTinSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.616 * _default_ * thfoTinFreq ' range=':= 1.616 * _default_ * thfoTinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 38 ' range=':= 17 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 38 ' range=':= 17 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -579,9 +579,9 @@
                             <OreBlock block='ThermalFoundation:Ore:1' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.000 * thfoTinSize ' range=':= 4.000 * thfoTinSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 4.000 * thfoTinFreq ' range=':= 4.000 * thfoTinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 38 ' range=':= 17 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 5.333 * thfoTinSize ' range=':= 2.67 * thfoTinSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 5.333 * thfoTinFreq ' range=':= 2.67 * thfoTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 38 ' range=':= 17 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -606,7 +606,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.226 * _default_ * thfoSilverFreq ' range=':= 1.226 * _default_ * thfoSilverFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.035 * _default_ * thfoSilverSize ' range=':= 1.035 * _default_ * thfoSilverSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 18 ' range=':= 12 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 18 ' range=':= 12 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -650,7 +650,7 @@
                             <Setting name='CloudRadius' avg=':= 1.183 * _default_ * thfoSilverSize ' range=':= 1.183 * _default_ * thfoSilverSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.183 * _default_ * thfoSilverSize ' range=':= 1.183 * _default_ * thfoSilverSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.400 * _default_ * thfoSilverFreq ' range=':= 1.400 * _default_ * thfoSilverFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 18 ' range=':= 12 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 18 ' range=':= 12 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -701,9 +701,9 @@
                             <OreBlock block='ThermalFoundation:Ore:2' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.000 * thfoSilverSize ' range=':= 4.000 * thfoSilverSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 3.000 * thfoSilverFreq ' range=':= 3.000 * thfoSilverFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 18 ' range=':= 12 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 5.333 * thfoSilverSize ' range=':= 2.67 * thfoSilverSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 4.0 * thfoSilverFreq ' range=':= 2.0 * thfoSilverFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 18 ' range=':= 12 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -728,7 +728,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.416 * _default_ * thfoLeadFreq ' range=':= 1.416 * _default_ * thfoLeadFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.060 * _default_ * thfoLeadSize ' range=':= 1.060 * _default_ * thfoLeadSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 23 ' range=':= 12 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 23 ' range=':= 12 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -772,7 +772,7 @@
                             <Setting name='CloudRadius' avg=':= 1.271 * _default_ * thfoLeadSize ' range=':= 1.271 * _default_ * thfoLeadSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.271 * _default_ * thfoLeadSize ' range=':= 1.271 * _default_ * thfoLeadSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.616 * _default_ * thfoLeadFreq ' range=':= 1.616 * _default_ * thfoLeadFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 23 ' range=':= 12 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 23 ' range=':= 12 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -823,9 +823,9 @@
                             <OreBlock block='ThermalFoundation:Ore:3' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.000 * thfoLeadSize ' range=':= 4.000 * thfoLeadSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 4.000 * thfoLeadFreq ' range=':= 4.000 * thfoLeadFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 23 ' range=':= 12 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 5.333 * thfoLeadSize ' range=':= 2.67 * thfoLeadSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 5.333 * thfoLeadFreq ' range=':= 2.67 * thfoLeadFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 23 ' range=':= 12 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -850,7 +850,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.613 * _default_ * thfoFerrousFreq ' range=':= 0.613 * _default_ * thfoFerrousFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.922 * _default_ * thfoFerrousSize ' range=':= 0.922 * _default_ * thfoFerrousSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 13 ' range=':= 7 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 13 ' range=':= 7 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -894,7 +894,7 @@
                             <Setting name='CloudRadius' avg=':= 0.837 * _default_ * thfoFerrousSize ' range=':= 0.837 * _default_ * thfoFerrousSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.837 * _default_ * thfoFerrousSize ' range=':= 0.837 * _default_ * thfoFerrousSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.700 * _default_ * thfoFerrousFreq ' range=':= 0.700 * _default_ * thfoFerrousFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 13 ' range=':= 7 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 13 ' range=':= 7 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -945,9 +945,9 @@
                             <OreBlock block='ThermalFoundation:Ore:4' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 2.000 * thfoFerrousSize ' range=':= 2.000 * thfoFerrousSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.500 * thfoFerrousFreq ' range=':= 1.500 * thfoFerrousFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 13 ' range=':= 7 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.667 * thfoFerrousSize ' range=':= 1.33 * thfoFerrousSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2.0 * thfoFerrousFreq ' range=':= 1.0 * thfoFerrousFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 13 ' range=':= 7 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -972,7 +972,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.306 * _default_ * thfoShinyFreq ' range=':= 0.306 * _default_ * thfoShinyFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.821 * _default_ * thfoShinySize ' range=':= 0.821 * _default_ * thfoShinySize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 18 ' range=':= 12 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 18 ' range=':= 12 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1016,7 +1016,7 @@
                             <Setting name='CloudRadius' avg=':= 0.592 * _default_ * thfoShinySize ' range=':= 0.592 * _default_ * thfoShinySize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.592 * _default_ * thfoShinySize ' range=':= 0.592 * _default_ * thfoShinySize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.350 * _default_ * thfoShinyFreq ' range=':= 0.350 * _default_ * thfoShinyFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 18 ' range=':= 12 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 18 ' range=':= 12 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1067,9 +1067,9 @@
                             <OreBlock block='ThermalFoundation:Ore:5' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 1.500 * thfoShinySize ' range=':= 1.500 * thfoShinySize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 0.500 * thfoShinyFreq ' range=':= 0.500 * thfoShinyFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 18 ' range=':= 12 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.0 * thfoShinySize ' range=':= 1.0 * thfoShinySize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 0.667 * thfoShinyFreq ' range=':= 0.33 * thfoShinyFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 18 ' range=':= 12 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>

--- a/src/main/resources/config/modules/TinkersConstruct.xml
+++ b/src/main/resources/config/modules/TinkersConstruct.xml
@@ -609,7 +609,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.708 * _default_ * ticoCopperFreq ' range=':= 0.708 * _default_ * ticoCopperFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.944 * _default_ * ticoCopperSize ' range=':= 0.944 * _default_ * ticoCopperSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 40 ' range=':= 20 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 40 ' range=':= 20 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -653,7 +653,7 @@
                             <Setting name='CloudRadius' avg=':= 0.899 * _default_ * ticoCopperSize ' range=':= 0.899 * _default_ * ticoCopperSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.899 * _default_ * ticoCopperSize ' range=':= 0.899 * _default_ * ticoCopperSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.808 * _default_ * ticoCopperFreq ' range=':= 0.808 * _default_ * ticoCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 40 ' range=':= 20 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 40 ' range=':= 20 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -704,9 +704,9 @@
                             <OreBlock block='TConstruct:SearedBrick:3' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.000 * ticoCopperSize ' range=':= 4.000 * ticoCopperSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.000 * ticoCopperFreq ' range=':= 1.000 * ticoCopperFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 40 ' range=':= 20 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 5.333 * ticoCopperSize ' range=':= 2.67 * ticoCopperSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.333 * ticoCopperFreq ' range=':= 0.67 * ticoCopperFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 40 ' range=':= 20 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -731,7 +731,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.708 * _default_ * ticoTinFreq ' range=':= 0.708 * _default_ * ticoTinFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.944 * _default_ * ticoTinSize ' range=':= 0.944 * _default_ * ticoTinSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 23 ' range=':= 17 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 23 ' range=':= 17 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -775,7 +775,7 @@
                             <Setting name='CloudRadius' avg=':= 0.899 * _default_ * ticoTinSize ' range=':= 0.899 * _default_ * ticoTinSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.899 * _default_ * ticoTinSize ' range=':= 0.899 * _default_ * ticoTinSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.808 * _default_ * ticoTinFreq ' range=':= 0.808 * _default_ * ticoTinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 23 ' range=':= 17 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 23 ' range=':= 17 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -826,9 +826,9 @@
                             <OreBlock block='TConstruct:SearedBrick:4' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.000 * ticoTinSize ' range=':= 4.000 * ticoTinSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.000 * ticoTinFreq ' range=':= 1.000 * ticoTinFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 23 ' range=':= 17 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 5.333 * ticoTinSize ' range=':= 2.67 * ticoTinSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.333 * ticoTinFreq ' range=':= 0.67 * ticoTinFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 23 ' range=':= 17 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -853,7 +853,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.751 * _default_ * ticoAluminumFreq ' range=':= 0.751 * _default_ * ticoAluminumFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.953 * _default_ * ticoAluminumSize ' range=':= 0.953 * _default_ * ticoAluminumSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 35 ' range=':= 29 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 35 ' range=':= 29 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -897,7 +897,7 @@
                             <Setting name='CloudRadius' avg=':= 0.926 * _default_ * ticoAluminumSize ' range=':= 0.926 * _default_ * ticoAluminumSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.926 * _default_ * ticoAluminumSize ' range=':= 0.926 * _default_ * ticoAluminumSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.857 * _default_ * ticoAluminumFreq ' range=':= 0.857 * _default_ * ticoAluminumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 35 ' range=':= 29 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 35 ' range=':= 29 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -948,9 +948,9 @@
                             <OreBlock block='TConstruct:SearedBrick:5' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3.000 * ticoAluminumSize ' range=':= 3.000 * ticoAluminumSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.500 * ticoAluminumFreq ' range=':= 1.500 * ticoAluminumFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 35 ' range=':= 29 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.0 * ticoAluminumSize ' range=':= 2.0 * ticoAluminumSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2.0 * ticoAluminumFreq ' range=':= 1.0 * ticoAluminumFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 35 ' range=':= 29 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -975,7 +975,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 2.238 * _default_ * ticoIronGravelFreq ' range=':= 2.238 * _default_ * ticoIronGravelFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.144 * _default_ * ticoIronGravelSize ' range=':= 1.144 * _default_ * ticoIronGravelSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 36 ' range=':= 31 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 36 ' range=':= 31 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1019,7 +1019,7 @@
                             <Setting name='CloudRadius' avg=':= 1.599 * _default_ * ticoIronGravelSize ' range=':= 1.599 * _default_ * ticoIronGravelSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.599 * _default_ * ticoIronGravelSize ' range=':= 1.599 * _default_ * ticoIronGravelSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 2.556 * _default_ * ticoIronGravelFreq ' range=':= 2.556 * _default_ * ticoIronGravelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 36 ' range=':= 31 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 36 ' range=':= 31 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1071,9 +1071,9 @@
                             <OreBlock block='TConstruct:GravelOre' weight='1.0' />
                             <Replaces block='minecraft:gravel' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.000 * ticoIronGravelSize ' range=':= 4.000 * ticoIronGravelSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 10.000 * ticoIronGravelFreq ' range=':= 10.000 * ticoIronGravelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 36 ' range=':= 31 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 5.333 * ticoIronGravelSize ' range=':= 2.67 * ticoIronGravelSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 13.333 * ticoIronGravelFreq ' range=':= 6.67 * ticoIronGravelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 36 ' range=':= 31 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1098,7 +1098,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.708 * _default_ * ticoGoldGravelFreq ' range=':= 0.708 * _default_ * ticoGoldGravelFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.944 * _default_ * ticoGoldGravelSize ' range=':= 0.944 * _default_ * ticoGoldGravelSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 19 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 19 ' range=':= 14 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1142,7 +1142,7 @@
                             <Setting name='CloudRadius' avg=':= 0.899 * _default_ * ticoGoldGravelSize ' range=':= 0.899 * _default_ * ticoGoldGravelSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.899 * _default_ * ticoGoldGravelSize ' range=':= 0.899 * _default_ * ticoGoldGravelSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.808 * _default_ * ticoGoldGravelFreq ' range=':= 0.808 * _default_ * ticoGoldGravelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 19 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 19 ' range=':= 14 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1194,9 +1194,9 @@
                             <OreBlock block='TConstruct:GravelOre:1' weight='1.0' />
                             <Replaces block='minecraft:gravel' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.000 * ticoGoldGravelSize ' range=':= 4.000 * ticoGoldGravelSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.000 * ticoGoldGravelFreq ' range=':= 1.000 * ticoGoldGravelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 19 ' range=':= 14 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 5.333 * ticoGoldGravelSize ' range=':= 2.67 * ticoGoldGravelSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.333 * ticoGoldGravelFreq ' range=':= 0.67 * ticoGoldGravelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 19 ' range=':= 14 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1221,7 +1221,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.708 * _default_ * ticoCopperGravelFreq ' range=':= 0.708 * _default_ * ticoCopperGravelFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.944 * _default_ * ticoCopperGravelSize ' range=':= 0.944 * _default_ * ticoCopperGravelSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 68 ' range=':= 28 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 68 ' range=':= 28 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1267,7 +1267,7 @@
                             <Setting name='CloudRadius' avg=':= 0.899 * _default_ * ticoCopperGravelSize ' range=':= 0.899 * _default_ * ticoCopperGravelSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.899 * _default_ * ticoCopperGravelSize ' range=':= 0.899 * _default_ * ticoCopperGravelSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.808 * _default_ * ticoCopperGravelFreq ' range=':= 0.808 * _default_ * ticoCopperGravelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 68 ' range=':= 28 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 68 ' range=':= 28 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1319,9 +1319,9 @@
                             <OreBlock block='TConstruct:GravelOre:2' weight='1.0' />
                             <Replaces block='minecraft:gravel' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.000 * ticoCopperGravelSize ' range=':= 4.000 * ticoCopperGravelSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.000 * ticoCopperGravelFreq ' range=':= 1.000 * ticoCopperGravelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 68 ' range=':= 28 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 5.333 * ticoCopperGravelSize ' range=':= 2.67 * ticoCopperGravelSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.333 * ticoCopperGravelFreq ' range=':= 0.67 * ticoCopperGravelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 68 ' range=':= 28 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1346,7 +1346,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.416 * _default_ * ticoTinGravelFreq ' range=':= 1.416 * _default_ * ticoTinGravelFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.060 * _default_ * ticoTinGravelSize ' range=':= 1.060 * _default_ * ticoTinGravelSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 38 ' range=':= 17 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 38 ' range=':= 17 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1390,7 +1390,7 @@
                             <Setting name='CloudRadius' avg=':= 1.271 * _default_ * ticoTinGravelSize ' range=':= 1.271 * _default_ * ticoTinGravelSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 1.271 * _default_ * ticoTinGravelSize ' range=':= 1.271 * _default_ * ticoTinGravelSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 1.616 * _default_ * ticoTinGravelFreq ' range=':= 1.616 * _default_ * ticoTinGravelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 38 ' range=':= 17 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 38 ' range=':= 17 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1442,9 +1442,9 @@
                             <OreBlock block='TConstruct:GravelOre:3' weight='1.0' />
                             <Replaces block='minecraft:gravel' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 4.000 * ticoTinGravelSize ' range=':= 4.000 * ticoTinGravelSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 4.000 * ticoTinGravelFreq ' range=':= 4.000 * ticoTinGravelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 38 ' range=':= 17 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 5.333 * ticoTinGravelSize ' range=':= 2.67 * ticoTinGravelSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 5.333 * ticoTinGravelFreq ' range=':= 2.67 * ticoTinGravelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 38 ' range=':= 17 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1469,7 +1469,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 0.751 * _default_ * ticoAluminumGravelFreq ' range=':= 0.751 * _default_ * ticoAluminumGravelFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 0.953 * _default_ * ticoAluminumGravelSize ' range=':= 0.953 * _default_ * ticoAluminumGravelSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 35 ' range=':= 29 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 35 ' range=':= 29 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1515,7 +1515,7 @@
                             <Setting name='CloudRadius' avg=':= 0.926 * _default_ * ticoAluminumGravelSize ' range=':= 0.926 * _default_ * ticoAluminumGravelSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.926 * _default_ * ticoAluminumGravelSize ' range=':= 0.926 * _default_ * ticoAluminumGravelSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.857 * _default_ * ticoAluminumGravelFreq ' range=':= 0.857 * _default_ * ticoAluminumGravelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 35 ' range=':= 29 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 35 ' range=':= 29 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1567,9 +1567,9 @@
                             <OreBlock block='TConstruct:GravelOre:4' weight='1.0' />
                             <Replaces block='minecraft:gravel' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 3.000 * ticoAluminumGravelSize ' range=':= 3.000 * ticoAluminumGravelSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.500 * ticoAluminumGravelFreq ' range=':= 1.500 * ticoAluminumGravelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 35 ' range=':= 29 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 4.0 * ticoAluminumGravelSize ' range=':= 2.0 * ticoAluminumGravelSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 2.0 * ticoAluminumGravelFreq ' range=':= 1.0 * ticoAluminumGravelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 35 ' range=':= 29 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1644,7 +1644,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.084 * _default_ * ticoCobaltFreq ' range=':= 1.084 * _default_ * ticoCobaltFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.014 * _default_ * ticoCobaltSize ' range=':= 1.014 * _default_ * ticoCobaltSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64 ' range=':= 64 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 64 ' range=':= 64 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1688,7 +1688,7 @@
                             <Setting name='CloudRadius' avg=':= 0.995 * _default_ * ticoCobaltSize ' range=':= 0.995 * _default_ * ticoCobaltSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.995 * _default_ * ticoCobaltSize ' range=':= 0.995 * _default_ * ticoCobaltSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.990 * _default_ * ticoCobaltFreq ' range=':= 0.990 * _default_ * ticoCobaltFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64 ' range=':= 64 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64 ' range=':= 64 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1739,9 +1739,9 @@
                             <OreBlock block='TConstruct:SearedBrick:1' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 1.500 * ticoCobaltSize ' range=':= 1.500 * ticoCobaltSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 4.000 * ticoCobaltFreq ' range=':= 4.000 * ticoCobaltFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64 ' range=':= 64 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.0 * ticoCobaltSize ' range=':= 1.0 * ticoCobaltSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 5.333 * ticoCobaltFreq ' range=':= 2.67 * ticoCobaltFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64 ' range=':= 64 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1768,7 +1768,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.084 * _default_ * ticoArditeFreq ' range=':= 1.084 * _default_ * ticoArditeFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.014 * _default_ * ticoArditeSize ' range=':= 1.014 * _default_ * ticoArditeSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64 ' range=':= 64 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 64 ' range=':= 64 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1812,7 +1812,7 @@
                             <Setting name='CloudRadius' avg=':= 0.995 * _default_ * ticoArditeSize ' range=':= 0.995 * _default_ * ticoArditeSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.995 * _default_ * ticoArditeSize ' range=':= 0.995 * _default_ * ticoArditeSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.990 * _default_ * ticoArditeFreq ' range=':= 0.990 * _default_ * ticoArditeFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64 ' range=':= 64 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64 ' range=':= 64 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1863,9 +1863,9 @@
                             <OreBlock block='TConstruct:SearedBrick:2' weight='1.0' />
                             <Replaces block='minecraft:netherrack' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 1.500 * ticoArditeSize ' range=':= 1.500 * ticoArditeSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 4.000 * ticoArditeFreq ' range=':= 4.000 * ticoArditeFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64 ' range=':= 64 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.0 * ticoArditeSize ' range=':= 1.0 * ticoArditeSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 5.333 * ticoArditeFreq ' range=':= 2.67 * ticoArditeFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64 ' range=':= 64 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>
@@ -1892,7 +1892,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.084 * _default_ * ticoCobaltGravelFreq ' range=':= 1.084 * _default_ * ticoCobaltGravelFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.014 * _default_ * ticoCobaltGravelSize ' range=':= 1.014 * _default_ * ticoCobaltGravelSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 64 ' range=':= 64 ' type='uniform' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 64 ' range=':= 64 ' type='uniform' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1938,7 +1938,7 @@
                             <Setting name='CloudRadius' avg=':= 0.995 * _default_ * ticoCobaltGravelSize ' range=':= 0.995 * _default_ * ticoCobaltGravelSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.995 * _default_ * ticoCobaltGravelSize ' range=':= 0.995 * _default_ * ticoCobaltGravelSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.990 * _default_ * ticoCobaltGravelFreq ' range=':= 0.990 * _default_ * ticoCobaltGravelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 64 ' range=':= 64 ' type='uniform' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 64 ' range=':= 64 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1990,9 +1990,9 @@
                             <OreBlock block='TConstruct:GravelOre:5' weight='1.0' />
                             <Replaces block='minecraft:gravel' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 1.500 * ticoCobaltGravelSize ' range=':= 1.500 * ticoCobaltGravelSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 4.000 * ticoCobaltGravelFreq ' range=':= 4.000 * ticoCobaltGravelFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 64 ' range=':= 64 ' type='uniform' scaleTo='base' />
+                            <Setting name='Size' avg=':= 2.0 * ticoCobaltGravelSize ' range=':= 1.0 * ticoCobaltGravelSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 5.333 * ticoCobaltGravelFreq ' range=':= 2.67 * ticoCobaltGravelFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 64 ' range=':= 64 ' type='uniform' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>

--- a/src/main/resources/config/modules/TinkersSteelworks.xml
+++ b/src/main/resources/config/modules/TinkersSteelworks.xml
@@ -128,7 +128,7 @@
                             <Setting name='CloudRadius' avg=':= 0.972 * _default_ * tiswLimestoneSize ' range=':= 0.972 * _default_ * tiswLimestoneSize ' type='normal' />
                             <Setting name='CloudThickness' avg=':= 0.972 * _default_ * tiswLimestoneSize ' range=':= 0.972 * _default_ * tiswLimestoneSize ' type='normal' scaleTo='base' />
                             <Setting name='DistributionFrequency' avg=':= 0.945 * _default_ * tiswLimestoneFreq ' range=':= 0.945 * _default_ * tiswLimestoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='CloudHeight' avg=':= 38 ' range=':= 26 ' type='normal' scaleTo='base' />
+                            <Setting name='CloudHeight' avg=':= 38 ' range=':= 26 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -154,7 +154,7 @@
                             <Biome name='.*'  />
                             <Setting name='MotherlodeFrequency' avg=':= 1.416 * _default_ * tiswLimestoneFreq ' range=':= 1.416 * _default_ * tiswLimestoneFreq ' type='normal' scaleTo='base' />
                             <Setting name='MotherlodeSize' avg=':= 1.060 * _default_ * tiswLimestoneSize ' range=':= 1.060 * _default_ * tiswLimestoneSize ' type='normal' />
-                            <Setting name='MotherlodeHeight' avg=':= 38 ' range=':= 26 ' type='normal' scaleTo='base' />
+                            <Setting name='MotherlodeHeight' avg=':= 38 ' range=':= 26 ' type='normal' scaleTo='position' />
                             <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                             <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -185,9 +185,9 @@
                             <OreBlock block='TSteelworks:Limestone' weight='1.0' />
                             <ReplacesOre block='stone' weight='1.0' />
                             <Biome name='.*'  />
-                            <Setting name='Size' avg=':= 16.000 * tiswLimestoneSize ' range=':= 16.000 * tiswLimestoneSize ' type='normal' />
-                            <Setting name='Frequency' avg=':= 1.000 * tiswLimestoneFreq ' range=':= 1.000 * tiswLimestoneFreq ' type='normal' scaleTo='base' />
-                            <Setting name='Height' avg=':= 38 ' range=':= 26 ' type='normal' scaleTo='base' />
+                            <Setting name='Size' avg=':= 21.333 * tiswLimestoneSize ' range=':= 10.67 * tiswLimestoneSize ' type='normal' />
+                            <Setting name='Frequency' avg=':= 1.333 * tiswLimestoneFreq ' range=':= 0.67 * tiswLimestoneFreq ' type='normal' scaleTo='base' />
+                            <Setting name='Height' avg=':= 38 ' range=':= 26 ' type='normal' scaleTo='position' />
                             <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                         </StandardGen>
                     </IfCondition>

--- a/src/main/resources/config/modules/VanillaMinecraft.xml
+++ b/src/main/resources/config/modules/VanillaMinecraft.xml
@@ -571,7 +571,7 @@
                     <Biome name='.*'  />
                     <Setting name='MotherlodeFrequency' avg=':= 7.748 * _default_ * vnlaCoalFreq ' range=':= 7.748 * _default_ * vnlaCoalFreq ' type='normal' scaleTo='base' />
                     <Setting name='MotherlodeSize' avg=':= 0 * _default_ * vnlaCoalSize ' range=':= 0 * _default_ * vnlaCoalSize ' type='normal' />
-                    <Setting name='MotherlodeHeight' avg=':= 64 ' range=':= 64 ' type='normal' scaleTo='base' />
+                    <Setting name='MotherlodeHeight' avg=':= 64 ' range=':= 64 ' type='normal' scaleTo='position' />
                     <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -613,7 +613,7 @@
                     <Setting name='CloudRadius' avg=':= 1.901 * _default_ * vnlaCoalSize ' range=':= 1.901 * _default_ * vnlaCoalSize ' type='normal' />
                     <Setting name='CloudThickness' avg=':= 1.901 * _default_ * vnlaCoalSize ' range=':= 1.901 * _default_ * vnlaCoalSize ' type='normal' scaleTo='base' />
                     <Setting name='DistributionFrequency' avg=':= 3.614 * _default_ * vnlaCoalFreq ' range=':= 3.614 * _default_ * vnlaCoalFreq ' type='normal' scaleTo='base' />
-                    <Setting name='CloudHeight' avg=':= 64 ' range=':= 64 ' type='normal' scaleTo='base' />
+                    <Setting name='CloudHeight' avg=':= 64 ' range=':= 64 ' type='normal' scaleTo='position' />
                     <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -661,9 +661,9 @@
                     <OreBlock block='minecraft:coal_ore' weight='1.0' />
                     <ReplacesOre block='stone' weight='1.0' />
                     <Biome name='.*'  />
-                    <Setting name='Size' avg=':= 8.000 * vnlaCoalSize ' range=':= 8.000 * vnlaCoalSize ' type='normal' />
-                    <Setting name='Frequency' avg=':= 10.000 * vnlaCoalFreq ' range=':= 10.000 * vnlaCoalFreq ' type='normal' scaleTo='base' />
-                    <Setting name='Height' avg=':= 64 ' range=':= 64 ' type='normal' scaleTo='base' />
+                    <Setting name='Size' avg=':= 10.667 * vnlaCoalSize ' range=':= 5.33 * vnlaCoalSize ' type='normal' />
+                    <Setting name='Frequency' avg=':= 13.333 * vnlaCoalFreq ' range=':= 6.67 * vnlaCoalFreq ' type='normal' scaleTo='base' />
+                    <Setting name='Height' avg=':= 64 ' range=':= 64 ' type='normal' scaleTo='position' />
                     <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                 </StandardGen>
             </IfCondition>
@@ -688,7 +688,7 @@
                     <Biome name='.*'  />
                     <Setting name='MotherlodeFrequency' avg=':= 2.238 * _default_ * vnlaIronFreq ' range=':= 2.238 * _default_ * vnlaIronFreq ' type='normal' scaleTo='base' />
                     <Setting name='MotherlodeSize' avg=':= 1.144 * _default_ * vnlaIronSize ' range=':= 1.144 * _default_ * vnlaIronSize ' type='normal' />
-                    <Setting name='MotherlodeHeight' avg=':= 32 ' range=':= 32 ' type='normal' scaleTo='base' />
+                    <Setting name='MotherlodeHeight' avg=':= 32 ' range=':= 32 ' type='normal' scaleTo='position' />
                     <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -730,7 +730,7 @@
                     <Setting name='CloudRadius' avg=':= 1.599 * _default_ * vnlaIronSize ' range=':= 1.599 * _default_ * vnlaIronSize ' type='normal' />
                     <Setting name='CloudThickness' avg=':= 1.599 * _default_ * vnlaIronSize ' range=':= 1.599 * _default_ * vnlaIronSize ' type='normal' scaleTo='base' />
                     <Setting name='DistributionFrequency' avg=':= 2.556 * _default_ * vnlaIronFreq ' range=':= 2.556 * _default_ * vnlaIronFreq ' type='normal' scaleTo='base' />
-                    <Setting name='CloudHeight' avg=':= 32 ' range=':= 32 ' type='normal' scaleTo='base' />
+                    <Setting name='CloudHeight' avg=':= 32 ' range=':= 32 ' type='normal' scaleTo='position' />
                     <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -778,9 +778,9 @@
                     <OreBlock block='minecraft:iron_ore' weight='1.0' />
                     <ReplacesOre block='stone' weight='1.0' />
                     <Biome name='.*'  />
-                    <Setting name='Size' avg=':= 4.000 * vnlaIronSize ' range=':= 4.000 * vnlaIronSize ' type='normal' />
-                    <Setting name='Frequency' avg=':= 10.000 * vnlaIronFreq ' range=':= 10.000 * vnlaIronFreq ' type='normal' scaleTo='base' />
-                    <Setting name='Height' avg=':= 32 ' range=':= 32 ' type='normal' scaleTo='base' />
+                    <Setting name='Size' avg=':= 5.333 * vnlaIronSize ' range=':= 2.67 * vnlaIronSize ' type='normal' />
+                    <Setting name='Frequency' avg=':= 13.333 * vnlaIronFreq ' range=':= 6.67 * vnlaIronFreq ' type='normal' scaleTo='base' />
+                    <Setting name='Height' avg=':= 32 ' range=':= 32 ' type='normal' scaleTo='position' />
                     <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                 </StandardGen>
             </IfCondition>
@@ -805,7 +805,7 @@
                     <Biome name='.*'  />
                     <Setting name='MotherlodeFrequency' avg=':= 0.708 * _default_ * vnlaGoldFreq ' range=':= 0.708 * _default_ * vnlaGoldFreq ' type='normal' scaleTo='base' />
                     <Setting name='MotherlodeSize' avg=':= 0.944 * _default_ * vnlaGoldSize ' range=':= 0.944 * _default_ * vnlaGoldSize ' type='normal' />
-                    <Setting name='MotherlodeHeight' avg=':= 16 ' range=':= 16 ' type='normal' scaleTo='base' />
+                    <Setting name='MotherlodeHeight' avg=':= 16 ' range=':= 16 ' type='normal' scaleTo='position' />
                     <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -847,7 +847,7 @@
                     <Setting name='CloudRadius' avg=':= 0.899 * _default_ * vnlaGoldSize ' range=':= 0.899 * _default_ * vnlaGoldSize ' type='normal' />
                     <Setting name='CloudThickness' avg=':= 0.899 * _default_ * vnlaGoldSize ' range=':= 0.899 * _default_ * vnlaGoldSize ' type='normal' scaleTo='base' />
                     <Setting name='DistributionFrequency' avg=':= 0.808 * _default_ * vnlaGoldFreq ' range=':= 0.808 * _default_ * vnlaGoldFreq ' type='normal' scaleTo='base' />
-                    <Setting name='CloudHeight' avg=':= 16 ' range=':= 16 ' type='normal' scaleTo='base' />
+                    <Setting name='CloudHeight' avg=':= 16 ' range=':= 16 ' type='normal' scaleTo='position' />
                     <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -895,9 +895,9 @@
                     <OreBlock block='minecraft:gold_ore' weight='1.0' />
                     <ReplacesOre block='stone' weight='1.0' />
                     <Biome name='.*'  />
-                    <Setting name='Size' avg=':= 4.000 * vnlaGoldSize ' range=':= 4.000 * vnlaGoldSize ' type='normal' />
-                    <Setting name='Frequency' avg=':= 1.000 * vnlaGoldFreq ' range=':= 1.000 * vnlaGoldFreq ' type='normal' scaleTo='base' />
-                    <Setting name='Height' avg=':= 16 ' range=':= 16 ' type='normal' scaleTo='base' />
+                    <Setting name='Size' avg=':= 5.333 * vnlaGoldSize ' range=':= 2.67 * vnlaGoldSize ' type='normal' />
+                    <Setting name='Frequency' avg=':= 1.333 * vnlaGoldFreq ' range=':= 0.67 * vnlaGoldFreq ' type='normal' scaleTo='base' />
+                    <Setting name='Height' avg=':= 16 ' range=':= 16 ' type='normal' scaleTo='position' />
                     <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                 </StandardGen>
             </IfCondition>
@@ -922,7 +922,7 @@
                     <Biome name='.*'  />
                     <Setting name='MotherlodeFrequency' avg=':= 2.406 * _default_ * vnlaRedstoneFreq ' range=':= 2.406 * _default_ * vnlaRedstoneFreq ' type='normal' scaleTo='base' />
                     <Setting name='MotherlodeSize' avg=':= 0 * _default_ * vnlaRedstoneSize ' range=':= 0 * _default_ * vnlaRedstoneSize ' type='normal' />
-                    <Setting name='MotherlodeHeight' avg=':= 8 ' range=':= 8 ' type='normal' scaleTo='base' />
+                    <Setting name='MotherlodeHeight' avg=':= 8 ' range=':= 8 ' type='normal' scaleTo='position' />
                     <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='BranchInclination' avg=':= -_default_ ' range=':= -_default_ ' type='normal' />
@@ -964,7 +964,7 @@
                     <Setting name='CloudRadius' avg=':= 1.230 * _default_ * vnlaRedstoneSize ' range=':= 1.230 * _default_ * vnlaRedstoneSize ' type='normal' />
                     <Setting name='CloudThickness' avg=':= 1.230 * _default_ * vnlaRedstoneSize ' range=':= 1.230 * _default_ * vnlaRedstoneSize ' type='normal' scaleTo='base' />
                     <Setting name='DistributionFrequency' avg=':= 1.512 * _default_ * vnlaRedstoneFreq ' range=':= 1.512 * _default_ * vnlaRedstoneFreq ' type='normal' scaleTo='base' />
-                    <Setting name='CloudHeight' avg=':= 8 ' range=':= 8 ' type='normal' scaleTo='base' />
+                    <Setting name='CloudHeight' avg=':= 8 ' range=':= 8 ' type='normal' scaleTo='position' />
                     <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1012,9 +1012,9 @@
                     <OreBlock block='minecraft:redstone_ore' weight='1.0' />
                     <ReplacesOre block='stone' weight='1.0' />
                     <Biome name='.*'  />
-                    <Setting name='Size' avg=':= 3.500 * vnlaRedstoneSize ' range=':= 3.500 * vnlaRedstoneSize ' type='normal' />
-                    <Setting name='Frequency' avg=':= 4.000 * vnlaRedstoneFreq ' range=':= 4.000 * vnlaRedstoneFreq ' type='normal' scaleTo='base' />
-                    <Setting name='Height' avg=':= 8 ' range=':= 8 ' type='normal' scaleTo='base' />
+                    <Setting name='Size' avg=':= 4.667 * vnlaRedstoneSize ' range=':= 2.33 * vnlaRedstoneSize ' type='normal' />
+                    <Setting name='Frequency' avg=':= 5.333 * vnlaRedstoneFreq ' range=':= 2.67 * vnlaRedstoneFreq ' type='normal' scaleTo='base' />
+                    <Setting name='Height' avg=':= 8 ' range=':= 8 ' type='normal' scaleTo='position' />
                     <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                 </StandardGen>
             </IfCondition>
@@ -1039,7 +1039,7 @@
                     <Biome name='.*'  />
                     <Setting name='MotherlodeFrequency' avg=':= 0.714 * _default_ * vnlaDiamondFreq ' range=':= 0.714 * _default_ * vnlaDiamondFreq ' type='normal' scaleTo='base' />
                     <Setting name='MotherlodeSize' avg=':= 0 * _default_ * vnlaDiamondSize ' range=':= 0 * _default_ * vnlaDiamondSize ' type='normal' />
-                    <Setting name='MotherlodeHeight' avg=':= 8 ' range=':= 8 ' type='normal' scaleTo='base' />
+                    <Setting name='MotherlodeHeight' avg=':= 8 ' range=':= 8 ' type='normal' scaleTo='position' />
                     <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1091,7 +1091,7 @@
                     <Setting name='CloudRadius' avg=':= 0.731 * _default_ * vnlaDiamondSize ' range=':= 0.731 * _default_ * vnlaDiamondSize ' type='normal' />
                     <Setting name='CloudThickness' avg=':= 0.731 * _default_ * vnlaDiamondSize ' range=':= 0.731 * _default_ * vnlaDiamondSize ' type='normal' scaleTo='base' />
                     <Setting name='DistributionFrequency' avg=':= 0.535 * _default_ * vnlaDiamondFreq ' range=':= 0.535 * _default_ * vnlaDiamondFreq ' type='normal' scaleTo='base' />
-                    <Setting name='CloudHeight' avg=':= 8 ' range=':= 8 ' type='normal' scaleTo='base' />
+                    <Setting name='CloudHeight' avg=':= 8 ' range=':= 8 ' type='normal' scaleTo='position' />
                     <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1139,9 +1139,9 @@
                     <OreBlock block='minecraft:diamond_ore' weight='1.0' />
                     <ReplacesOre block='stone' weight='1.0' />
                     <Biome name='.*'  />
-                    <Setting name='Size' avg=':= 3.500 * vnlaDiamondSize ' range=':= 3.500 * vnlaDiamondSize ' type='normal' />
-                    <Setting name='Frequency' avg=':= 0.500 * vnlaDiamondFreq ' range=':= 0.500 * vnlaDiamondFreq ' type='normal' scaleTo='base' />
-                    <Setting name='Height' avg=':= 8 ' range=':= 8 ' type='normal' scaleTo='base' />
+                    <Setting name='Size' avg=':= 4.667 * vnlaDiamondSize ' range=':= 2.33 * vnlaDiamondSize ' type='normal' />
+                    <Setting name='Frequency' avg=':= 0.667 * vnlaDiamondFreq ' range=':= 0.33 * vnlaDiamondFreq ' type='normal' scaleTo='base' />
+                    <Setting name='Height' avg=':= 8 ' range=':= 8 ' type='normal' scaleTo='position' />
                     <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                 </StandardGen>
             </IfCondition>
@@ -1166,7 +1166,7 @@
                     <Biome name='.*'  />
                     <Setting name='MotherlodeFrequency' avg=':= 0.787 * _default_ * vnlaLapisLazuliFreq ' range=':= 0.787 * _default_ * vnlaLapisLazuliFreq ' type='normal' scaleTo='base' />
                     <Setting name='MotherlodeSize' avg=':= 0 * _default_ * vnlaLapisLazuliSize ' range=':= 0 * _default_ * vnlaLapisLazuliSize ' type='normal' />
-                    <Setting name='MotherlodeHeight' avg=':= 16 ' range=':= 0 ' type='normal' scaleTo='base' />
+                    <Setting name='MotherlodeHeight' avg=':= 16 ' range=':= 0 ' type='normal' scaleTo='position' />
                     <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='BranchInclination' avg=':= -_default_ ' range=':= -_default_ ' type='normal' />
@@ -1208,7 +1208,7 @@
                     <Setting name='CloudRadius' avg=':= 0.703 * _default_ * vnlaLapisLazuliSize ' range=':= 0.703 * _default_ * vnlaLapisLazuliSize ' type='normal' />
                     <Setting name='CloudThickness' avg=':= 0.703 * _default_ * vnlaLapisLazuliSize ' range=':= 0.703 * _default_ * vnlaLapisLazuliSize ' type='normal' scaleTo='base' />
                     <Setting name='DistributionFrequency' avg=':= 0.495 * _default_ * vnlaLapisLazuliFreq ' range=':= 0.495 * _default_ * vnlaLapisLazuliFreq ' type='normal' scaleTo='base' />
-                    <Setting name='CloudHeight' avg=':= 16 ' range=':= 0 ' type='normal' scaleTo='base' />
+                    <Setting name='CloudHeight' avg=':= 16 ' range=':= 0 ' type='normal' scaleTo='position' />
                     <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1256,9 +1256,9 @@
                     <OreBlock block='minecraft:lapis_ore' weight='1.0' />
                     <ReplacesOre block='stone' weight='1.0' />
                     <Biome name='.*'  />
-                    <Setting name='Size' avg=':= 3.000 * vnlaLapisLazuliSize ' range=':= 3.000 * vnlaLapisLazuliSize ' type='normal' />
-                    <Setting name='Frequency' avg=':= 0.500 * vnlaLapisLazuliFreq ' range=':= 0.500 * vnlaLapisLazuliFreq ' type='normal' scaleTo='base' />
-                    <Setting name='Height' avg=':= 16 ' range=':= 0 ' type='normal' scaleTo='base' />
+                    <Setting name='Size' avg=':= 4.0 * vnlaLapisLazuliSize ' range=':= 2.0 * vnlaLapisLazuliSize ' type='normal' />
+                    <Setting name='Frequency' avg=':= 0.667 * vnlaLapisLazuliFreq ' range=':= 0.33 * vnlaLapisLazuliFreq ' type='normal' scaleTo='base' />
+                    <Setting name='Height' avg=':= 16 ' range=':= 0 ' type='normal' scaleTo='position' />
                     <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                 </StandardGen>
             </IfCondition>
@@ -1283,7 +1283,7 @@
                     <BiomeType name='Mountain'  />
                     <Setting name='MotherlodeFrequency' avg=':= 1.145 * _default_ * vnlaEmeraldFreq ' range=':= 1.145 * _default_ * vnlaEmeraldFreq ' type='normal' scaleTo='base' />
                     <Setting name='MotherlodeSize' avg=':= 0 * _default_ * vnlaEmeraldSize ' range=':= 0 * _default_ * vnlaEmeraldSize ' type='normal' />
-                    <Setting name='MotherlodeHeight' avg=':= 16 ' range=':= 12 ' type='normal' scaleTo='base' />
+                    <Setting name='MotherlodeHeight' avg=':= 16 ' range=':= 12 ' type='normal' scaleTo='position' />
                     <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1335,7 +1335,7 @@
                     <Setting name='CloudRadius' avg=':= 0.926 * _default_ * vnlaEmeraldSize ' range=':= 0.926 * _default_ * vnlaEmeraldSize ' type='normal' />
                     <Setting name='CloudThickness' avg=':= 0.926 * _default_ * vnlaEmeraldSize ' range=':= 0.926 * _default_ * vnlaEmeraldSize ' type='normal' scaleTo='base' />
                     <Setting name='DistributionFrequency' avg=':= 0.857 * _default_ * vnlaEmeraldFreq ' range=':= 0.857 * _default_ * vnlaEmeraldFreq ' type='normal' scaleTo='base' />
-                    <Setting name='CloudHeight' avg=':= 16 ' range=':= 12 ' type='normal' scaleTo='base' />
+                    <Setting name='CloudHeight' avg=':= 16 ' range=':= 12 ' type='normal' scaleTo='position' />
                     <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1383,9 +1383,9 @@
                     <OreBlock block='minecraft:emerald_ore' weight='1.0' />
                     <ReplacesOre block='stone' weight='1.0' />
                     <BiomeType name='Mountain'  />
-                    <Setting name='Size' avg=':= 1.000 * vnlaEmeraldSize ' range=':= 1.000 * vnlaEmeraldSize ' type='normal' />
-                    <Setting name='Frequency' avg=':= 4.500 * vnlaEmeraldFreq ' range=':= 4.500 * vnlaEmeraldFreq ' type='normal' scaleTo='base' />
-                    <Setting name='Height' avg=':= 16 ' range=':= 12 ' type='normal' scaleTo='base' />
+                    <Setting name='Size' avg=':= 1.333 * vnlaEmeraldSize ' range=':= 0.67 * vnlaEmeraldSize ' type='normal' />
+                    <Setting name='Frequency' avg=':= 6.0 * vnlaEmeraldFreq ' range=':= 3.0 * vnlaEmeraldFreq ' type='normal' scaleTo='base' />
+                    <Setting name='Height' avg=':= 16 ' range=':= 12 ' type='normal' scaleTo='position' />
                     <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                 </StandardGen>
             </IfCondition>
@@ -1447,7 +1447,7 @@
                     <Biome name='.*'  />
                     <Setting name='MotherlodeFrequency' avg=':= 6.247 * _default_ * vnlaNetherQuartzFreq ' range=':= 6.247 * _default_ * vnlaNetherQuartzFreq ' type='normal' scaleTo='base' />
                     <Setting name='MotherlodeSize' avg=':= 0 * _default_ * vnlaNetherQuartzSize ' range=':= 0 * _default_ * vnlaNetherQuartzSize ' type='normal' />
-                    <Setting name='MotherlodeHeight' avg=':= 59 ' range=':= 49 ' type='uniform' scaleTo='base' />
+                    <Setting name='MotherlodeHeight' avg=':= 59 ' range=':= 49 ' type='uniform' scaleTo='position' />
                     <Setting name='MotherlodeRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='BranchFrequency' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='BranchInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1489,7 +1489,7 @@
                     <Setting name='CloudRadius' avg=':= 1.707 * _default_ * vnlaNetherQuartzSize ' range=':= 1.707 * _default_ * vnlaNetherQuartzSize ' type='normal' />
                     <Setting name='CloudThickness' avg=':= 1.707 * _default_ * vnlaNetherQuartzSize ' range=':= 1.707 * _default_ * vnlaNetherQuartzSize ' type='normal' scaleTo='base' />
                     <Setting name='DistributionFrequency' avg=':= 2.914 * _default_ * vnlaNetherQuartzFreq ' range=':= 2.914 * _default_ * vnlaNetherQuartzFreq ' type='normal' scaleTo='base' />
-                    <Setting name='CloudHeight' avg=':= 59 ' range=':= 49 ' type='uniform' scaleTo='base' />
+                    <Setting name='CloudHeight' avg=':= 59 ' range=':= 49 ' type='uniform' scaleTo='position' />
                     <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='CloudSizeNoise' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                     <Setting name='CloudInclination' avg=':= _default_ ' range=':= _default_ ' type='normal' />
@@ -1537,9 +1537,9 @@
                     <OreBlock block='minecraft:quartz_ore' weight='1.0' />
                     <Replaces block='minecraft:netherrack' weight='1.0' />
                     <Biome name='.*'  />
-                    <Setting name='Size' avg=':= 8.000 * vnlaNetherQuartzSize ' range=':= 8.000 * vnlaNetherQuartzSize ' type='normal' />
-                    <Setting name='Frequency' avg=':= 6.500 * vnlaNetherQuartzFreq ' range=':= 6.500 * vnlaNetherQuartzFreq ' type='normal' scaleTo='base' />
-                    <Setting name='Height' avg=':= 59 ' range=':= 49 ' type='uniform' scaleTo='base' />
+                    <Setting name='Size' avg=':= 10.667 * vnlaNetherQuartzSize ' range=':= 5.33 * vnlaNetherQuartzSize ' type='normal' />
+                    <Setting name='Frequency' avg=':= 8.667 * vnlaNetherQuartzFreq ' range=':= 4.33 * vnlaNetherQuartzFreq ' type='normal' scaleTo='base' />
+                    <Setting name='Height' avg=':= 59 ' range=':= 49 ' type='uniform' scaleTo='position' />
                     <Setting name='ParentRangeLimit' avg=':= _default_ ' range=':= _default_ ' type='normal' />
                 </StandardGen>
             </IfCondition>


### PR DESCRIPTION
The range for vanilla size and frequency now start at 1/3 the mod's original maximum, and then tops off at that maximum.  This will prevent ores with large maximums from having minimum veins of 1 or less.