### PR TITLE
Add 'Touches' placement restriction for configuration

### DIFF
--- a/src/main/java/CustomOreGen/Config/ValidatorTouchingDescriptor.java
+++ b/src/main/java/CustomOreGen/Config/ValidatorTouchingDescriptor.java
@@ -1,0 +1,72 @@
+package CustomOreGen.Config;
+
+import org.w3c.dom.Node;
+
+import CustomOreGen.Util.TouchingDescriptor.TouchingContactType;
+import CustomOreGen.Util.TouchingDescriptor.TouchingDirection;
+import CustomOreGen.Util.TouchingDescriptor.TouchingVolume;
+
+public class ValidatorTouchingDescriptor extends ValidatorBlockDescriptor {
+    private final int MINIMUM_POSSIBLE_TOUCHES = 0;
+    // 3x3x3 cube surrounding block
+    private final int MAXIMUM_POSSIBLE_TOUCHES = (3 * 3 * 3) - 1;
+
+    private final int DEFAULT_MINIMUM_TOUCHES = 1;
+    // default to the maximum otherwise user might create a touching rule and it will be missing some touches 
+    private final int DEFAULT_MAXIMUM_TOUCHES = MAXIMUM_POSSIBLE_TOUCHES;
+    
+    private final TouchingVolume DEFAULT_VOLUME = TouchingVolume.Any;
+    private final TouchingContactType DEFAULT_CONTACT_TYPE = TouchingContactType.Face;
+    private final TouchingDirection DEFAULT_DIRECTION = TouchingDirection.Any;
+    private final boolean DEFAULT_MANDATORY = false;
+    private final boolean DEFAULT_NEGATE = false;
+
+    public int minimumTouches = DEFAULT_MINIMUM_TOUCHES;
+    public int maximumTouches = DEFAULT_MAXIMUM_TOUCHES;
+    public TouchingVolume volume = DEFAULT_VOLUME;
+    public TouchingContactType contactType = DEFAULT_CONTACT_TYPE;
+    public TouchingDirection direction = DEFAULT_DIRECTION;
+    public boolean mandatory = DEFAULT_MANDATORY;
+    public boolean negate = DEFAULT_NEGATE;
+
+    protected ValidatorTouchingDescriptor(ValidatorNode parent, Node node) {
+        super(parent, node);
+    }
+
+    @Override
+    protected boolean validateChildren() throws ParserException {
+        this.minimumTouches = this.validateNamedAttribute(Integer.class, "minimumTouches", DEFAULT_MINIMUM_TOUCHES,
+                true);
+        if (this.minimumTouches < MINIMUM_POSSIBLE_TOUCHES || this.minimumTouches > MAXIMUM_POSSIBLE_TOUCHES) {
+            throw new ParserException("'minimumTouches' must be between " + Integer.toString(MINIMUM_POSSIBLE_TOUCHES) + " and "
+                    + Integer.toString(MAXIMUM_POSSIBLE_TOUCHES) + " inclusive.", this.getNode());
+        }
+
+        this.maximumTouches = this.validateNamedAttribute(Integer.class, "maximumTouches", DEFAULT_MAXIMUM_TOUCHES,
+                true);
+        if (this.maximumTouches < MINIMUM_POSSIBLE_TOUCHES || this.maximumTouches > MAXIMUM_POSSIBLE_TOUCHES) {
+            throw new ParserException("'maximumTouches' must be between " + Integer.toString(MINIMUM_POSSIBLE_TOUCHES) + " and "
+                    + Integer.toString(MAXIMUM_POSSIBLE_TOUCHES) + " inclusive.", this.getNode());
+        }
+
+        if (this.minimumTouches > this.maximumTouches) {
+            throw new ParserException("'minimumTouches' must be less than or equal to 'maximumTouches'.",
+                    this.getNode());
+        }
+
+        this.volume = this.validateNamedAttribute(TouchingVolume.class, "volume", DEFAULT_VOLUME, true);
+        this.contactType = this.validateNamedAttribute(TouchingContactType.class, "contactType", DEFAULT_CONTACT_TYPE, true);
+        this.direction = this.validateNamedAttribute(TouchingDirection.class, "direction", DEFAULT_DIRECTION, true);
+
+        this.mandatory = this.validateNamedAttribute(Boolean.class, "mandatory", this.mandatory, true);
+        this.negate = this.validateNamedAttribute(Boolean.class, "negate", this.negate, true);
+
+        return super.validateChildren();
+    }
+
+    public static class Factory implements IValidatorFactory<ValidatorTouchingDescriptor> {
+        public ValidatorTouchingDescriptor createValidator(ValidatorNode parent, Node node) {
+            return new ValidatorTouchingDescriptor(parent, node);
+        }
+    }
+}

--- a/src/main/java/CustomOreGen/Server/IOreDistribution.java
+++ b/src/main/java/CustomOreGen/Server/IOreDistribution.java
@@ -43,6 +43,7 @@ public interface IOreDistribution
         PlacesAbove,
         PlacesBelow,
         PlacesBeside,
+        Touches,
         TargetBiome,
         Parent;
     }

--- a/src/main/java/CustomOreGen/Server/MapGenOreDistribution.java
+++ b/src/main/java/CustomOreGen/Server/MapGenOreDistribution.java
@@ -17,6 +17,7 @@ import CustomOreGen.Util.IGeometryBuilder;
 import CustomOreGen.Util.PDist;
 import CustomOreGen.Util.PDist.Type;
 import CustomOreGen.Util.TileEntityHelper;
+import CustomOreGen.Util.TouchingDescriptorList;
 import CustomOreGen.Util.Transform;
 import CustomOreGen.Util.WireframeShapes;
 import net.minecraft.init.Blocks;
@@ -85,7 +86,13 @@ public abstract class MapGenOreDistribution extends MapGenStructure implements I
             info = "List of blocks allowed beside generated block"
     )
     public final BlockDescriptor besideBlocks;
-    
+
+    @DistributionSetting(
+            name = "Touches",
+            info = "List of blocks allowed to neighbor the generated block"
+    )
+    public final TouchingDescriptorList touchingBlocks;
+
     @DistributionSetting(
             name = "TargetBiome",
             info = "List of valid target biomes"
@@ -194,6 +201,7 @@ public abstract class MapGenOreDistribution extends MapGenStructure implements I
         this.aboveBlocks = new BlockDescriptor();
         this.belowBlocks = new BlockDescriptor();
         this.besideBlocks = new BlockDescriptor();
+        this.touchingBlocks = new TouchingDescriptorList();
         this.biomes = new BiomeDescriptor(".*");
         this.frequency = new HeightScaledPDist(0.025F, 0.0F);
         this.parent = null;
@@ -805,7 +813,8 @@ public abstract class MapGenOreDistribution extends MapGenStructure implements I
             }
             else
             {
-                BlockArrangement arrangement = new BlockArrangement(replaceableBlocks, aboveBlocks, belowBlocks, besideBlocks);
+                BlockArrangement arrangement = new BlockArrangement(replaceableBlocks, aboveBlocks, belowBlocks,
+                        besideBlocks, touchingBlocks);
                 boolean matched = arrangement.matchesAt(world, random, pos);
                 if (matched)
                 {

--- a/src/main/java/CustomOreGen/Server/WorldGenSubstitution.java
+++ b/src/main/java/CustomOreGen/Server/WorldGenSubstitution.java
@@ -10,6 +10,7 @@ import CustomOreGen.Util.BlockDescriptor;
 import CustomOreGen.Util.BlockDescriptor.BlockInfo;
 import CustomOreGen.Util.GeometryStream;
 import CustomOreGen.Util.TileEntityHelper;
+import CustomOreGen.Util.TouchingDescriptorList;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.init.Blocks;
@@ -71,7 +72,13 @@ public class WorldGenSubstitution extends WorldGenerator implements IOreDistribu
             info = "List of blocks allowed beside generated block"
     )
     public final BlockDescriptor besideBlocks;
-    
+
+    @DistributionSetting(
+            name = "Touches",
+            info = "List of blocks allowed to neighbor the generated block"
+    )
+    public final TouchingDescriptorList touchingBlocks;
+
     @DistributionSetting(
             name = "TargetBiome",
             info = "List of valid target biomes"
@@ -131,6 +138,7 @@ public class WorldGenSubstitution extends WorldGenerator implements IOreDistribu
         this.aboveBlocks = new BlockDescriptor();
         this.belowBlocks = new BlockDescriptor();
         this.besideBlocks = new BlockDescriptor();
+        this.touchingBlocks = new TouchingDescriptorList();
         this.biomes = new BiomeDescriptor(".*");
         this.additionalRange = 0;
         this.minHeight = Integer.MIN_VALUE;
@@ -264,7 +272,8 @@ public class WorldGenSubstitution extends WorldGenerator implements IOreDistribu
             int hRange = (this.additionalRange + 7) / 8;
             int minh = Math.max(0, this.minHeight);
             int maxh = Math.min(world.getHeight() - 1, this.maxHeight);
-            BlockArrangement arrangement = new BlockArrangement(replaceableBlocks, aboveBlocks, belowBlocks, besideBlocks);
+            BlockArrangement arrangement = new BlockArrangement(replaceableBlocks, aboveBlocks, belowBlocks,
+                    besideBlocks, touchingBlocks);
 
             for (int dCX = -cRange; dCX <= cRange; ++dCX)
             {

--- a/src/main/java/CustomOreGen/Util/BlockArrangement.java
+++ b/src/main/java/CustomOreGen/Util/BlockArrangement.java
@@ -7,55 +7,121 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
 public class BlockArrangement {
-	private BlockDescriptor center, above, below, beside;
+    private BlockDescriptor center, above, below, beside;
+    private TouchingDescriptorList touching;
 
-	public BlockArrangement(BlockDescriptor center, BlockDescriptor above,
-			BlockDescriptor below, BlockDescriptor beside) {
-		super();
-		this.center = center;
-		this.above = above;
-		this.below = below;
-		this.beside = beside;
-	}
-	
-	public boolean matchesAt(World world, Random rand, BlockPos pos) {
-		return 
-			this.descriptorMatchesAt(center, world, rand, pos) &&
-			this.descriptorMatchesAt(above, world, rand, pos.up()) &&
-			this.descriptorMatchesAt(below, world, rand, pos.down()) && 
-			(this.descriptorMatchesAt(beside, world, rand, pos.east()) ||
-			 this.descriptorMatchesAt(beside, world, rand, pos.south()) ||
-			 this.descriptorMatchesAt(beside, world, rand, pos.west()) ||
-			 this.descriptorMatchesAt(beside, world, rand, pos.north()));
-	}
+    public BlockArrangement(BlockDescriptor center, BlockDescriptor above, BlockDescriptor below,
+            BlockDescriptor beside, TouchingDescriptorList touching) {
+        super();
+        this.center = center;
+        this.above = above;
+        this.below = below;
+        this.beside = beside;
+        this.touching = touching;
+    }
 
-	private boolean descriptorMatchesAt(BlockDescriptor descriptor, World world,
-			Random rand, BlockPos pos) {
-		if (descriptor.isEmpty()) {
-			return true;
-		}
-		IBlockState blockState = world.getBlockState(pos);
-		int fastCheck = descriptor.matchesBlock_fast(blockState);
-		if (fastCheck == -1) {
-			return descriptor.matchesBlock(blockState, rand);
-		}
-		return fastCheck == 1;
-	}
-	
-	public BlockDescriptor getCenter() {
-		return center;
-	}
+    public boolean matchesAt(World world, Random rand, BlockPos pos) {
+        return 
+            this.descriptorMatchesAt(center, world, rand, pos) &&
+            this.descriptorMatchesAt(above, world, rand, pos.up()) &&
+            this.descriptorMatchesAt(below, world, rand, pos.down()) && 
+            
+            (this.descriptorMatchesAt(beside, world, rand, pos.north()) ||
+            this.descriptorMatchesAt(beside, world, rand, pos.east()) ||
+            this.descriptorMatchesAt(beside, world, rand, pos.south()) ||
+            this.descriptorMatchesAt(beside, world, rand, pos.west())) &&
+            
+            this.touchesAt(world, rand, pos);
+    }
 
-	public BlockDescriptor getAbove() {
-		return above;
-	}
+    private boolean descriptorMatchesAt(BlockDescriptor descriptor, World world, Random rand, BlockPos pos) {
+        if (descriptor.isEmpty()) {
+            return true;
+        }
+        IBlockState blockState = world.getBlockState(pos);
+        int fastCheck = descriptor.matchesBlock_fast(blockState);
+        if (fastCheck == -1) {
+            return descriptor.matchesBlock(blockState, rand);
+        }
+        return fastCheck == 1;
+    }
 
-	public BlockDescriptor getBelow() {
-		return below;
-	}
+    private boolean touchesAt(World world, Random rand, BlockPos pos) {
+        if (this.touching.size() <= 0)
+            return true;
 
-	public BlockDescriptor getBeside() {
-		return beside;
-	}
+        // mandatory touching descriptors, all must pass
+        for (TouchingDescriptor descriptor : this.touching) {
+            if (descriptor.mandatory) {
+                if (!touchesAt(descriptor, world, rand, pos)) {
+                    // mandatory descriptor failed, can't place block
+                    return false;
+                }
+            }
+        }
+
+        // optional touching descriptors, at least one must pass
+        int numberOfOptionalDescriptors = 0;
+        for (TouchingDescriptor descriptor : this.touching) {
+            if (!descriptor.mandatory) {
+                numberOfOptionalDescriptors++;
+
+                if (touchesAt(descriptor, world, rand, pos)) {
+                    // one passed
+                    return true;
+                }
+            }
+        }
+
+        if (numberOfOptionalDescriptors <= 0) {
+            // all mandatory passed and there are no optional
+            return true;
+        }
+
+        // no optionals passed or there are no touching rules for this distribution
+        return false;
+    }
+
+    private boolean touchesAt(TouchingDescriptor descriptor, World world, Random rand, BlockPos pos) {
+        int numberOfTouches = 0;
+
+        // search each required block position
+        for (BlockPos positionDelta : descriptor.deltaPositionMap) {
+            if (descriptorMatchesAt(descriptor.blockDescriptor, world, rand, pos.add(positionDelta))) {
+                numberOfTouches++;
+            }
+        }
+
+        boolean returnValue = true;
+
+        if (numberOfTouches < descriptor.minimumTouches || numberOfTouches > descriptor.maximumTouches)
+            returnValue = false;
+
+        if (descriptor.negate) {
+            returnValue = !returnValue;
+        }
+
+        return returnValue;
+    }
+
+    public BlockDescriptor getCenter() {
+        return center;
+    }
+
+    public BlockDescriptor getAbove() {
+        return above;
+    }
+
+    public BlockDescriptor getBelow() {
+        return below;
+    }
+
+    public BlockDescriptor getBeside() {
+        return beside;
+    }
+
+    public TouchingDescriptorList getTouching() {
+        return touching;
+    }
 
 }

--- a/src/main/java/CustomOreGen/Util/TouchingDescriptor.java
+++ b/src/main/java/CustomOreGen/Util/TouchingDescriptor.java
@@ -1,0 +1,459 @@
+package CustomOreGen.Util;
+
+import java.util.HashSet;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.BlockPos;
+
+public class TouchingDescriptor {
+    BlockDescriptor blockDescriptor;
+
+    int minimumTouches;
+    int maximumTouches;
+    TouchingVolume volume;
+    TouchingContactType contactType;
+    TouchingDirection direction;
+    boolean mandatory;
+    boolean negate;
+
+    // positions to check for this distribution
+    HashSet<BlockPos> deltaPositionMap;
+
+    // pre-calculate the search area for each kind of clause
+    private static HashSet<BlockPos> positionMapContactTypeFace;
+    private static HashSet<BlockPos> positionMapContactTypeEdge;
+    private static HashSet<BlockPos> positionMapContactTypeVertex;
+    private static HashSet<BlockPos> positionMapContactTypeFaceAndEdge;
+    private static HashSet<BlockPos> positionMapContactTypeAny;
+
+    private static HashSet<BlockPos> positionMapDirectionAny;
+    private static HashSet<BlockPos> positionMapDirectionNorth;
+    private static HashSet<BlockPos> positionMapDirectionEast;
+    private static HashSet<BlockPos> positionMapDirectionSouth;
+    private static HashSet<BlockPos> positionMapDirectionWest;
+    private static HashSet<BlockPos> positionMapDirectionUp;
+    private static HashSet<BlockPos> positionMapDirectionDown;
+    private static HashSet<BlockPos> positionMapDirectionNorthSouth;
+    private static HashSet<BlockPos> positionMapDirectionEastWest;
+    private static HashSet<BlockPos> positionMapDirectionNorthEast;
+    private static HashSet<BlockPos> positionMapDirectionNorthWest;
+    private static HashSet<BlockPos> positionMapDirectionSouthEast;
+    private static HashSet<BlockPos> positionMapDirectionSouthWest;
+    private static HashSet<BlockPos> positionMapDirectionVertical;
+    private static HashSet<BlockPos> positionMapDirectionHorizontal;
+
+    private static HashSet<BlockPos> positionMapVolumeCube;
+    private static HashSet<BlockPos> positionMapVolumePlaneXY;
+    private static HashSet<BlockPos> positionMapVolumePlaneXZ;
+    private static HashSet<BlockPos> positionMapVolumePlaneYZ;
+
+    static {
+        createPositionMapConstant();
+    }
+
+    public TouchingDescriptor(BlockDescriptor blockDescriptor, int minimumTouches, int maximumTouches,
+            TouchingVolume volume, TouchingContactType contactType, TouchingDirection direction, boolean mandatory,
+            boolean negate) {
+        this.blockDescriptor = blockDescriptor;
+        this.minimumTouches = minimumTouches;
+        this.maximumTouches = maximumTouches;
+        this.volume = volume;
+        this.contactType = contactType;
+        this.direction = direction;
+        this.mandatory = mandatory;
+        this.negate = negate;
+
+        createPositionMap();
+    }
+
+    private void createPositionMap() {
+        HashSet<BlockPos> volumeMap = getPositionMapConstant(this.volume);
+        HashSet<BlockPos> contactTypeMap = getPositionMapConstant(this.contactType);
+        HashSet<BlockPos> directionMap = getPositionMapConstant(this.direction);
+
+        // block positions are just get the set union of the 3 maps
+        deltaPositionMap = new HashSet<BlockPos>();
+        deltaPositionMap.addAll(volumeMap);
+        deltaPositionMap.retainAll(contactTypeMap);
+        deltaPositionMap.retainAll(directionMap);
+    }
+
+    // pre-calculate delta positions for search area
+    private static void createPositionMapConstant() {
+        positionMapContactTypeFace = createPositionMapConstant(TouchingContactType.Face);
+        positionMapContactTypeEdge = createPositionMapConstant(TouchingContactType.Edge);
+        positionMapContactTypeVertex = createPositionMapConstant(TouchingContactType.Vertex);
+        positionMapContactTypeFaceAndEdge = createPositionMapConstant(TouchingContactType.FaceAndEdge);
+        positionMapContactTypeAny = createPositionMapConstant(TouchingContactType.Any);
+
+        positionMapDirectionAny = createPositionMapConstant(EnumFacing.NORTH);
+        positionMapDirectionAny.addAll(createPositionMapConstant(EnumFacing.EAST));
+        positionMapDirectionAny.addAll(createPositionMapConstant(EnumFacing.SOUTH));
+        positionMapDirectionAny.addAll(createPositionMapConstant(EnumFacing.WEST));
+        positionMapDirectionAny.addAll(createPositionMapConstant(EnumFacing.UP));
+        positionMapDirectionAny.addAll(createPositionMapConstant(EnumFacing.DOWN));
+
+        positionMapDirectionNorth = createPositionMapConstant(EnumFacing.NORTH);
+        positionMapDirectionEast = createPositionMapConstant(EnumFacing.EAST);
+        positionMapDirectionSouth = createPositionMapConstant(EnumFacing.SOUTH);
+        positionMapDirectionWest = createPositionMapConstant(EnumFacing.WEST);
+        positionMapDirectionUp = createPositionMapConstant(EnumFacing.UP);
+        positionMapDirectionDown = createPositionMapConstant(EnumFacing.DOWN);
+
+        positionMapDirectionNorthSouth = createPositionMapConstant(EnumFacing.SOUTH);
+        positionMapDirectionNorthSouth.addAll(createPositionMapConstant(EnumFacing.NORTH));
+        positionMapDirectionEastWest = createPositionMapConstant(EnumFacing.EAST);
+        positionMapDirectionEastWest.addAll(createPositionMapConstant(EnumFacing.WEST));
+
+        positionMapDirectionNorthEast = createPositionMapConstant(EnumFacing.NORTH);
+        positionMapDirectionNorthEast.addAll(createPositionMapConstant(EnumFacing.EAST));
+        positionMapDirectionNorthWest = createPositionMapConstant(EnumFacing.NORTH);
+        positionMapDirectionNorthWest.addAll(createPositionMapConstant(EnumFacing.WEST));
+        positionMapDirectionSouthEast = createPositionMapConstant(EnumFacing.SOUTH);
+        positionMapDirectionSouthEast.addAll(createPositionMapConstant(EnumFacing.EAST));
+        positionMapDirectionSouthWest = createPositionMapConstant(EnumFacing.SOUTH);
+        positionMapDirectionSouthWest.addAll(createPositionMapConstant(EnumFacing.WEST));
+
+        positionMapDirectionVertical = createPositionMapConstant(EnumFacing.UP);
+        positionMapDirectionVertical.addAll(createPositionMapConstant(EnumFacing.DOWN));
+        positionMapDirectionHorizontal = createPositionMapConstant(EnumFacing.NORTH);
+        positionMapDirectionHorizontal.addAll(createPositionMapConstant(EnumFacing.EAST));
+        positionMapDirectionHorizontal.addAll(createPositionMapConstant(EnumFacing.SOUTH));
+        positionMapDirectionHorizontal.addAll(createPositionMapConstant(EnumFacing.WEST));
+
+        positionMapVolumeCube = createPositionMapConstant(TouchingVolume.Any);
+        positionMapVolumePlaneXY = createPositionMapConstant(TouchingVolume.PlaneXY);
+        positionMapVolumePlaneXZ = createPositionMapConstant(TouchingVolume.PlaneXZ);
+        positionMapVolumePlaneYZ = createPositionMapConstant(TouchingVolume.PlaneYZ);
+    }
+
+    // hardcoded delta positions for the different search area types
+    private static HashSet<BlockPos> createPositionMapConstant(TouchingContactType contactType) {
+        switch (contactType) {
+        default:
+        case Face: {
+            HashSet<BlockPos> returnValue = new HashSet<>();
+            returnValue.add(new BlockPos(1, 0, 0));
+            returnValue.add(new BlockPos(-1, 0, 0));
+            returnValue.add(new BlockPos(0, 1, 0));
+            returnValue.add(new BlockPos(0, -1, 0));
+            returnValue.add(new BlockPos(0, 0, 1));
+            returnValue.add(new BlockPos(0, 0, -1));
+            return returnValue;
+        }
+
+        case Edge: {
+            HashSet<BlockPos> returnValue = new HashSet<>();
+            returnValue.add(new BlockPos(-1, 0, -1));
+            returnValue.add(new BlockPos(-1, 0, 1));
+            returnValue.add(new BlockPos(-1, -1, 0));
+            returnValue.add(new BlockPos(-1, 1, 0));
+            returnValue.add(new BlockPos(0, -1, -1));
+            returnValue.add(new BlockPos(0, -1, 1));
+            returnValue.add(new BlockPos(0, 1, -1));
+            returnValue.add(new BlockPos(0, 1, 1));
+            returnValue.add(new BlockPos(1, -1, 0));
+            returnValue.add(new BlockPos(1, 1, 0));
+            returnValue.add(new BlockPos(1, 0, -1));
+            returnValue.add(new BlockPos(1, 0, 1));
+            return returnValue;
+        }
+
+        case Vertex: {
+            HashSet<BlockPos> returnValue = new HashSet<>();
+            returnValue = new HashSet<>();
+            returnValue.add(new BlockPos(-1, -1, -1));
+            returnValue.add(new BlockPos(-1, -1, 1));
+            returnValue.add(new BlockPos(-1, 1, -1));
+            returnValue.add(new BlockPos(-1, 1, 1));
+            returnValue.add(new BlockPos(1, -1, -1));
+            returnValue.add(new BlockPos(1, -1, 1));
+            returnValue.add(new BlockPos(1, 1, -1));
+            returnValue.add(new BlockPos(1, 1, 1));
+            return returnValue;
+        }
+
+        case Any: {
+            HashSet<BlockPos> returnValue = createPositionMapConstant(TouchingContactType.Face);
+            returnValue.addAll(createPositionMapConstant(TouchingContactType.Edge));
+            returnValue.addAll(createPositionMapConstant(TouchingContactType.Vertex));
+            return returnValue;
+        }
+
+        case FaceAndEdge: {
+            HashSet<BlockPos> returnValue = createPositionMapConstant(TouchingContactType.Face);
+            returnValue.addAll(createPositionMapConstant(TouchingContactType.Edge));
+            return returnValue;
+        }
+        }
+    }
+
+    private static HashSet<BlockPos> getPositionMapConstant(TouchingContactType contactType) {
+        switch (contactType) {
+        default:
+        case Face:
+            return positionMapContactTypeFace;
+        case Edge:
+            return positionMapContactTypeEdge;
+        case Vertex:
+            return positionMapContactTypeVertex;
+        case Any:
+            return positionMapContactTypeAny;
+        case FaceAndEdge:
+            return positionMapContactTypeFaceAndEdge;
+        }
+    }
+
+    // hardcoded delta positions for the different search volumes
+    private static HashSet<BlockPos> createPositionMapConstant(TouchingVolume volume) {
+        switch (volume) {
+        default:
+        case Any: {
+            HashSet<BlockPos> returnValue = new HashSet<>();
+
+            // face
+            returnValue.add(new BlockPos(1, 0, 0));
+            returnValue.add(new BlockPos(-1, 0, 0));
+            returnValue.add(new BlockPos(0, 1, 0));
+            returnValue.add(new BlockPos(0, -1, 0));
+            returnValue.add(new BlockPos(0, 0, 1));
+            returnValue.add(new BlockPos(0, 0, -1));
+
+            // edge
+            returnValue.add(new BlockPos(-1, 0, -1));
+            returnValue.add(new BlockPos(-1, 0, 1));
+            returnValue.add(new BlockPos(-1, -1, 0));
+            returnValue.add(new BlockPos(-1, 1, 0));
+            returnValue.add(new BlockPos(0, -1, -1));
+            returnValue.add(new BlockPos(0, -1, 1));
+            returnValue.add(new BlockPos(0, 1, -1));
+            returnValue.add(new BlockPos(0, 1, 1));
+            returnValue.add(new BlockPos(1, -1, 0));
+            returnValue.add(new BlockPos(1, 1, 0));
+            returnValue.add(new BlockPos(1, 0, -1));
+            returnValue.add(new BlockPos(1, 0, 1));
+
+            // vertex
+            returnValue.add(new BlockPos(-1, -1, -1));
+            returnValue.add(new BlockPos(-1, -1, 1));
+            returnValue.add(new BlockPos(-1, 1, -1));
+            returnValue.add(new BlockPos(-1, 1, 1));
+            returnValue.add(new BlockPos(1, -1, -1));
+            returnValue.add(new BlockPos(1, -1, 1));
+            returnValue.add(new BlockPos(1, 1, -1));
+            returnValue.add(new BlockPos(1, 1, 1));
+
+            return returnValue;
+        }
+
+        case PlaneXY: {
+            HashSet<BlockPos> returnValue = new HashSet<>();
+            returnValue.add(new BlockPos(-1, -1, 0));
+            returnValue.add(new BlockPos(-1, 0, 0));
+            returnValue.add(new BlockPos(-1, 1, 0));
+            returnValue.add(new BlockPos(0, -1, 0));
+            returnValue.add(new BlockPos(0, 1, 0));
+            returnValue.add(new BlockPos(1, -1, 0));
+            returnValue.add(new BlockPos(1, 0, 0));
+            returnValue.add(new BlockPos(1, 1, 0));
+            return returnValue;
+        }
+        case PlaneXZ: {
+            HashSet<BlockPos> returnValue = new HashSet<>();
+            returnValue.add(new BlockPos(-1, 0, -1));
+            returnValue.add(new BlockPos(-1, 0, 0));
+            returnValue.add(new BlockPos(-1, 0, 1));
+            returnValue.add(new BlockPos(0, 0, -1));
+            returnValue.add(new BlockPos(0, 0, 1));
+            returnValue.add(new BlockPos(1, 0, -1));
+            returnValue.add(new BlockPos(1, 0, 0));
+            returnValue.add(new BlockPos(1, 0, 1));
+            return returnValue;
+        }
+        case PlaneYZ: {
+            HashSet<BlockPos> returnValue = new HashSet<>();
+            returnValue.add(new BlockPos(0, -1, -1));
+            returnValue.add(new BlockPos(0, -1, 0));
+            returnValue.add(new BlockPos(0, -1, 1));
+            returnValue.add(new BlockPos(0, 0, -1));
+            returnValue.add(new BlockPos(0, 0, 1));
+            returnValue.add(new BlockPos(0, 1, -1));
+            returnValue.add(new BlockPos(0, 1, 0));
+            returnValue.add(new BlockPos(0, 1, 1));
+            return returnValue;
+        }
+        }
+    }
+
+    private static HashSet<BlockPos> getPositionMapConstant(TouchingVolume volume) {
+        switch (volume) {
+        default:
+        case Any:
+            return positionMapVolumeCube;
+        case PlaneXY:
+            return positionMapVolumePlaneXY;
+        case PlaneXZ:
+            return positionMapVolumePlaneXZ;
+        case PlaneYZ:
+            return positionMapVolumePlaneYZ;
+        }
+    }
+
+    // each direction is the 3x3 wall of blocks next to the player  
+    private static HashSet<BlockPos> createPositionMapConstant(EnumFacing direction) {
+        switch (direction) {
+        default:
+        case NORTH: {
+            HashSet<BlockPos> returnValue = new HashSet<>();
+            returnValue.add(new BlockPos(-1, -1, -1));
+            returnValue.add(new BlockPos(-1, 0, -1));
+            returnValue.add(new BlockPos(-1, 1, -1));
+            returnValue.add(new BlockPos(0, -1, -1));
+            returnValue.add(new BlockPos(0, 0, -1));
+            returnValue.add(new BlockPos(0, 1, -1));
+            returnValue.add(new BlockPos(1, -1, -1));
+            returnValue.add(new BlockPos(1, 0, -1));
+            returnValue.add(new BlockPos(1, 1, -1));
+            return returnValue;
+        }
+
+        case EAST: {
+            HashSet<BlockPos> returnValue = new HashSet<>();
+            returnValue.add(new BlockPos(1, -1, -1));
+            returnValue.add(new BlockPos(1, -1, 0));
+            returnValue.add(new BlockPos(1, -1, 1));
+            returnValue.add(new BlockPos(1, 0, -1));
+            returnValue.add(new BlockPos(1, 0, 0));
+            returnValue.add(new BlockPos(1, 0, 1));
+            returnValue.add(new BlockPos(1, 1, -1));
+            returnValue.add(new BlockPos(1, 1, 0));
+            returnValue.add(new BlockPos(1, 1, 1));
+            return returnValue;
+        }
+
+        case SOUTH: {
+            HashSet<BlockPos> returnValue = new HashSet<>();
+            returnValue.add(new BlockPos(-1, -1, 1));
+            returnValue.add(new BlockPos(-1, 0, 1));
+            returnValue.add(new BlockPos(-1, 1, 1));
+            returnValue.add(new BlockPos(0, -1, 1));
+            returnValue.add(new BlockPos(0, 0, 1));
+            returnValue.add(new BlockPos(0, 1, 1));
+            returnValue.add(new BlockPos(1, -1, 1));
+            returnValue.add(new BlockPos(1, 0, 1));
+            returnValue.add(new BlockPos(1, 1, 1));
+            return returnValue;
+        }
+
+        case WEST: {
+            HashSet<BlockPos> returnValue = new HashSet<>();
+            returnValue.add(new BlockPos(-1, -1, -1));
+            returnValue.add(new BlockPos(-1, -1, 0));
+            returnValue.add(new BlockPos(-1, -1, 1));
+            returnValue.add(new BlockPos(-1, 0, -1));
+            returnValue.add(new BlockPos(-1, 0, 0));
+            returnValue.add(new BlockPos(-1, 0, 1));
+            returnValue.add(new BlockPos(-1, 1, -1));
+            returnValue.add(new BlockPos(-1, 1, 0));
+            returnValue.add(new BlockPos(-1, 1, 1));
+            return returnValue;
+        }
+
+        case UP: {
+            HashSet<BlockPos> returnValue = new HashSet<>();
+            returnValue.add(new BlockPos(-1, 1, -1));
+            returnValue.add(new BlockPos(-1, 1, 0));
+            returnValue.add(new BlockPos(-1, 1, 1));
+            returnValue.add(new BlockPos(0, 1, -1));
+            returnValue.add(new BlockPos(0, 1, 0));
+            returnValue.add(new BlockPos(0, 1, 1));
+            returnValue.add(new BlockPos(1, 1, -1));
+            returnValue.add(new BlockPos(1, 1, 0));
+            returnValue.add(new BlockPos(1, 1, 1));
+            return returnValue;
+        }
+
+        case DOWN: {
+            HashSet<BlockPos> returnValue = new HashSet<>();
+            returnValue.add(new BlockPos(-1, -1, -1));
+            returnValue.add(new BlockPos(-1, -1, 0));
+            returnValue.add(new BlockPos(-1, -1, 1));
+            returnValue.add(new BlockPos(0, -1, -1));
+            returnValue.add(new BlockPos(0, -1, 0));
+            returnValue.add(new BlockPos(0, -1, 1));
+            returnValue.add(new BlockPos(1, -1, -1));
+            returnValue.add(new BlockPos(1, -1, 0));
+            returnValue.add(new BlockPos(1, -1, 1));
+            return returnValue;
+        }
+        }
+    }
+
+    private static HashSet<BlockPos> getPositionMapConstant(TouchingDirection direction) {
+        switch (direction) {
+        default:
+        case Any:
+            return positionMapDirectionAny;
+        case North:
+            return positionMapDirectionNorth;
+        case East:
+            return positionMapDirectionEast;
+        case South:
+            return positionMapDirectionSouth;
+        case West:
+            return positionMapDirectionWest;
+        case Up:
+            return positionMapDirectionUp;
+        case Down:
+            return positionMapDirectionDown;
+        case NorthSouth:
+            return positionMapDirectionNorthSouth;
+        case EastWest:
+            return positionMapDirectionEastWest;
+        case NorthEast:
+            return positionMapDirectionNorthEast;
+        case NorthWest:
+            return positionMapDirectionNorthWest;
+        case SouthEast:
+            return positionMapDirectionSouthEast;
+        case SouthWest:
+            return positionMapDirectionSouthWest;
+        case Vertical:
+            return positionMapDirectionVertical;
+        case Horizontal:
+            return positionMapDirectionHorizontal;
+        }
+    }
+
+    public enum TouchingContactType {
+        Any,
+        Face,
+        Edge,
+        Vertex,
+        FaceAndEdge,
+    }
+
+    public enum TouchingDirection {
+        Any,
+        North,
+        East,
+        South,
+        West,
+        Up,
+        Down,
+        NorthSouth,
+        EastWest,
+        NorthEast,
+        NorthWest,
+        SouthEast,
+        SouthWest,
+        Vertical,
+        Horizontal,
+    }
+
+    public enum TouchingVolume {
+        Any,
+        PlaneXY,
+        PlaneXZ,
+        PlaneYZ,
+    }
+}

--- a/src/main/java/CustomOreGen/Util/TouchingDescriptorList.java
+++ b/src/main/java/CustomOreGen/Util/TouchingDescriptorList.java
@@ -1,0 +1,18 @@
+package CustomOreGen.Util;
+
+import java.util.ArrayList;
+
+import CustomOreGen.Server.DistributionSettingMap.Copyable;
+
+public class TouchingDescriptorList extends ArrayList<TouchingDescriptor> implements Copyable<TouchingDescriptorList> {
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public void copyFrom(TouchingDescriptorList var1) {
+        this.clear();
+
+        for (TouchingDescriptor descriptor : var1) {
+            this.add(descriptor);
+        }
+    }
+}


### PR DESCRIPTION
Adds additional functionality to `PlacesBeside` configuration option for ore distributions.  A new XML element has been added called `Touches` that has a superset of the `PlacesBeside` functionality.  `PlacesBeside` will still be kept for legacy usage and existing configuration files will not be affected for users.

The new configuration option has the following features:
- Must be placed within an ore distribution (Veins, Cloud, StandardGen etc.).
- `block` attribute sets the block type to check for
- `block` can be a regular expression like the PlacesBeside command.  This is controlled by appending 'Regexp' to the touches command (`TouchesRegexp` instead of `Touches`).  Alternatively you can also append 'Ore'.
- `minimumTouches` and `maximumTouches` define the number of touching blocks allowed.  Defaults to minimum of 0 and maximum of 26 (3x3x3 blocks minus the block being placed).
- `volume` defines the area to check for blocks.  Can be `any`, `planeXY`, `planeXZ`, `planeYZ`.  The planes are 3x3 slabs.  Defaults to `any` which is all 26 surrounding blocks.
- `contactType` is how the blocks touch the block that is being placed.  Can be `any`, `face`, `edge`, `vertex`, `faceAndEdge`.  Defaults to `face` because that is what the user expects in most cases.
- `direction` defines which side of the block to check on.  Can be `any`, `north`, `east`, `south`, `west`, `up`, `down`, `northSouth`, `eastWest`, `northEast`, `northWest`, `southEast`, `southWest`, `vertical`, `horizontal`.  `north` refers to the 3x3 wall of blocks to the north of the block being checked.  `northSouth` means any of the 18 blocks to north or the south.  Similarly, `vertical` is the top 9 blocks or the bottom 9 blocks (so everything except sideways blocks).  Horizontal is all blocks except the block directly above and below, so 24 blocks total.
- `mandatory` means the placement command must pass otherwise the block is not placed, regardless of any other `Touches` commands.  Can be `true` or `false` (default).  At least one non-mandatory command must pass otherwise the block is not placed.  Even though this seems strange, it doesn't make sense to allow a placement if all non-mandatory `Touches` commands fail.  It would mean you just place it every time which is redundant.
- `negate` simply flips the result of the placement restriction check.  So if you have a rule like: `<Touches block='minecraft:grass' negate='true' />` then blocks will only be placed when they are not touching grass.  Defaults to false.  Boolean logic can be controlled via a combination of `mandatory` and `negate` which are the equivalent of 'and', 'or' and 'not'.  

All attributes are optional except for `block`.  `minimumTouches` must not be greater than `maximumTouches`.  Commands are executed in the order they are found in the XML configuration.  The attributes `volume`, `contactType` and `direction` are combined together using 'and' logic rather than 'or'.  So a direction of `north` specifies the 3x3 slab to the north but if the command also has a volume of `planeXZ` it will only be the 3 of those 9 blocks that sit on the same y level as the block being checked.

There are issues at chunk boundaries which will cause missing blocks due to placement checks being made when some chunks are not yet loaded at all.  If you are having issues with placement restrictions check whether they are occurring at a chunk boundary.  This only affects placements that refer to other ore distributions, it doesn't affect those that reference natural terrain.

Examples:

- Place grass on the north side of stone.  Note the direction is opposite compared to the way `PlacesBeside` is used:

`<VeinsPreset name='test'>`
`    <OreBlock block='minecraft:grass' />`
`    <Touches block='minecraft:stone' direction='south' />`
`</VeinsPreset>`

- Only place if there is stone on opposite ends of the block, and no stone on the other sides.  Both x and z axis are checked separately.  Finally the block must have a total of only 2 stone touching it.  At least one of the first 2 optional commands must pass:

`<VeinsPreset name='test'>`
`    <OreBlock block='minecraft:grass' />`
`    <Touches block='minecraft:stone' direction='northSouth' minimumTouches='2'  mandatory='false' />`
`    <Touches block='minecraft:stone' direction='eastWest' minimumTouches='2' mandatory='false' />`
`    <Touches block='minecraft:stone' direction='any' volume='planeXZ' maximumTouches='2' mandatory='true' />`
`</VeinsPreset>`
