### PR TITLE
Update Vanilla.xml

### DIFF
--- a/src/main/resources/config/modules/Vanilla.xml
+++ b/src/main/resources/config/modules/Vanilla.xml
@@ -693,9 +693,9 @@
             <Replaces block='minecraft:gravel' weight='1.0' />
             <Replaces block='minecraft:dirt' weight='1.0' />
             <Biome name='.*'  />
-            <Biome name='Ocean'  weight='-1' />
-            <Biome name='Desert'  weight='-1' />
-            <Biome name='Mountain'  weight='-1' />
+            <Biome name='.*Ocean.*'  weight='-1' />
+            <Biome name='.*Desert.*'  weight='-1' />
+            <Biome name='.*Mountain.*'  weight='-1' />
             <Setting name='MotherlodeFrequency' avg=':= 1.252 * _default_ * vnlaClayFreq ' range=':= 1.252 * _default_ * vnlaClayFreq ' type='normal' scaleTo='base' />
             <Setting name='MotherlodeSize' avg=':= 1.648 * _default_ * vnlaClaySize ' range=':= 1.648 * _default_ * vnlaClaySize ' type='normal' />
             <Setting name='MotherlodeHeight' avg=':= 64 ' range=':= 10 ' type='uniform' scaleTo='seaLevel' />
@@ -726,9 +726,9 @@
             <BiomeType name='Swamp'  />
             <BiomeType name='Beach'  />
             <BiomeType name='River'  />
-            <Biome name='Ocean'  weight='-1' />
-            <Biome name='Desert'  weight='-1' />
-            <Biome name='Mountain'  weight='-1' />
+            <Biome name='.*Ocean.*'  weight='-1' />
+            <Biome name='.*Desert.*'  weight='-1' />
+            <Biome name='.*Mountain.*'  weight='-1' />
             <Setting name='MotherlodeFrequency' avg=':= 1.252 * _default_ * vnlaClayFreq ' range=':= 1.252 * _default_ * vnlaClayFreq ' type='normal' scaleTo='base' />
             <Setting name='MotherlodeSize' avg=':= 1.648 * _default_ * vnlaClaySize ' range=':= 1.648 * _default_ * vnlaClaySize ' type='normal' />
             <Setting name='MotherlodeHeight' avg=':= 64 ' range=':= 10 ' type='uniform' scaleTo='seaLevel' />


### PR DESCRIPTION
Wildcard biome names for clay distribution, otherwise it generates in Desert *Hills* and *Deep* Ocean, which it probably shouldn't.  May also wish to consider removing Extreme Hills (and mutants) as well as vanilla does not have a biome named "mountain."