### PR TITLE
Renamed "Vanilla Minecraft" to just "Vanilla"

### DIFF
--- a/src/main/java/CustomOreGen/CustomOreGenBase.java
+++ b/src/main/java/CustomOreGen/CustomOreGenBase.java
@@ -93,7 +93,7 @@ public class CustomOreGenBase
             "ThermalFoundation.xml",
             "TinkersConstruct.xml",
             "TinkersSteelworks.xml",
-            "VanillaMinecraft.xml"
+            "Vanilla.xml"
         };
         for (String module : extraModules) {
         	unpackConfigFile("modules/" + module, new File(defaultModulesDir, module));

--- a/src/main/resources/config/CustomOreGen_Config_Default.xml
+++ b/src/main/resources/config/CustomOreGen_Config_Default.xml
@@ -493,7 +493,7 @@
 
     <!-- Vanilla minecraft ores should always be the first ores to 
          load. -->
-    <Import file='modules/default/VanillaMinecraft.xml'/>
+    <Import file='modules/default/Vanilla.xml'/>
     
     <!-- Dense Ores in particular NEEDS to be run after the vanilla
          configuration, as it clears and regenerates vanilla ores while

--- a/src/main/resources/config/modules/Vanilla.xml
+++ b/src/main/resources/config/modules/Vanilla.xml
@@ -1,8 +1,8 @@
 <!-- =================================================================
-     Custom Ore Generation "Vanilla Minecraft" Module: This
-     configuration covers clay, coal, iron, mountain iron, gold,
-     mountain gold, redstone, mountain redstone, diamond, lapis
-     lazuli, mountain lapis lazuli, emerald, and nether quartz.
+     Custom Ore Generation "Vanilla" Module: This configuration covers
+     clay, coal, iron, mountain iron, gold, mountain gold, redstone,
+     mountain redstone, diamond, lapis lazuli, mountain lapis lazuli,
+     emerald, and nether quartz.
      ================================================================= -->
 
 
@@ -21,17 +21,17 @@
 
   <!-- Setup Screen Configuration -->
   <ConfigSection>
-    <OptionDisplayGroup name='groupVanillaMinecraft' displayName='Vanilla Minecraft' displayState='shown'>
+    <OptionDisplayGroup name='groupVanilla' displayName='Vanilla' displayState='shown'>
       <Description>
-        Distribution options for Vanilla Minecraft Ores.
+        Distribution options for Vanilla Ores.
       </Description>
     </OptionDisplayGroup>
 
     <!-- Clay Configuration UI Starting -->
     <ConfigSection>
-      <OptionChoice name='vnlaClayDist'  displayState=':= "shown"' displayGroup='groupVanillaMinecraft'>
+      <OptionChoice name='vnlaClayDist'  displayState=':= "shown"' displayGroup='groupVanilla'>
         <Description> Controls how Clay is generated </Description>
-        <DisplayName>Vanilla Minecraft Clay</DisplayName>
+        <DisplayName>Vanilla Clay</DisplayName>
         <IfCondition condition=':= (?blockExists("minecraft:clay")) '>
 
         <Choice value='SmallDeposits' displayValue='Small Deposits'>
@@ -43,13 +43,13 @@
 
         <Choice value='none' displayValue='None' description='Clay is not generated in the world.'/>
       </OptionChoice>
-      <OptionNumeric name='vnlaClayFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions, "shown", "hidden")' displayGroup='groupVanillaMinecraft'>
-        <Description> Frequency multiplier for Vanilla Minecraft Clay distributions </Description>
-        <DisplayName>Vanilla Minecraft Clay Freq.</DisplayName>
+      <OptionNumeric name='vnlaClayFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions, "shown", "hidden")' displayGroup='groupVanilla'>
+        <Description> Frequency multiplier for Vanilla Clay distributions </Description>
+        <DisplayName>Vanilla Clay Freq.</DisplayName>
       </OptionNumeric>
-      <OptionNumeric name='vnlaClaySize' default='1'  min='0' max='5' displayState=':= if(?advOptions, "shown", "hidden")' displayGroup='groupVanillaMinecraft'>
-        <Description> Size multiplier for Vanilla Minecraft Clay distributions </Description>
-        <DisplayName>Vanilla Minecraft Clay Size</DisplayName>
+      <OptionNumeric name='vnlaClaySize' default='1'  min='0' max='5' displayState=':= if(?advOptions, "shown", "hidden")' displayGroup='groupVanilla'>
+        <Description> Size multiplier for Vanilla Clay distributions </Description>
+        <DisplayName>Vanilla Clay Size</DisplayName>
       </OptionNumeric>
     </ConfigSection>
     <!-- Clay Configuration UI Complete -->
@@ -57,9 +57,9 @@
 
     <!-- Coal Configuration UI Starting -->
     <ConfigSection>
-      <OptionChoice name='vnlaCoalDist'  displayState=':= "shown"' displayGroup='groupVanillaMinecraft'>
+      <OptionChoice name='vnlaCoalDist'  displayState=':= "shown"' displayGroup='groupVanilla'>
         <Description> Controls how Coal is generated </Description>
-        <DisplayName>Vanilla Minecraft Coal</DisplayName>
+        <DisplayName>Vanilla Coal</DisplayName>
         <IfCondition condition=':= (?blockExists("minecraft:coal_ore")) '>
 
         <Choice value='SparseVeins' displayValue='Sparse Veins'>
@@ -89,13 +89,13 @@
 
         <Choice value='none' displayValue='None' description='Coal is not generated in the world.'/>
       </OptionChoice>
-      <OptionNumeric name='vnlaCoalFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions, "shown", "hidden")' displayGroup='groupVanillaMinecraft'>
-        <Description> Frequency multiplier for Vanilla Minecraft Coal distributions </Description>
-        <DisplayName>Vanilla Minecraft Coal Freq.</DisplayName>
+      <OptionNumeric name='vnlaCoalFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions, "shown", "hidden")' displayGroup='groupVanilla'>
+        <Description> Frequency multiplier for Vanilla Coal distributions </Description>
+        <DisplayName>Vanilla Coal Freq.</DisplayName>
       </OptionNumeric>
-      <OptionNumeric name='vnlaCoalSize' default='1'  min='0' max='5' displayState=':= if(?advOptions, "shown", "hidden")' displayGroup='groupVanillaMinecraft'>
-        <Description> Size multiplier for Vanilla Minecraft Coal distributions </Description>
-        <DisplayName>Vanilla Minecraft Coal Size</DisplayName>
+      <OptionNumeric name='vnlaCoalSize' default='1'  min='0' max='5' displayState=':= if(?advOptions, "shown", "hidden")' displayGroup='groupVanilla'>
+        <Description> Size multiplier for Vanilla Coal distributions </Description>
+        <DisplayName>Vanilla Coal Size</DisplayName>
       </OptionNumeric>
     </ConfigSection>
     <!-- Coal Configuration UI Complete -->
@@ -103,9 +103,9 @@
 
     <!-- Iron Configuration UI Starting -->
     <ConfigSection>
-      <OptionChoice name='vnlaIronDist'  displayState=':= "shown"' displayGroup='groupVanillaMinecraft'>
+      <OptionChoice name='vnlaIronDist'  displayState=':= "shown"' displayGroup='groupVanilla'>
         <Description> Controls how Iron is generated </Description>
-        <DisplayName>Vanilla Minecraft Iron</DisplayName>
+        <DisplayName>Vanilla Iron</DisplayName>
         <IfCondition condition=':= (?blockExists("minecraft:iron_ore")) '>
 
         <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -135,13 +135,13 @@
 
         <Choice value='none' displayValue='None' description='Iron is not generated in the world.'/>
       </OptionChoice>
-      <OptionNumeric name='vnlaIronFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions, "shown", "hidden")' displayGroup='groupVanillaMinecraft'>
-        <Description> Frequency multiplier for Vanilla Minecraft Iron distributions </Description>
-        <DisplayName>Vanilla Minecraft Iron Freq.</DisplayName>
+      <OptionNumeric name='vnlaIronFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions, "shown", "hidden")' displayGroup='groupVanilla'>
+        <Description> Frequency multiplier for Vanilla Iron distributions </Description>
+        <DisplayName>Vanilla Iron Freq.</DisplayName>
       </OptionNumeric>
-      <OptionNumeric name='vnlaIronSize' default='1'  min='0' max='5' displayState=':= if(?advOptions, "shown", "hidden")' displayGroup='groupVanillaMinecraft'>
-        <Description> Size multiplier for Vanilla Minecraft Iron distributions </Description>
-        <DisplayName>Vanilla Minecraft Iron Size</DisplayName>
+      <OptionNumeric name='vnlaIronSize' default='1'  min='0' max='5' displayState=':= if(?advOptions, "shown", "hidden")' displayGroup='groupVanilla'>
+        <Description> Size multiplier for Vanilla Iron distributions </Description>
+        <DisplayName>Vanilla Iron Size</DisplayName>
       </OptionNumeric>
     </ConfigSection>
     <!-- Iron Configuration UI Complete -->
@@ -149,9 +149,9 @@
 
     <!-- Mountain Iron Configuration UI Starting -->
     <ConfigSection>
-      <OptionChoice name='vnlaMountainIronDist'  displayState=':= "shown"' displayGroup='groupVanillaMinecraft'>
+      <OptionChoice name='vnlaMountainIronDist'  displayState=':= "shown"' displayGroup='groupVanilla'>
         <Description> Controls how Mountain Iron is generated </Description>
-        <DisplayName>Vanilla Minecraft Mountain Iron</DisplayName>
+        <DisplayName>Vanilla Mountain Iron</DisplayName>
         <IfCondition condition=':= (?blockExists("minecraft:iron_ore")) '>
 
         <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -181,13 +181,13 @@
 
         <Choice value='none' displayValue='None' description='Mountain Iron is not generated in the world.'/>
       </OptionChoice>
-      <OptionNumeric name='vnlaMountainIronFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions, "shown", "hidden")' displayGroup='groupVanillaMinecraft'>
-        <Description> Frequency multiplier for Vanilla Minecraft Mountain Iron distributions </Description>
-        <DisplayName>Vanilla Minecraft Mountain Iron Freq.</DisplayName>
+      <OptionNumeric name='vnlaMountainIronFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions, "shown", "hidden")' displayGroup='groupVanilla'>
+        <Description> Frequency multiplier for Vanilla Mountain Iron distributions </Description>
+        <DisplayName>Vanilla Mountain Iron Freq.</DisplayName>
       </OptionNumeric>
-      <OptionNumeric name='vnlaMountainIronSize' default='1'  min='0' max='5' displayState=':= if(?advOptions, "shown", "hidden")' displayGroup='groupVanillaMinecraft'>
-        <Description> Size multiplier for Vanilla Minecraft Mountain Iron distributions </Description>
-        <DisplayName>Vanilla Minecraft Mountain Iron Size</DisplayName>
+      <OptionNumeric name='vnlaMountainIronSize' default='1'  min='0' max='5' displayState=':= if(?advOptions, "shown", "hidden")' displayGroup='groupVanilla'>
+        <Description> Size multiplier for Vanilla Mountain Iron distributions </Description>
+        <DisplayName>Vanilla Mountain Iron Size</DisplayName>
       </OptionNumeric>
     </ConfigSection>
     <!-- Mountain Iron Configuration UI Complete -->
@@ -195,9 +195,9 @@
 
     <!-- Gold Configuration UI Starting -->
     <ConfigSection>
-      <OptionChoice name='vnlaGoldDist'  displayState=':= "shown"' displayGroup='groupVanillaMinecraft'>
+      <OptionChoice name='vnlaGoldDist'  displayState=':= "shown"' displayGroup='groupVanilla'>
         <Description> Controls how Gold is generated </Description>
-        <DisplayName>Vanilla Minecraft Gold</DisplayName>
+        <DisplayName>Vanilla Gold</DisplayName>
         <IfCondition condition=':= (?blockExists("minecraft:gold_ore")) '>
 
         <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -227,13 +227,13 @@
 
         <Choice value='none' displayValue='None' description='Gold is not generated in the world.'/>
       </OptionChoice>
-      <OptionNumeric name='vnlaGoldFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions, "shown", "hidden")' displayGroup='groupVanillaMinecraft'>
-        <Description> Frequency multiplier for Vanilla Minecraft Gold distributions </Description>
-        <DisplayName>Vanilla Minecraft Gold Freq.</DisplayName>
+      <OptionNumeric name='vnlaGoldFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions, "shown", "hidden")' displayGroup='groupVanilla'>
+        <Description> Frequency multiplier for Vanilla Gold distributions </Description>
+        <DisplayName>Vanilla Gold Freq.</DisplayName>
       </OptionNumeric>
-      <OptionNumeric name='vnlaGoldSize' default='1'  min='0' max='5' displayState=':= if(?advOptions, "shown", "hidden")' displayGroup='groupVanillaMinecraft'>
-        <Description> Size multiplier for Vanilla Minecraft Gold distributions </Description>
-        <DisplayName>Vanilla Minecraft Gold Size</DisplayName>
+      <OptionNumeric name='vnlaGoldSize' default='1'  min='0' max='5' displayState=':= if(?advOptions, "shown", "hidden")' displayGroup='groupVanilla'>
+        <Description> Size multiplier for Vanilla Gold distributions </Description>
+        <DisplayName>Vanilla Gold Size</DisplayName>
       </OptionNumeric>
     </ConfigSection>
     <!-- Gold Configuration UI Complete -->
@@ -241,9 +241,9 @@
 
     <!-- Mountain Gold Configuration UI Starting -->
     <ConfigSection>
-      <OptionChoice name='vnlaMountainGoldDist'  displayState=':= "shown"' displayGroup='groupVanillaMinecraft'>
+      <OptionChoice name='vnlaMountainGoldDist'  displayState=':= "shown"' displayGroup='groupVanilla'>
         <Description> Controls how Mountain Gold is generated </Description>
-        <DisplayName>Vanilla Minecraft Mountain Gold</DisplayName>
+        <DisplayName>Vanilla Mountain Gold</DisplayName>
         <IfCondition condition=':= (?blockExists("minecraft:gold_ore")) '>
 
         <Choice value='LayeredVeins' displayValue='Layered Veins'>
@@ -273,13 +273,13 @@
 
         <Choice value='none' displayValue='None' description='Mountain Gold is not generated in the world.'/>
       </OptionChoice>
-      <OptionNumeric name='vnlaMountainGoldFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions, "shown", "hidden")' displayGroup='groupVanillaMinecraft'>
-        <Description> Frequency multiplier for Vanilla Minecraft Mountain Gold distributions </Description>
-        <DisplayName>Vanilla Minecraft Mountain Gold Freq.</DisplayName>
+      <OptionNumeric name='vnlaMountainGoldFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions, "shown", "hidden")' displayGroup='groupVanilla'>
+        <Description> Frequency multiplier for Vanilla Mountain Gold distributions </Description>
+        <DisplayName>Vanilla Mountain Gold Freq.</DisplayName>
       </OptionNumeric>
-      <OptionNumeric name='vnlaMountainGoldSize' default='1'  min='0' max='5' displayState=':= if(?advOptions, "shown", "hidden")' displayGroup='groupVanillaMinecraft'>
-        <Description> Size multiplier for Vanilla Minecraft Mountain Gold distributions </Description>
-        <DisplayName>Vanilla Minecraft Mountain Gold Size</DisplayName>
+      <OptionNumeric name='vnlaMountainGoldSize' default='1'  min='0' max='5' displayState=':= if(?advOptions, "shown", "hidden")' displayGroup='groupVanilla'>
+        <Description> Size multiplier for Vanilla Mountain Gold distributions </Description>
+        <DisplayName>Vanilla Mountain Gold Size</DisplayName>
       </OptionNumeric>
     </ConfigSection>
     <!-- Mountain Gold Configuration UI Complete -->
@@ -287,9 +287,9 @@
 
     <!-- Redstone Configuration UI Starting -->
     <ConfigSection>
-      <OptionChoice name='vnlaRedstoneDist'  displayState=':= "shown"' displayGroup='groupVanillaMinecraft'>
+      <OptionChoice name='vnlaRedstoneDist'  displayState=':= "shown"' displayGroup='groupVanilla'>
         <Description> Controls how Redstone is generated </Description>
-        <DisplayName>Vanilla Minecraft Redstone</DisplayName>
+        <DisplayName>Vanilla Redstone</DisplayName>
         <IfCondition condition=':= (?blockExists("minecraft:redstone_ore")) '>
 
         <Choice value='VerticalVeins' displayValue='Vertical Veins'>
@@ -319,13 +319,13 @@
 
         <Choice value='none' displayValue='None' description='Redstone is not generated in the world.'/>
       </OptionChoice>
-      <OptionNumeric name='vnlaRedstoneFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions, "shown", "hidden")' displayGroup='groupVanillaMinecraft'>
-        <Description> Frequency multiplier for Vanilla Minecraft Redstone distributions </Description>
-        <DisplayName>Vanilla Minecraft Redstone Freq.</DisplayName>
+      <OptionNumeric name='vnlaRedstoneFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions, "shown", "hidden")' displayGroup='groupVanilla'>
+        <Description> Frequency multiplier for Vanilla Redstone distributions </Description>
+        <DisplayName>Vanilla Redstone Freq.</DisplayName>
       </OptionNumeric>
-      <OptionNumeric name='vnlaRedstoneSize' default='1'  min='0' max='5' displayState=':= if(?advOptions, "shown", "hidden")' displayGroup='groupVanillaMinecraft'>
-        <Description> Size multiplier for Vanilla Minecraft Redstone distributions </Description>
-        <DisplayName>Vanilla Minecraft Redstone Size</DisplayName>
+      <OptionNumeric name='vnlaRedstoneSize' default='1'  min='0' max='5' displayState=':= if(?advOptions, "shown", "hidden")' displayGroup='groupVanilla'>
+        <Description> Size multiplier for Vanilla Redstone distributions </Description>
+        <DisplayName>Vanilla Redstone Size</DisplayName>
       </OptionNumeric>
     </ConfigSection>
     <!-- Redstone Configuration UI Complete -->
@@ -333,9 +333,9 @@
 
     <!-- Mountain Redstone Configuration UI Starting -->
     <ConfigSection>
-      <OptionChoice name='vnlaMountainRedstoneDist'  displayState=':= "shown"' displayGroup='groupVanillaMinecraft'>
+      <OptionChoice name='vnlaMountainRedstoneDist'  displayState=':= "shown"' displayGroup='groupVanilla'>
         <Description> Controls how Mountain Redstone is generated </Description>
-        <DisplayName>Vanilla Minecraft Mountain Redstone</DisplayName>
+        <DisplayName>Vanilla Mountain Redstone</DisplayName>
         <IfCondition condition=':= (?blockExists("minecraft:redstone_ore")) '>
 
         <Choice value='VerticalVeins' displayValue='Vertical Veins'>
@@ -365,13 +365,13 @@
 
         <Choice value='none' displayValue='None' description='Mountain Redstone is not generated in the world.'/>
       </OptionChoice>
-      <OptionNumeric name='vnlaMountainRedstoneFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions, "shown", "hidden")' displayGroup='groupVanillaMinecraft'>
-        <Description> Frequency multiplier for Vanilla Minecraft Mountain Redstone distributions </Description>
-        <DisplayName>Vanilla Minecraft Mountain Redstone Freq.</DisplayName>
+      <OptionNumeric name='vnlaMountainRedstoneFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions, "shown", "hidden")' displayGroup='groupVanilla'>
+        <Description> Frequency multiplier for Vanilla Mountain Redstone distributions </Description>
+        <DisplayName>Vanilla Mountain Redstone Freq.</DisplayName>
       </OptionNumeric>
-      <OptionNumeric name='vnlaMountainRedstoneSize' default='1'  min='0' max='5' displayState=':= if(?advOptions, "shown", "hidden")' displayGroup='groupVanillaMinecraft'>
-        <Description> Size multiplier for Vanilla Minecraft Mountain Redstone distributions </Description>
-        <DisplayName>Vanilla Minecraft Mountain Redstone Size</DisplayName>
+      <OptionNumeric name='vnlaMountainRedstoneSize' default='1'  min='0' max='5' displayState=':= if(?advOptions, "shown", "hidden")' displayGroup='groupVanilla'>
+        <Description> Size multiplier for Vanilla Mountain Redstone distributions </Description>
+        <DisplayName>Vanilla Mountain Redstone Size</DisplayName>
       </OptionNumeric>
     </ConfigSection>
     <!-- Mountain Redstone Configuration UI Complete -->
@@ -379,9 +379,9 @@
 
     <!-- Diamond Configuration UI Starting -->
     <ConfigSection>
-      <OptionChoice name='vnlaDiamondDist'  displayState=':= "shown"' displayGroup='groupVanillaMinecraft'>
+      <OptionChoice name='vnlaDiamondDist'  displayState=':= "shown"' displayGroup='groupVanilla'>
         <Description> Controls how Diamond is generated </Description>
-        <DisplayName>Vanilla Minecraft Diamond</DisplayName>
+        <DisplayName>Vanilla Diamond</DisplayName>
         <IfCondition condition=':= (?blockExists("minecraft:diamond_ore")) &amp; (?blockExists("minecraft:lava")) '>
 
         <Choice value='PipeVeins' displayValue='Pipe Veins'>
@@ -411,13 +411,13 @@
 
         <Choice value='none' displayValue='None' description='Diamond is not generated in the world.'/>
       </OptionChoice>
-      <OptionNumeric name='vnlaDiamondFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions, "shown", "hidden")' displayGroup='groupVanillaMinecraft'>
-        <Description> Frequency multiplier for Vanilla Minecraft Diamond distributions </Description>
-        <DisplayName>Vanilla Minecraft Diamond Freq.</DisplayName>
+      <OptionNumeric name='vnlaDiamondFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions, "shown", "hidden")' displayGroup='groupVanilla'>
+        <Description> Frequency multiplier for Vanilla Diamond distributions </Description>
+        <DisplayName>Vanilla Diamond Freq.</DisplayName>
       </OptionNumeric>
-      <OptionNumeric name='vnlaDiamondSize' default='1'  min='0' max='5' displayState=':= if(?advOptions, "shown", "hidden")' displayGroup='groupVanillaMinecraft'>
-        <Description> Size multiplier for Vanilla Minecraft Diamond distributions </Description>
-        <DisplayName>Vanilla Minecraft Diamond Size</DisplayName>
+      <OptionNumeric name='vnlaDiamondSize' default='1'  min='0' max='5' displayState=':= if(?advOptions, "shown", "hidden")' displayGroup='groupVanilla'>
+        <Description> Size multiplier for Vanilla Diamond distributions </Description>
+        <DisplayName>Vanilla Diamond Size</DisplayName>
       </OptionNumeric>
     </ConfigSection>
     <!-- Diamond Configuration UI Complete -->
@@ -425,9 +425,9 @@
 
     <!-- Lapis Lazuli Configuration UI Starting -->
     <ConfigSection>
-      <OptionChoice name='vnlaLapisLazuliDist'  displayState=':= "shown"' displayGroup='groupVanillaMinecraft'>
+      <OptionChoice name='vnlaLapisLazuliDist'  displayState=':= "shown"' displayGroup='groupVanilla'>
         <Description> Controls how Lapis Lazuli is generated </Description>
-        <DisplayName>Vanilla Minecraft Lapis Lazuli</DisplayName>
+        <DisplayName>Vanilla Lapis Lazuli</DisplayName>
         <IfCondition condition=':= (?blockExists("minecraft:lapis_ore")) '>
 
         <Choice value='VerticalVeins' displayValue='Vertical Veins'>
@@ -457,13 +457,13 @@
 
         <Choice value='none' displayValue='None' description='Lapis Lazuli is not generated in the world.'/>
       </OptionChoice>
-      <OptionNumeric name='vnlaLapisLazuliFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions, "shown", "hidden")' displayGroup='groupVanillaMinecraft'>
-        <Description> Frequency multiplier for Vanilla Minecraft Lapis Lazuli distributions </Description>
-        <DisplayName>Vanilla Minecraft Lapis Lazuli Freq.</DisplayName>
+      <OptionNumeric name='vnlaLapisLazuliFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions, "shown", "hidden")' displayGroup='groupVanilla'>
+        <Description> Frequency multiplier for Vanilla Lapis Lazuli distributions </Description>
+        <DisplayName>Vanilla Lapis Lazuli Freq.</DisplayName>
       </OptionNumeric>
-      <OptionNumeric name='vnlaLapisLazuliSize' default='1'  min='0' max='5' displayState=':= if(?advOptions, "shown", "hidden")' displayGroup='groupVanillaMinecraft'>
-        <Description> Size multiplier for Vanilla Minecraft Lapis Lazuli distributions </Description>
-        <DisplayName>Vanilla Minecraft Lapis Lazuli Size</DisplayName>
+      <OptionNumeric name='vnlaLapisLazuliSize' default='1'  min='0' max='5' displayState=':= if(?advOptions, "shown", "hidden")' displayGroup='groupVanilla'>
+        <Description> Size multiplier for Vanilla Lapis Lazuli distributions </Description>
+        <DisplayName>Vanilla Lapis Lazuli Size</DisplayName>
       </OptionNumeric>
     </ConfigSection>
     <!-- Lapis Lazuli Configuration UI Complete -->
@@ -471,9 +471,9 @@
 
     <!-- Mountain Lapis Lazuli Configuration UI Starting -->
     <ConfigSection>
-      <OptionChoice name='vnlaMountainLapisLazuliDist'  displayState=':= "shown"' displayGroup='groupVanillaMinecraft'>
+      <OptionChoice name='vnlaMountainLapisLazuliDist'  displayState=':= "shown"' displayGroup='groupVanilla'>
         <Description> Controls how Mountain Lapis Lazuli is generated </Description>
-        <DisplayName>Vanilla Minecraft Mountain Lapis Lazuli</DisplayName>
+        <DisplayName>Vanilla Mountain Lapis Lazuli</DisplayName>
         <IfCondition condition=':= (?blockExists("minecraft:lapis_ore")) '>
 
         <Choice value='VerticalVeins' displayValue='Vertical Veins'>
@@ -503,13 +503,13 @@
 
         <Choice value='none' displayValue='None' description='Mountain Lapis Lazuli is not generated in the world.'/>
       </OptionChoice>
-      <OptionNumeric name='vnlaMountainLapisLazuliFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions, "shown", "hidden")' displayGroup='groupVanillaMinecraft'>
-        <Description> Frequency multiplier for Vanilla Minecraft Mountain Lapis Lazuli distributions </Description>
-        <DisplayName>Vanilla Minecraft Mountain Lapis Lazuli Freq.</DisplayName>
+      <OptionNumeric name='vnlaMountainLapisLazuliFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions, "shown", "hidden")' displayGroup='groupVanilla'>
+        <Description> Frequency multiplier for Vanilla Mountain Lapis Lazuli distributions </Description>
+        <DisplayName>Vanilla Mountain Lapis Lazuli Freq.</DisplayName>
       </OptionNumeric>
-      <OptionNumeric name='vnlaMountainLapisLazuliSize' default='1'  min='0' max='5' displayState=':= if(?advOptions, "shown", "hidden")' displayGroup='groupVanillaMinecraft'>
-        <Description> Size multiplier for Vanilla Minecraft Mountain Lapis Lazuli distributions </Description>
-        <DisplayName>Vanilla Minecraft Mountain Lapis Lazuli Size</DisplayName>
+      <OptionNumeric name='vnlaMountainLapisLazuliSize' default='1'  min='0' max='5' displayState=':= if(?advOptions, "shown", "hidden")' displayGroup='groupVanilla'>
+        <Description> Size multiplier for Vanilla Mountain Lapis Lazuli distributions </Description>
+        <DisplayName>Vanilla Mountain Lapis Lazuli Size</DisplayName>
       </OptionNumeric>
     </ConfigSection>
     <!-- Mountain Lapis Lazuli Configuration UI Complete -->
@@ -517,9 +517,9 @@
 
     <!-- Emerald Configuration UI Starting -->
     <ConfigSection>
-      <OptionChoice name='vnlaEmeraldDist'  displayState=':= "shown"' displayGroup='groupVanillaMinecraft'>
+      <OptionChoice name='vnlaEmeraldDist'  displayState=':= "shown"' displayGroup='groupVanilla'>
         <Description> Controls how Emerald is generated </Description>
-        <DisplayName>Vanilla Minecraft Emerald</DisplayName>
+        <DisplayName>Vanilla Emerald</DisplayName>
         <IfCondition condition=':= (?blockExists("minecraft:emerald_ore")) &amp; (?blockExists("minecraft:monster_egg")) '>
 
         <Choice value='PipeVeins' displayValue='Pipe Veins'>
@@ -549,13 +549,13 @@
 
         <Choice value='none' displayValue='None' description='Emerald is not generated in the world.'/>
       </OptionChoice>
-      <OptionNumeric name='vnlaEmeraldFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions, "shown", "hidden")' displayGroup='groupVanillaMinecraft'>
-        <Description> Frequency multiplier for Vanilla Minecraft Emerald distributions </Description>
-        <DisplayName>Vanilla Minecraft Emerald Freq.</DisplayName>
+      <OptionNumeric name='vnlaEmeraldFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions, "shown", "hidden")' displayGroup='groupVanilla'>
+        <Description> Frequency multiplier for Vanilla Emerald distributions </Description>
+        <DisplayName>Vanilla Emerald Freq.</DisplayName>
       </OptionNumeric>
-      <OptionNumeric name='vnlaEmeraldSize' default='1'  min='0' max='5' displayState=':= if(?advOptions, "shown", "hidden")' displayGroup='groupVanillaMinecraft'>
-        <Description> Size multiplier for Vanilla Minecraft Emerald distributions </Description>
-        <DisplayName>Vanilla Minecraft Emerald Size</DisplayName>
+      <OptionNumeric name='vnlaEmeraldSize' default='1'  min='0' max='5' displayState=':= if(?advOptions, "shown", "hidden")' displayGroup='groupVanilla'>
+        <Description> Size multiplier for Vanilla Emerald distributions </Description>
+        <DisplayName>Vanilla Emerald Size</DisplayName>
       </OptionNumeric>
     </ConfigSection>
     <!-- Emerald Configuration UI Complete -->
@@ -563,9 +563,9 @@
 
     <!-- Nether Quartz Configuration UI Starting -->
     <ConfigSection>
-      <OptionChoice name='vnlaNetherQuartzDist'  displayState=':= "shown"' displayGroup='groupVanillaMinecraft'>
+      <OptionChoice name='vnlaNetherQuartzDist'  displayState=':= "shown"' displayGroup='groupVanilla'>
         <Description> Controls how Nether Quartz is generated </Description>
-        <DisplayName>Vanilla Minecraft Nether Quartz</DisplayName>
+        <DisplayName>Vanilla Nether Quartz</DisplayName>
         <IfCondition condition=':= (?blockExists("minecraft:quartz_ore")) '>
 
         <Choice value='SparseVeins' displayValue='Sparse Veins'>
@@ -595,13 +595,13 @@
 
         <Choice value='none' displayValue='None' description='Nether Quartz is not generated in the world.'/>
       </OptionChoice>
-      <OptionNumeric name='vnlaNetherQuartzFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions, "shown", "hidden")' displayGroup='groupVanillaMinecraft'>
-        <Description> Frequency multiplier for Vanilla Minecraft Nether Quartz distributions </Description>
-        <DisplayName>Vanilla Minecraft Nether Quartz Freq.</DisplayName>
+      <OptionNumeric name='vnlaNetherQuartzFreq' default='1'  min='0' max='5' displayState=':= if(?advOptions, "shown", "hidden")' displayGroup='groupVanilla'>
+        <Description> Frequency multiplier for Vanilla Nether Quartz distributions </Description>
+        <DisplayName>Vanilla Nether Quartz Freq.</DisplayName>
       </OptionNumeric>
-      <OptionNumeric name='vnlaNetherQuartzSize' default='1'  min='0' max='5' displayState=':= if(?advOptions, "shown", "hidden")' displayGroup='groupVanillaMinecraft'>
-        <Description> Size multiplier for Vanilla Minecraft Nether Quartz distributions </Description>
-        <DisplayName>Vanilla Minecraft Nether Quartz Size</DisplayName>
+      <OptionNumeric name='vnlaNetherQuartzSize' default='1'  min='0' max='5' displayState=':= if(?advOptions, "shown", "hidden")' displayGroup='groupVanilla'>
+        <Description> Size multiplier for Vanilla Nether Quartz distributions </Description>
+        <DisplayName>Vanilla Nether Quartz Size</DisplayName>
       </OptionNumeric>
     </ConfigSection>
     <!-- Nether Quartz Configuration UI Complete -->


### PR DESCRIPTION
All instances of "Vanilla Minecraft" or "VanillaMinecraft" have been replaced with "Vanilla".