### PR TITLE
By jove, I think I've done it

### DIFF
--- a/src/main/java/CustomOreGen/ModEventBusSubscriber.java
+++ b/src/main/java/CustomOreGen/ModEventBusSubscriber.java
@@ -5,6 +5,7 @@ import java.util.Random;
 import javax.annotation.Nonnull;
 
 import CustomOreGen.Server.ServerState;
+import CustomOreGen.Server.WorldConfig;
 import CustomOreGen.Server.WorldGenFeature;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
@@ -28,12 +29,13 @@ public class ModEventBusSubscriber {
      *        However, the population step falls outside of the system. There could be a populating Feature that runs after the rest.
      *        Better would be a Forge event when a chunk changes status. Population could run after FEATURES completion.
      */
-	@Deprecated
+	/*@Deprecated
 	@SuppressWarnings("rawtypes")
 	public void generate(Random random, int chunkX, int chunkZ, World world, ChunkGenerator chunkGenerator, AbstractChunkProvider chunkProvider) {
 		ServerState.checkIfServerChanged(world.getServer(), world.getWorldInfo());
-        ServerState.onPopulateChunk(world, chunkX, chunkZ, random);
-	}
+		WorldConfig cfg = ServerState.getWorldConfig(world);
+		ServerState.onPopulateChunk(cfg, chunkGenerator, chunkProvider, chunkX, chunkZ, random);
+	}*/
 
     @SubscribeEvent
 	public static void onFMLPreInit(FMLCommonSetupEvent event) {

--- a/src/main/java/CustomOreGen/Server/MapGenOreDistribution.java
+++ b/src/main/java/CustomOreGen/Server/MapGenOreDistribution.java
@@ -839,7 +839,7 @@ public abstract class MapGenOreDistribution extends MapGenStructure implements I
 			else
 			{
 				BlockArrangement arrangement = new BlockArrangement(replaceableBlocks, aboveBlocks, belowBlocks, besideBlocks, touchingBlocks);
-				boolean matched = arrangement.matchesAt(world.getWorld(), random, pos);
+				boolean matched = arrangement.matchesAt(world, random, pos);
 				if (matched)
 				{
 					BlockInfo match = oreBlock.getMatchingBlock(random);

--- a/src/main/java/CustomOreGen/Server/ServerState.java
+++ b/src/main/java/CustomOreGen/Server/ServerState.java
@@ -22,6 +22,7 @@ import net.minecraft.client.gui.widget.button.Button;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.math.ChunkPos;
 import net.minecraft.world.server.ServerWorld;
+import net.minecraft.world.IWorld;
 import net.minecraft.world.World;
 import net.minecraft.world.chunk.ChunkStatus;
 import net.minecraft.world.dimension.DimensionType;
@@ -122,13 +123,14 @@ public class ServerState
     }
 
     // TODO: add force option; if true then we will generate even when there is no version
-    public static void populateDistributions(Collection<IOreDistribution> distributions, World world, int chunkX, int chunkZ)
+    public static void populateDistributions(Collection<IOreDistribution> distributions, IWorld world, int chunkX, int chunkZ)
     {
         SimpleProfiler.globalProfiler.startSection("Populate");
         
         // FIXME: Before 1.14, we were forcing instant block updates here. Not clear how to do that now.
         
         for (IOreDistribution dist : distributions) {
+        	System.out.println(dist.toString());
         	dist.generate(world, chunkX, chunkZ);
             dist.populate(world, chunkX, chunkZ);
             dist.cull();
@@ -176,22 +178,22 @@ public class ServerState
         }
     }
 
-    public static void onPopulateChunk(World world, int chunkX, int chunkZ, Random rand) {
-    	WorldConfig cfg = getWorldConfig(world);
+    public static void onPopulateChunk(WorldConfig cfg, IWorld world, int chunkX, int chunkZ, Random rand) {
     	int range = (cfg.deferredPopulationRange + 15) / 16;
     	//for (int iX = chunkX - range; iX <= chunkX + range; ++iX)
-        //{
+        {
             //for (int iZ = chunkZ - range; iZ <= chunkZ + range; ++iZ)
-            //{
-            	//if (allNeighborsPopulated(world, iX, iZ, range)) {
+            {
+            	//if (allNeighborsPopulated(world, iX, iZ, range))
+            	{
             		//CustomOreGenBase.log.info("[" + iX + "," + iZ + "]: POPULATING");
             		populateDistributions(cfg.getOreDistributions(), world, chunkX, chunkZ);
-            	//}
-            //}
-        //}
+            	}
+            }
+        }
     }
 
-    private static boolean allNeighborsPopulated(World world, int chunkX, int chunkZ, int range) {
+    private static boolean allNeighborsPopulated(IWorld world, int chunkX, int chunkZ, int range) {
     	int area = 4 * range * (range + 1) + 1;
     	int neighborCount = 0;
         for (int iX = chunkX - range; iX <= chunkX + range; ++iX)
@@ -208,7 +210,7 @@ public class ServerState
 		return neighborCount == area; 
 	}
 
-	private static boolean chunkHasBeenPopulated(World world, int chunkX, int chunkZ) {
+	private static boolean chunkHasBeenPopulated(IWorld world, int chunkX, int chunkZ) {
 		return world.getChunk(chunkX, chunkZ).getStatus().isAtLeast(ChunkStatus.FEATURES);
 	}
 

--- a/src/main/java/CustomOreGen/Server/SubstitutionFeature.java
+++ b/src/main/java/CustomOreGen/Server/SubstitutionFeature.java
@@ -16,8 +16,8 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IWorld;
 import net.minecraft.world.World;
 import net.minecraft.world.biome.Biome;
-import net.minecraft.world.chunk.Chunk;
 import net.minecraft.world.chunk.ChunkStatus;
+import net.minecraft.world.chunk.IChunk;
 import net.minecraft.world.gen.ChunkGenerator;
 import net.minecraft.world.gen.GenerationSettings;
 import net.minecraft.world.gen.Heightmap;
@@ -307,7 +307,7 @@ public class SubstitutionFeature extends Feature<NoFeatureConfig> implements IOr
                 	int chunkZ = depositCZ + dCZ;
                     int chunkX = depositCX + dCX;
 
-                    Chunk chunk = (Chunk)world.getChunk(chunkX, chunkZ, ChunkStatus.FEATURES.getParent(), false);
+                    IChunk chunk = world.getChunk(chunkX, chunkZ, ChunkStatus.FEATURES.getParent(), false);
                     if (chunk != null)
                     {
                         int minX = dCX < 0 && -dCX * 2 > hRange ? 8 : 0;
@@ -336,7 +336,7 @@ public class SubstitutionFeature extends Feature<NoFeatureConfig> implements IOr
                                     	int worldX = chunkX * 16 + x;
                                     	int worldZ = chunkZ * 16 + z;
                                     	BlockPos worldPos = new BlockPos(worldX, y, worldZ);
-                                    	if (arrangement.matchesAt(world.getWorld(), random, worldPos)) {	
+                                    	if (arrangement.matchesAt(world, random, worldPos)) {	
                                             BlockInfo match = this.oreBlock.getMatchingBlock(random);
                                             if (match == null)
                                             {
@@ -365,7 +365,7 @@ public class SubstitutionFeature extends Feature<NoFeatureConfig> implements IOr
         }
     }
     
-    private int findSurfaceHeight(Chunk chunk, int x, int z) {
+    private int findSurfaceHeight(IChunk chunk, int x, int z) {
     	return chunk.getTopBlockY(Heightmap.Type.WORLD_SURFACE, x, z);
 	}
 

--- a/src/main/java/CustomOreGen/Server/WorldConfig.java
+++ b/src/main/java/CustomOreGen/Server/WorldConfig.java
@@ -345,7 +345,7 @@ public class WorldConfig
 
         properties.put("dimension.generator", genName);
         properties.put("dimension.generator.class", genClass);
-        properties.put("dimension", world == null ? "" : world.getDimension().getType().getRegistryName());
+        properties.put("dimension", world == null ? "" : world.getDimension().getType().getRegistryName().getPath());
         properties.put("dimension.id", world == null ? 0 : world.getDimension().getType().getId());
         properties.put("dimension.isSurface", world == null ? false : world.getDimension().isSurfaceWorld());
         properties.put("dimension.hasNoSky", world == null ? false : world.getDimension().hasSkyLight());

--- a/src/main/java/CustomOreGen/Server/WorldGenFeature.java
+++ b/src/main/java/CustomOreGen/Server/WorldGenFeature.java
@@ -28,7 +28,8 @@ public class WorldGenFeature extends Feature<NoFeatureConfig> {
 	public boolean place(IWorld worldIn, ChunkGenerator<? extends GenerationSettings> generator, Random rand, BlockPos pos, NoFeatureConfig config) {
         ServerState.checkIfServerChanged(worldIn.getWorld().getServer(), worldIn.getWorldInfo());
         ChunkPos p = new ChunkPos(pos);
-        ServerState.onPopulateChunk(worldIn.getWorld(), p.x, p.z, worldIn.getRandom()); //TOOD: should use IWorld, not World
+        WorldConfig cfg = ServerState.getWorldConfig(worldIn.getWorld());
+        ServerState.onPopulateChunk(cfg, worldIn, p.x, p.z, worldIn.getRandom()); //TOOD: should use IWorld, not World
 		return false;
 	}
 }

--- a/src/main/java/CustomOreGen/Util/BlockArrangement.java
+++ b/src/main/java/CustomOreGen/Util/BlockArrangement.java
@@ -4,7 +4,7 @@ import java.util.Random;
 
 import net.minecraft.block.BlockState;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.world.World;
+import net.minecraft.world.IWorld;
 
 public class BlockArrangement {
     private BlockDescriptor center, above, below, beside;
@@ -20,7 +20,7 @@ public class BlockArrangement {
         this.touching = touching;
     }
 
-    public boolean matchesAt(World world, Random rand, BlockPos pos) {
+    public boolean matchesAt(IWorld world, Random rand, BlockPos pos) {
         return 
             this.descriptorMatchesAt(center, world, rand, pos) &&
             this.descriptorMatchesAt(above, world, rand, pos.up()) &&
@@ -34,7 +34,7 @@ public class BlockArrangement {
             this.touchesAt(world, rand, pos);
     }
 
-    private boolean descriptorMatchesAt(BlockDescriptor descriptor, World world, Random rand, BlockPos pos) {
+    private boolean descriptorMatchesAt(BlockDescriptor descriptor, IWorld world, Random rand, BlockPos pos) {
         if (descriptor.isEmpty()) {
             return true;
         }
@@ -42,7 +42,7 @@ public class BlockArrangement {
         return descriptor.matchesBlock(blockState, rand);
     }
 
-    private boolean touchesAt(World world, Random rand, BlockPos pos) {
+    private boolean touchesAt(IWorld world, Random rand, BlockPos pos) {
         if (this.touching.size() <= 0)
             return true;
 
@@ -78,7 +78,7 @@ public class BlockArrangement {
         return false;
     }
 
-    private boolean touchesAt(TouchingDescriptor descriptor, World world, Random rand, BlockPos pos) {
+    private boolean touchesAt(TouchingDescriptor descriptor, IWorld world, Random rand, BlockPos pos) {
         int numberOfTouches = 0;
 
         // search each required block position


### PR DESCRIPTION
`World` -> `IWorld` was the last piece. The worldgen being threaded meant that by trying to read/write to ServerWorld instead of the pseudo worldgen abstract region, it was locking up, two threads waiting on each other.

Behold, success:

![pic](https://cdn.discordapp.com/attachments/272889008806428682/1124943022124179566/2023-07-02_01.01.33.png)

Commands are still inoperable, have no idea if the wireframe rendering code needs its own updates, I didn't even mess with those *last* time. Not critical to my own build path, though certainly handy.

The literal BS feature/structure registration I did having *worked* without any issue is a huge load off my conscience as it means I don't need to try and figure out what the hell COG does or how structures work. Did the literal bare bones required for the game to accept things at compile-time, hoping I didn't have to go deeper, worked out.

Now I can start on updating for 1.19, which hopefully is just updating mappings for the most part, though I'm sure a few other oddities abound as well, eg. the world now extends down to y=-64.