### PR TITLE
Removed extra space after dimension code.

### DIFF
--- a/src/main/resources/config/modules/AppliedEnergistics.xml
+++ b/src/main/resources/config/modules/AppliedEnergistics.xml
@@ -414,22 +414,6 @@
       </IfCondition>
       <!-- Overworld Setup Complete -->
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
     </IfCondition>
 
   </ConfigSection>

--- a/src/main/resources/config/modules/ArsMagica2.xml
+++ b/src/main/resources/config/modules/ArsMagica2.xml
@@ -1057,22 +1057,6 @@
       </IfCondition>
       <!-- Overworld Setup Complete -->
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
     </IfCondition>
 
   </ConfigSection>

--- a/src/main/resources/config/modules/BiomesOPlenty.xml
+++ b/src/main/resources/config/modules/BiomesOPlenty.xml
@@ -1340,7 +1340,6 @@
 
 
 
-
       <!-- End Setup Beginning -->
 
       <IfCondition condition=':= dimension.generator.class = "ChunkProviderEnd"'>
@@ -1491,20 +1490,6 @@
 
       </IfCondition>
       <!-- End Setup Complete -->
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
     </IfCondition>
 

--- a/src/main/resources/config/modules/Chisel2.xml
+++ b/src/main/resources/config/modules/Chisel2.xml
@@ -734,22 +734,6 @@
       </IfCondition>
       <!-- Overworld Setup Complete -->
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
     </IfCondition>
 
   </ConfigSection>

--- a/src/main/resources/config/modules/DenseOres.xml
+++ b/src/main/resources/config/modules/DenseOres.xml
@@ -2099,21 +2099,6 @@
       </IfCondition>
       <!-- Nether Setup Complete -->
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
     </IfCondition>
 
   </ConfigSection>

--- a/src/main/resources/config/modules/ElectriCraft.xml
+++ b/src/main/resources/config/modules/ElectriCraft.xml
@@ -1821,22 +1821,6 @@
       </IfCondition>
       <!-- Overworld Setup Complete -->
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
     </IfCondition>
 
   </ConfigSection>

--- a/src/main/resources/config/modules/EtFuturum.xml
+++ b/src/main/resources/config/modules/EtFuturum.xml
@@ -863,22 +863,6 @@
       </IfCondition>
       <!-- Overworld Setup Complete -->
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
     </IfCondition>
 
   </ConfigSection>

--- a/src/main/resources/config/modules/Factorization.xml
+++ b/src/main/resources/config/modules/Factorization.xml
@@ -554,22 +554,6 @@
       </IfCondition>
       <!-- Overworld Setup Complete -->
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
     </IfCondition>
 
   </ConfigSection>

--- a/src/main/resources/config/modules/FlaxbeardsSteamcraft.xml
+++ b/src/main/resources/config/modules/FlaxbeardsSteamcraft.xml
@@ -708,22 +708,6 @@
       </IfCondition>
       <!-- Overworld Setup Complete -->
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
     </IfCondition>
 
   </ConfigSection>

--- a/src/main/resources/config/modules/Forestry.xml
+++ b/src/main/resources/config/modules/Forestry.xml
@@ -555,22 +555,6 @@
       </IfCondition>
       <!-- Overworld Setup Complete -->
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
     </IfCondition>
 
   </ConfigSection>

--- a/src/main/resources/config/modules/FossilsandArchaeology.xml
+++ b/src/main/resources/config/modules/FossilsandArchaeology.xml
@@ -469,22 +469,6 @@
       </IfCondition>
       <!-- Overworld Setup Complete -->
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
     </IfCondition>
 
   </ConfigSection>

--- a/src/main/resources/config/modules/Galacticraft.xml
+++ b/src/main/resources/config/modules/Galacticraft.xml
@@ -1344,22 +1344,6 @@
       </IfCondition>
       <!-- Overworld Setup Complete -->
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
     </IfCondition>
 
   </ConfigSection>

--- a/src/main/resources/config/modules/GeoStrata.xml
+++ b/src/main/resources/config/modules/GeoStrata.xml
@@ -4158,22 +4158,6 @@
       </IfCondition>
       <!-- Overworld Setup Complete -->
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
     </IfCondition>
 
   </ConfigSection>

--- a/src/main/resources/config/modules/ImmersiveEngineering.xml
+++ b/src/main/resources/config/modules/ImmersiveEngineering.xml
@@ -1660,22 +1660,6 @@
       </IfCondition>
       <!-- Overworld Setup Complete -->
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
     </IfCondition>
 
   </ConfigSection>

--- a/src/main/resources/config/modules/IndustrialCraft2.xml
+++ b/src/main/resources/config/modules/IndustrialCraft2.xml
@@ -1351,22 +1351,6 @@
       </IfCondition>
       <!-- Overworld Setup Complete -->
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
     </IfCondition>
 
   </ConfigSection>

--- a/src/main/resources/config/modules/MagnetiCraft.xml
+++ b/src/main/resources/config/modules/MagnetiCraft.xml
@@ -2440,22 +2440,6 @@
       </IfCondition>
       <!-- Overworld Setup Complete -->
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
     </IfCondition>
 
   </ConfigSection>

--- a/src/main/resources/config/modules/Mariculture.xml
+++ b/src/main/resources/config/modules/Mariculture.xml
@@ -548,22 +548,6 @@
       </IfCondition>
       <!-- Overworld Setup Complete -->
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
     </IfCondition>
 
   </ConfigSection>

--- a/src/main/resources/config/modules/Mekanism.xml
+++ b/src/main/resources/config/modules/Mekanism.xml
@@ -1024,22 +1024,6 @@
       </IfCondition>
       <!-- Overworld Setup Complete -->
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
     </IfCondition>
 
   </ConfigSection>

--- a/src/main/resources/config/modules/Metallurgy4.xml
+++ b/src/main/resources/config/modules/Metallurgy4.xml
@@ -5739,20 +5739,6 @@
       </IfCondition>
       <!-- End Setup Complete -->
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
     </IfCondition>
 
   </ConfigSection>

--- a/src/main/resources/config/modules/Mimicry.xml
+++ b/src/main/resources/config/modules/Mimicry.xml
@@ -793,20 +793,6 @@
       </IfCondition>
       <!-- End Setup Complete -->
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
     </IfCondition>
 
   </ConfigSection>

--- a/src/main/resources/config/modules/MineChem.xml
+++ b/src/main/resources/config/modules/MineChem.xml
@@ -390,22 +390,6 @@
       </IfCondition>
       <!-- Overworld Setup Complete -->
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
     </IfCondition>
 
   </ConfigSection>

--- a/src/main/resources/config/modules/MinecraftComesAlive.xml
+++ b/src/main/resources/config/modules/MinecraftComesAlive.xml
@@ -393,22 +393,6 @@
       </IfCondition>
       <!-- Overworld Setup Complete -->
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
     </IfCondition>
 
   </ConfigSection>

--- a/src/main/resources/config/modules/NetherOres.xml
+++ b/src/main/resources/config/modules/NetherOres.xml
@@ -1521,7 +1521,6 @@
 
 
 
-
       <!-- Nether Setup Beginning -->
 
       <IfCondition condition=':= dimension.generator.class = "ChunkProviderHell"'>
@@ -5252,21 +5251,6 @@
 
       </IfCondition>
       <!-- Nether Setup Complete -->
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
     </IfCondition>
 

--- a/src/main/resources/config/modules/Netherrocks.xml
+++ b/src/main/resources/config/modules/Netherrocks.xml
@@ -304,7 +304,6 @@
 
 
 
-
       <!-- Nether Setup Beginning -->
 
       <IfCondition condition=':= dimension.generator.class = "ChunkProviderHell"'>
@@ -937,21 +936,6 @@
 
       </IfCondition>
       <!-- Nether Setup Complete -->
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
     </IfCondition>
 

--- a/src/main/resources/config/modules/Nuclearcraft.xml
+++ b/src/main/resources/config/modules/Nuclearcraft.xml
@@ -2847,21 +2847,6 @@
       </IfCondition>
       <!-- Nether Setup Complete -->
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
     </IfCondition>
 
   </ConfigSection>

--- a/src/main/resources/config/modules/PamsHarvestCraft.xml
+++ b/src/main/resources/config/modules/PamsHarvestCraft.xml
@@ -238,22 +238,6 @@
       </IfCondition>
       <!-- Overworld Setup Complete -->
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
     </IfCondition>
 
   </ConfigSection>

--- a/src/main/resources/config/modules/ProjectRed.xml
+++ b/src/main/resources/config/modules/ProjectRed.xml
@@ -2114,22 +2114,6 @@
       </IfCondition>
       <!-- Overworld Setup Complete -->
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
     </IfCondition>
 
   </ConfigSection>

--- a/src/main/resources/config/modules/RailCraft.xml
+++ b/src/main/resources/config/modules/RailCraft.xml
@@ -2372,21 +2372,6 @@
       </IfCondition>
       <!-- Nether Setup Complete -->
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
     </IfCondition>
 
   </ConfigSection>

--- a/src/main/resources/config/modules/ReactorCraft.xml
+++ b/src/main/resources/config/modules/ReactorCraft.xml
@@ -4817,20 +4817,6 @@
       </IfCondition>
       <!-- End Setup Complete -->
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
     </IfCondition>
 
   </ConfigSection>

--- a/src/main/resources/config/modules/SimpleOres.xml
+++ b/src/main/resources/config/modules/SimpleOres.xml
@@ -1544,21 +1544,6 @@
       </IfCondition>
       <!-- Nether Setup Complete -->
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
     </IfCondition>
 
   </ConfigSection>

--- a/src/main/resources/config/modules/Thaumcraft4.xml
+++ b/src/main/resources/config/modules/Thaumcraft4.xml
@@ -2127,22 +2127,6 @@
       </IfCondition>
       <!-- Overworld Setup Complete -->
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
     </IfCondition>
 
   </ConfigSection>

--- a/src/main/resources/config/modules/ThermalFoundation.xml
+++ b/src/main/resources/config/modules/ThermalFoundation.xml
@@ -1820,22 +1820,6 @@
       </IfCondition>
       <!-- Overworld Setup Complete -->
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
     </IfCondition>
 
   </ConfigSection>

--- a/src/main/resources/config/modules/TinkersConstruct.xml
+++ b/src/main/resources/config/modules/TinkersConstruct.xml
@@ -3007,21 +3007,6 @@
       </IfCondition>
       <!-- Nether Setup Complete -->
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
     </IfCondition>
 
   </ConfigSection>

--- a/src/main/resources/config/modules/TinkersSteelworks.xml
+++ b/src/main/resources/config/modules/TinkersSteelworks.xml
@@ -336,22 +336,6 @@
       </IfCondition>
       <!-- Overworld Setup Complete -->
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
     </IfCondition>
 
   </ConfigSection>

--- a/src/main/resources/config/modules/Vanilla.xml
+++ b/src/main/resources/config/modules/Vanilla.xml
@@ -2114,21 +2114,6 @@
   <!-- Nether Setup Complete -->
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 </ConfigSection>
 <!-- Configuration for Custom Ore Generation Complete! -->
 


### PR DESCRIPTION
I figured out the [derp](https://github.com/reteo/Sprocket/commit/7b5cf6d9fe943c851d6b7042e53f421605e8afda) that caused all that extra space in the configurations and fixed it.  These have no changes, except that all the extra space is gone.  There's still a larger-than-average space between major sections, but that's by design for readability.

Oh, and it's a total of 19 dimensions, not 16.  21, if you count the three dimensions as part of COGActive.